### PR TITLE
harden multi-tenant core contract

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 11
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Typecheck
+        run: pnpm typecheck
+
+      - name: Test
+        run: pnpm test
+
+      - name: Build
+        run: pnpm build

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,3 @@ dist/
 coverage/
 *.log
 .DS_Store
-
-# pnpm 11 auto-generates this supply-chain allowlist; regenerate on install.
-pnpm-workspace.yaml

--- a/README.md
+++ b/README.md
@@ -15,7 +15,9 @@ Given an authenticated `TenantPrincipal`, `dsh-multi-tenant` owns and authorizes
 access to opaque DSH session ids through a fail-closed, durable-store-compatible
 ownership contract.
 
-Concretely, it provides a single Cordis service, `ctx.multiTenant`, that:
+Concretely, it provides two Cordis services — `ctx.tenantSessionStore` (the
+ownership-storage seam) and `ctx.multiTenant` (ownership + authorization) —
+that together:
 
 - **abstracts the authenticated principal** (`TenantPrincipal`),
 - **owns sessions** with claim-once, immutable ownership,
@@ -99,7 +101,8 @@ dsh plugin --profile web add github:GuoMonth/dsh-multi-tenant
 ```
 
 The package declares [`dsh.bundle`](./package.json), so this appends its patch
-layer to the profile and mounts `ctx.multiTenant`.
+layer to the profile and mounts both `ctx.tenantSessionStore` and
+`ctx.multiTenant`.
 
 ## Core API
 

--- a/README.md
+++ b/README.md
@@ -118,27 +118,32 @@ interface SessionOwner {
 }
 ```
 
-### `TenantSessionStore`
+### `TenantSessionStore` (service seam, `ctx.tenantSessionStore`)
 
-The storage seam. `claim` is **atomic** (single operation, not get-then-set) so
-a durable implementation can map it to `INSERT … ON CONFLICT`:
+The storage seam is a Cordis **Service**, not a plain interface: it is provided
+by a backend plugin and consumed by `MultiTenantService`. `claim` is **atomic**
+(single operation, not get-then-set) so a durable backend can map it to
+`INSERT … ON CONFLICT`:
 
 ```ts
 type ClaimResult = 'created' | 'idempotent' | 'conflict'
 
-interface TenantSessionStore {
+abstract class TenantSessionStore extends Service {
   claim(sessionId: string, owner: SessionOwner): Promise<ClaimResult>
   get(sessionId: string): Promise<SessionOwner | undefined>
-  release(sessionId: string): Promise<void>
 }
 ```
 
-`InMemoryTenantSessionStore` is the default implementation — a process-local
-`Map`, intended for **development/bootstrap only**, not production persistence.
+There is deliberately **no release/delete** in the v0 contract: ownership is
+claim-once and immutable. `InMemoryTenantSessionStore` is the default provider —
+a process-local `Map`, intended for **development/bootstrap only**, not
+production persistence. A future durable backend swaps the `tenantSessionStore`
+provider without touching `MultiTenantService`.
 
 ### `MultiTenantService` (`ctx.multiTenant`)
 
-All methods are async so a durable store can be adopted without a breaking change.
+Consumes `ctx.tenantSessionStore` (declared via `static inject`). All methods are
+async so a durable store can be adopted without a breaking change.
 
 | Method | Semantics |
 | --- | --- |
@@ -146,7 +151,6 @@ All methods are async so a durable store can be adopted without a breaking chang
 | `getSessionOwner(sessionId)` | Trusted-facing lookup; returns the owner or `undefined`. |
 | `canAccessSession(principal, sessionId)` | Fail-closed boolean. Same tenant + same owner → `true`; else `false`. |
 | `assertSessionAccess(principal, sessionId)` | Like above, but throws a uniform `SessionAccessDeniedError`. |
-| `releaseSession(sessionId, principal)` | Owner-only release; non-owner or unknown → denied. |
 
 Authorization semantics:
 
@@ -161,12 +165,12 @@ and never assumes UUID/numeric shapes — only opaque exact-match identity.
 
 ## Error privacy
 
-`assertSessionAccess` and `releaseSession` throw a single, non-enumerating
-`SessionAccessDeniedError` (`"Access to session denied."`). Unknown sessions and
-foreign sessions are indistinguishable, and the error never carries the owner's
-tenant or user id. Internal diagnostic reasons (`UNKNOWN_SESSION`,
-`TENANT_MISMATCH`, `USER_MISMATCH`) exist for tests/audit/observability but are
-not part of the public authorization result.
+`assertSessionAccess` throws a single, non-enumerating `SessionAccessDeniedError`
+(`"Access to session denied."`). Unknown sessions and foreign sessions are
+indistinguishable, and the error never carries the owner's tenant or user id.
+Internal diagnostic reasons (`UNKNOWN_SESSION`, `TENANT_MISMATCH`,
+`USER_MISMATCH`) exist for tests/audit/observability but are not part of the
+public authorization result.
 
 ## Security boundary
 

--- a/README.md
+++ b/README.md
@@ -4,24 +4,52 @@ Multi-tenant SaaS extension for DeepSeek Harness (DSH): tenant identity,
 session ownership, authorization boundaries, tenant-aware MCP, and audit.
 
 > **Status: early development / architecture bootstrap.** This repository
-> establishes the plugin skeleton and the multi-tenant *core abstractions*. It
-> is **not** yet a production security boundary — see
-> [Security boundary](#security-boundary).
+> implements the multi-tenant **core contract** only. It is **not** a complete
+> SaaS security solution — see [What this core is not](#what-this-core-is-not).
 
 ---
 
-## What this is
+## What this core does
 
-`dsh-multi-tenant` is a [Cordis](https://github.com/cordiverse/cordis) plugin
-for [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) that
-provides a single service, `ctx.multiTenant`, which owns the mapping between
-DSH sessions and the tenant/user that may access them. The goal is to let one
-shared Harness runtime host many tenants with **logical isolation** — without
-forking Harness and without patching `node_modules`.
+Given an authenticated `TenantPrincipal`, `dsh-multi-tenant` owns and authorizes
+access to opaque DSH session ids through a fail-closed, durable-store-compatible
+ownership contract.
 
-This first milestone ships only the core: identity types, session ownership,
-and fail-closed authorization. Everything else is on the
-[roadmap](#roadmap).
+Concretely, it provides a single Cordis service, `ctx.multiTenant`, that:
+
+- **abstracts the authenticated principal** (`TenantPrincipal`),
+- **owns sessions** with claim-once, immutable ownership,
+- **enforces the tenant boundary** unconditionally (no role crosses it),
+- **authorizes fail-closed** (unknown and foreign sessions are both denied),
+- **defines a storage seam** (`TenantSessionStore`) so ownership persistence can
+  move to a durable store without a breaking API change.
+
+## What this core is not
+
+- ❌ Authentication / HTTP transport (no JWT, cookies, web login)
+- ❌ Transport authorization / WebSocket filtering / `events.mux` / `events.host`
+- ❌ MCP client or tenant-aware MCP credential pooling
+- ❌ Downstream data isolation / ERP token
+- ❌ Audit persistence
+- ❌ UI / billing / dashboards
+- ❌ An RBAC / role-policy framework
+
+These are all on the [roadmap](#roadmap). The core is the middle of the future
+chain:
+
+```text
+Authenticated Transport
+        ↓
+TenantPrincipal
+        ↓
+dsh-multi-tenant Core          ← this repository (Principal + Ownership + Authorization)
+        ↓
+Session ACL
+        ↓
+Tenant-aware MCP / business credentials
+        ↓
+Downstream tenant validation
+```
 
 ## Architecture
 
@@ -53,19 +81,16 @@ Audit / usage store
 
 - **Shared runtime, logical isolation** — one Harness process, many tenants,
   separated by authorization rather than by process or fork.
-- **Fail closed** — unknown sessions and unauthenticated identities are denied
-  by default.
-- **Identity is server-derived** — a `TenantPrincipal` comes from the
-  authenticated request boundary, never from a client-supplied field.
-- **Explicit session ownership** — every session has one recorded owner; access
-  requires matching that owner (or a future elevated role).
+- **Fail closed** — unknown sessions and unauthenticated identities are denied.
+- **Identity is server-derived** — `TenantPrincipal` comes from the
+  authenticated boundary, never from a client-supplied field.
+- **Claim-once ownership** — a session's owner is immutable; a conflicting
+  claim is denied, never overwritten.
 - **Streams are authorization surfaces** — sessions, RPC, and tool/MCP streams
-  are each an authorization boundary, not just the HTTP entry point.
-- **Tenant-aware tool execution** — tool and MCP access is scoped per tenant.
-- **Defense in depth** — this plugin is one layer; it does not replace the
+  are each a boundary, not just the HTTP entry point.
+- **Defense in depth** — this core is one layer; it does not replace the
   authenticated boundary or downstream tenant validation.
-- **Prefer plugins over forks** — build on DSH's public plugin/service/event
-  seams; do not fork Harness.
+- **Prefer plugins over forks** — build on DSH's public plugin/service seams.
 
 ## Install
 
@@ -73,42 +98,12 @@ Audit / usage store
 dsh plugin --profile web add github:GuoMonth/dsh-multi-tenant
 ```
 
-This installs the package and, because it declares
-[`dsh.bundle`](./package.json), appends its patch layer to the profile. The
-bundle inserts one Cordis row that mounts this service.
-
-> A git install fetches sources, not built artifacts, so the package ships a
-> `prepare` script that builds `dist/` after install. pnpm ≥10 requires the
-> build to be allow-listed the first time — copy the exact package key pnpm
-> prints into the profile's `pnpm-workspace.yaml` under `allowBuilds`, then
-> re-run the `add`.
-
-## Usage
-
-```ts
-import { Context } from '@deepseek-ai/cordis'
-import MultiTenantService, { type TenantPrincipal } from 'dsh-multi-tenant'
-
-const ctx = new Context()
-await ctx.plugin(MultiTenantService)
-
-const principal: TenantPrincipal = {
-  tenantId: 'acme',
-  userId: 'alice',
-  roles: ['member'],
-}
-
-ctx.multiTenant.bindSession('session-42', principal)
-
-ctx.multiTenant.canAccessSession(principal, 'session-42') // true
-ctx.multiTenant.assertSessionAccess(principal, 'session-42') // ok
-
-ctx.multiTenant.unbindSession('session-42')
-```
+The package declares [`dsh.bundle`](./package.json), so this appends its patch
+layer to the profile and mounts `ctx.multiTenant`.
 
 ## Core API
 
-### `TenantPrincipal`
+### Types
 
 ```ts
 interface TenantPrincipal {
@@ -116,87 +111,93 @@ interface TenantPrincipal {
   userId: string
   roles: readonly string[]
 }
-```
 
-### `SessionOwner`
-
-```ts
 interface SessionOwner {
   tenantId: string
   userId: string
 }
 ```
 
-### `MultiTenantService` (provided as `ctx.multiTenant`)
+### `TenantSessionStore`
 
-| Method | Description |
+The storage seam. `claim` is **atomic** (single operation, not get-then-set) so
+a durable implementation can map it to `INSERT … ON CONFLICT`:
+
+```ts
+type ClaimResult = 'created' | 'idempotent' | 'conflict'
+
+interface TenantSessionStore {
+  claim(sessionId: string, owner: SessionOwner): Promise<ClaimResult>
+  get(sessionId: string): Promise<SessionOwner | undefined>
+  release(sessionId: string): Promise<void>
+}
+```
+
+`InMemoryTenantSessionStore` is the default implementation — a process-local
+`Map`, intended for **development/bootstrap only**, not production persistence.
+
+### `MultiTenantService` (`ctx.multiTenant`)
+
+All methods are async so a durable store can be adopted without a breaking change.
+
+| Method | Semantics |
 | --- | --- |
-| `bindSession(sessionId, principal)` | Record the owning tenant/user for a session. |
-| `getSessionOwner(sessionId)` | Return the recorded owner, or `undefined`. |
-| `canAccessSession(principal, sessionId)` | Fail-closed boolean authorization. |
-| `assertSessionAccess(principal, sessionId)` | Like `canAccessSession`, but throws. |
-| `unbindSession(sessionId)` | Forget the ownership binding. |
+| `claimSession(sessionId, principal)` | Claim-once. Unclaimed → success; same owner → idempotent; different owner → `SessionOwnershipConflictError`. |
+| `getSessionOwner(sessionId)` | Trusted-facing lookup; returns the owner or `undefined`. |
+| `canAccessSession(principal, sessionId)` | Fail-closed boolean. Same tenant + same owner → `true`; else `false`. |
+| `assertSessionAccess(principal, sessionId)` | Like above, but throws a uniform `SessionAccessDeniedError`. |
+| `releaseSession(sessionId, principal)` | Owner-only release; non-owner or unknown → denied. |
 
 Authorization semantics:
 
-- **Unknown session** → denied (`UnknownSessionError`).
-- **Tenant mismatch** → denied (`SessionAccessDeniedError`).
+- **Unknown session** → denied.
+- **Tenant mismatch** → denied (unconditional; checked before anything else).
+- **Same tenant, different user** → denied (ownership only; no RBAC yet).
 - **Same tenant, same user** → allowed.
-- **Same tenant, different user** → denied by default; the `canElevatedAccess`
-  extension point is where a future `tenant-admin` / `platform-admin` rule
-  would grant cross-user access.
-- `sessionId` is an **opaque identifier**; the service never parses a tenant id
-  out of it, and never trusts a client-provided tenant id.
 
-## Scope of this milestone
+Identifiers (`sessionId`, `tenantId`, `userId`) are **opaque**: the core never
+parses a tenant id out of a session id, never uses prefix-based authorization,
+and never assumes UUID/numeric shapes — only opaque exact-match identity.
 
-Implemented (in-memory, development bootstrap):
+## Error privacy
 
-- project skeleton matching the DSH bundle/plugin contract
-- `TenantPrincipal` / `SessionOwner`
-- `ctx.multiTenant` Cordis service
-- fail-closed core authorization
-- unit tests + bundle-contract test
-
-Explicitly **not** implemented yet:
-
-- Web HTTP authentication
-- WebSocket filtering / mux
-- API-proxy replacement
-- MCP connection pool
-- database persistence
-- UI
-- audit backend
+`assertSessionAccess` and `releaseSession` throw a single, non-enumerating
+`SessionAccessDeniedError` (`"Access to session denied."`). Unknown sessions and
+foreign sessions are indistinguishable, and the error never carries the owner's
+tenant or user id. Internal diagnostic reasons (`UNKNOWN_SESSION`,
+`TENANT_MISMATCH`, `USER_MISMATCH`) exist for tests/audit/observability but are
+not part of the public authorization result.
 
 ## Security boundary
 
 Cordis / DSH **scope** is a *composition and visibility* mechanism — service
-isolation and dependency wiring. It is **not** by itself a multi-tenant
-security boundary.
+isolation and dependency wiring. It is **not** by itself a multi-tenant security
+boundary.
 
-A production deployment must enforce isolation across multiple layers:
+A production deployment must enforce isolation across layers:
 
 ```text
 authenticated request boundary
         +
-session ACL
+session ACL                          ← this core
         +
 tenant-aware MCP / business token
         +
 downstream ERP / business API tenant validation
 ```
 
-This plugin provides the **session ACL** layer and the extension points for the
-others. Do not treat the in-memory store or the Cordis scope as the security
-perimeter.
+Do not treat the in-memory store or the Cordis scope as the security perimeter.
 
 ## Roadmap
 
 - [x] project bootstrap
-- [x] `TenantPrincipal`
-- [x] session ownership
+- [x] `TenantPrincipal` / `SessionOwner`
+- [x] claim-once session ownership
 - [x] fail-closed core authorization
-- [ ] durable `TenantSessionStore`
+- [x] `TenantSessionStore` seam (in-memory)
+- [x] runtime invariant validation
+- [x] Loader integration test
+- [ ] durable `TenantSessionStore` (PostgreSQL / MySQL / Redis / remote)
 - [ ] HTTP principal/auth integration
 - [ ] session RPC authorization
 - [ ] WebSocket mux filtering
@@ -217,7 +218,7 @@ pnpm build
 
 - `build` runs `tsdown`, emitting `dist/index.mjs` + `dist/index.d.mts`.
 - `typecheck` runs `tsc --noEmit`.
-- `test` runs the Vitest suite.
+- `test` runs unit, security, and a real Cordis Loader integration test.
 
 ## License
 

--- a/cordis.patch.yml
+++ b/cordis.patch.yml
@@ -1,6 +1,12 @@
-# DeepSeek Harness bundle layer. Loads the in-memory multi-tenant service into
-# the profile. Later milestones (HTTP auth, RPC authorization, tenant-aware MCP)
-# will depend on it via `inject: [multiTenant]`; this row only mounts the core.
+# DeepSeek Harness bundle layer. Assembles the in-memory ownership backend
+# (`ctx.tenantSessionStore`) and the multi-tenant service (`ctx.multiTenant`)
+# as two independent Cordis rows. A durable backend replaces the first row's
+# provider (same `tenantSessionStore` service name) without touching the
+# service. Row order carries no load semantics — activation is driven by
+# service availability.
 - insert:
+    - id: tenant-session-store
+      name: dsh-multi-tenant/store
+
     - id: multi-tenant
       name: dsh-multi-tenant

--- a/demo/cordis.yml
+++ b/demo/cordis.yml
@@ -1,6 +1,10 @@
 # Minimal composition that loads dsh-multi-tenant through the real Cordis
 # Loader (not `new MultiTenantService()`), plus a fixture plugin that exercises
-# it. `../src/index.ts` resolves against the demo directory's base URL.
+# it. `../src/*` resolves against the demo directory's base URL, mirroring the
+# two rows of the shipped bundle.
+- id: tenant-session-store
+  name: '../src/store.ts'
+
 - id: multi-tenant
   name: '../src/index.ts'
 

--- a/demo/cordis.yml
+++ b/demo/cordis.yml
@@ -1,0 +1,8 @@
+# Minimal composition that loads dsh-multi-tenant through the real Cordis
+# Loader (not `new MultiTenantService()`), plus a fixture plugin that exercises
+# it. `../src/index.ts` resolves against the demo directory's base URL.
+- id: multi-tenant
+  name: '../src/index.ts'
+
+- id: fixture
+  name: './fixture.ts'

--- a/demo/fixture.ts
+++ b/demo/fixture.ts
@@ -1,0 +1,28 @@
+import type { Context } from '@deepseek-ai/cordis'
+
+export const name = 'dsh-multi-tenant-runtime-fixture'
+export const inject = ['multiTenant']
+export let completed: Promise<void> = Promise.resolve()
+
+export function apply(ctx: Context): void {
+  completed = (async () => {
+    const alice = { tenantId: 'acme', userId: 'alice', roles: ['member'] }
+    const eve = { tenantId: 'evilcorp', userId: 'alice', roles: ['member'] }
+
+    await ctx.multiTenant.claimSession('s1', alice)
+    const owner = await ctx.multiTenant.getSessionOwner('s1')
+    const sameAllowed = await ctx.multiTenant.canAccessSession(alice, 's1')
+    const crossTenantAllowed = await ctx.multiTenant.canAccessSession(eve, 's1')
+
+    let denialName: string | undefined
+    let denialMessage: string | undefined
+    try {
+      await ctx.multiTenant.assertSessionAccess(eve, 's1')
+    } catch (error) {
+      denialName = (error as Error).constructor.name
+      denialMessage = (error as Error).message
+    }
+
+    console.log(JSON.stringify({ owner, sameAllowed, crossTenantAllowed, denialName, denialMessage }))
+  })()
+}

--- a/demo/run-loader.ts
+++ b/demo/run-loader.ts
@@ -1,0 +1,19 @@
+import { Context } from '@deepseek-ai/cordis'
+import Include from '@deepseek-ai/cordis-plugin-include'
+import Loader from '@deepseek-ai/cordis-plugin-loader'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+
+const demoDirectory = fileURLToPath(new URL('.', import.meta.url))
+const demoUrl = `${pathToFileURL(demoDirectory).href}/`
+const ctx = new Context()
+
+ctx.baseUrl = demoUrl
+await ctx.plugin(Loader, { baseUrl: demoUrl })
+await ctx.plugin(Include, { path: './cordis.yml', initial: [] })
+const fixture = await import('./fixture.ts')
+await ctx.loader.await()
+
+// The fixture starts once the included tree activates. Await its completion so
+// this executable is deterministic for the integration test.
+await fixture.completed
+await ctx.fiber.dispose()

--- a/package.json
+++ b/package.json
@@ -54,8 +54,11 @@
   },
   "devDependencies": {
     "@deepseek-ai/cordis": "^4.0.1",
+    "@deepseek-ai/cordis-plugin-include": "^1.0.6",
+    "@deepseek-ai/cordis-plugin-loader": "^1.0.2",
     "@types/node": "^22.20.0",
     "tsdown": "^0.22.2",
+    "tsx": "^4.22.4",
     "typescript": "^6.0.3",
     "vitest": "^4.1.8"
   },

--- a/package.json
+++ b/package.json
@@ -24,6 +24,10 @@
       "types": "./dist/index.d.mts",
       "import": "./dist/index.mjs"
     },
+    "./store": {
+      "types": "./dist/store.d.mts",
+      "import": "./dist/store.mjs"
+    },
     "./cordis.patch.yml": "./cordis.patch.yml"
   },
   "files": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,21 +10,45 @@ importers:
     devDependencies:
       '@deepseek-ai/cordis':
         specifier: ^4.0.1
-        version: 4.0.1
+        version: 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
+      '@deepseek-ai/cordis-plugin-include':
+        specifier: ^1.0.6
+        version: 1.0.6(@deepseek-ai/cordis-plugin-loader@1.0.2)(@deepseek-ai/cordis@4.0.1)
+      '@deepseek-ai/cordis-plugin-loader':
+        specifier: ^1.0.2
+        version: 1.0.2(@deepseek-ai/cordis@4.0.1)
       '@types/node':
         specifier: ^22.20.0
         version: 22.20.1
       tsdown:
         specifier: ^0.22.2
-        version: 0.22.14(typescript@6.0.3)
+        version: 0.22.14(tsx@4.23.12)(typescript@6.0.3)
+      tsx:
+        specifier: ^4.22.4
+        version: 4.23.12
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
       vitest:
         specifier: ^4.1.8
-        version: 4.1.10(@types/node@22.20.1)(vite@8.2.1(@types/node@22.20.1))
+        version: 4.1.10(@types/node@22.20.1)(vite@8.2.1(@types/node@22.20.1)(esbuild@0.28.2)(tsx@4.23.12))
 
 packages:
+
+  '@deepseek-ai/cordis-plugin-include@1.0.6':
+    resolution: {integrity: sha512-i1VXrZCbv6tk/iUgedCNjrxxArbWT3IvRZGB5sdqJ3ectnihivXXQbRZ8JJ73DSmAPvlMGmrbtjFAfm10yvXRg==}
+    peerDependencies:
+      '@deepseek-ai/cordis': ^4.0.1
+      '@deepseek-ai/cordis-plugin-loader': ^1.0.2
+
+  '@deepseek-ai/cordis-plugin-loader@1.0.2':
+    resolution: {integrity: sha512-RIW9hoVyhYDWdCI9BsvtZccPde1ECLC4OAxupwowGTak78vwVTVdb3HezTSOK1Y1/Ax3Ru0LA1pYOB04CnTxIQ==}
+    peerDependencies:
+      '@deepseek-ai/cordis': ^4.0.1
+      node-addon-require-builtin: ^0.1.4
+    peerDependenciesMeta:
+      node-addon-require-builtin:
+        optional: true
 
   '@deepseek-ai/cordis@4.0.1':
     resolution: {integrity: sha512-YBdskTU2Po1kru3GgcUWUbkTsPMA9LkSQDAY8rBkFJeajdgcQad3QPJZE26JyK99Xb6HaASvoXg2DSUTeN/0Nw==}
@@ -40,6 +64,162 @@ packages:
 
   '@deepseek-ai/cosmokit@1.8.2':
     resolution: {integrity: sha512-muBOKtSrUKU5m/xpq8ZXWL6hQ/jgd4PhU2PqH97bcxIiLEJfNwZOGQEx4t/aS/GgxRAR+ra9pMHPMtTHU4sqqA==}
+
+  '@esbuild/aix-ppc64@0.28.2':
+    resolution: {integrity: sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.28.2':
+    resolution: {integrity: sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.28.2':
+    resolution: {integrity: sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.28.2':
+    resolution: {integrity: sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.28.2':
+    resolution: {integrity: sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.28.2':
+    resolution: {integrity: sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.28.2':
+    resolution: {integrity: sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.28.2':
+    resolution: {integrity: sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.28.2':
+    resolution: {integrity: sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.28.2':
+    resolution: {integrity: sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.28.2':
+    resolution: {integrity: sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.28.2':
+    resolution: {integrity: sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.28.2':
+    resolution: {integrity: sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.28.2':
+    resolution: {integrity: sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.28.2':
+    resolution: {integrity: sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.28.2':
+    resolution: {integrity: sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.28.2':
+    resolution: {integrity: sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.28.2':
+    resolution: {integrity: sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.28.2':
+    resolution: {integrity: sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.28.2':
+    resolution: {integrity: sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.28.2':
+    resolution: {integrity: sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.28.2':
+    resolution: {integrity: sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.28.2':
+    resolution: {integrity: sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.28.2':
+    resolution: {integrity: sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.28.2':
+    resolution: {integrity: sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.28.2':
+    resolution: {integrity: sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
 
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
@@ -326,6 +506,9 @@ packages:
     resolution: {integrity: sha512-BJ8/l4R5LRE7hW9WdSuGYrLSHi2ynxeFpDFbH0K/CgNeY/tyhk+vO6TYxXC5r5CpUhNVX310xzPsN/H9lCdfOA==}
     engines: {node: '>=14'}
 
+  argparse@2.0.1:
+    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
@@ -364,6 +547,11 @@ packages:
   es-module-lexer@2.3.1:
     resolution: {integrity: sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==}
 
+  esbuild@0.28.2:
+    resolution: {integrity: sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
 
@@ -395,6 +583,10 @@ packages:
   import-without-cache@0.4.0:
     resolution: {integrity: sha512-NkJQA7oZ4YHQhd2+H3BoRFKF3d/XNsiKpHZCQEMH9pDX27hQQLsTyOocyRgaIVtf8gHX3Nt3LPkR4e5EdtPAGQ==}
     engines: {node: ^22.18.0 || >=24.0.0}
+
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
+    hasBin: true
 
   lightningcss-android-arm64@1.33.0:
     resolution: {integrity: sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==}
@@ -592,6 +784,11 @@ packages:
       unrun:
         optional: true
 
+  tsx@4.23.12:
+    resolution: {integrity: sha512-FDf4L4sYzKtzWYhU/Xm0AQFdTjdIxNo9ElTf2mxXM6k8YMHXzYUe4yODVaXP4V9uMFbVg8c0qyBccK2OOxb45Q==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
   typescript@6.0.3:
     resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
@@ -707,12 +904,105 @@ packages:
 
 snapshots:
 
-  '@deepseek-ai/cordis@4.0.1':
+  '@deepseek-ai/cordis-plugin-include@1.0.6(@deepseek-ai/cordis-plugin-loader@1.0.2)(@deepseek-ai/cordis@4.0.1)':
+    dependencies:
+      '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
+      '@deepseek-ai/cordis-plugin-loader': 1.0.2(@deepseek-ai/cordis@4.0.1)
+      '@deepseek-ai/cosmokit': 1.8.2
+      js-yaml: 4.3.1
+
+  '@deepseek-ai/cordis-plugin-loader@1.0.2(@deepseek-ai/cordis@4.0.1)':
+    dependencies:
+      '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
+      '@deepseek-ai/cosmokit': 1.8.2
+
+  '@deepseek-ai/cordis@4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)':
     dependencies:
       '@deepseek-ai/cosmokit': 1.8.2
       '@standard-schema/spec': 1.1.0
+    optionalDependencies:
+      '@deepseek-ai/cordis-plugin-include': 1.0.6(@deepseek-ai/cordis-plugin-loader@1.0.2)(@deepseek-ai/cordis@4.0.1)
+      '@deepseek-ai/cordis-plugin-loader': 1.0.2(@deepseek-ai/cordis@4.0.1)
 
   '@deepseek-ai/cosmokit@1.8.2': {}
+
+  '@esbuild/aix-ppc64@0.28.2':
+    optional: true
+
+  '@esbuild/android-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/android-arm@0.28.2':
+    optional: true
+
+  '@esbuild/android-x64@0.28.2':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/darwin-x64@0.28.2':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.28.2':
+    optional: true
+
+  '@esbuild/linux-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/linux-arm@0.28.2':
+    optional: true
+
+  '@esbuild/linux-ia32@0.28.2':
+    optional: true
+
+  '@esbuild/linux-loong64@0.28.2':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.28.2':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.28.2':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.28.2':
+    optional: true
+
+  '@esbuild/linux-s390x@0.28.2':
+    optional: true
+
+  '@esbuild/linux-x64@0.28.2':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.28.2':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.28.2':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/sunos-x64@0.28.2':
+    optional: true
+
+  '@esbuild/win32-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/win32-ia32@0.28.2':
+    optional: true
+
+  '@esbuild/win32-x64@0.28.2':
+    optional: true
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
 
@@ -790,13 +1080,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.1
 
-  '@vitest/mocker@4.1.10(vite@8.2.1(@types/node@22.20.1))':
+  '@vitest/mocker@4.1.10(vite@8.2.1(@types/node@22.20.1)(esbuild@0.28.2)(tsx@4.23.12))':
     dependencies:
       '@vitest/spy': 4.1.10
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.2.1(@types/node@22.20.1)
+      vite: 8.2.1(@types/node@22.20.1)(esbuild@0.28.2)(tsx@4.23.12)
 
   '@vitest/pretty-format@4.1.10':
     dependencies:
@@ -898,6 +1188,8 @@ snapshots:
 
   ansis@4.3.1: {}
 
+  argparse@2.0.1: {}
+
   assertion-error@2.0.1: {}
 
   cac@7.0.0: {}
@@ -915,6 +1207,35 @@ snapshots:
   empathic@2.0.1: {}
 
   es-module-lexer@2.3.1: {}
+
+  esbuild@0.28.2:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.28.2
+      '@esbuild/android-arm': 0.28.2
+      '@esbuild/android-arm64': 0.28.2
+      '@esbuild/android-x64': 0.28.2
+      '@esbuild/darwin-arm64': 0.28.2
+      '@esbuild/darwin-x64': 0.28.2
+      '@esbuild/freebsd-arm64': 0.28.2
+      '@esbuild/freebsd-x64': 0.28.2
+      '@esbuild/linux-arm': 0.28.2
+      '@esbuild/linux-arm64': 0.28.2
+      '@esbuild/linux-ia32': 0.28.2
+      '@esbuild/linux-loong64': 0.28.2
+      '@esbuild/linux-mips64el': 0.28.2
+      '@esbuild/linux-ppc64': 0.28.2
+      '@esbuild/linux-riscv64': 0.28.2
+      '@esbuild/linux-s390x': 0.28.2
+      '@esbuild/linux-x64': 0.28.2
+      '@esbuild/netbsd-arm64': 0.28.2
+      '@esbuild/netbsd-x64': 0.28.2
+      '@esbuild/openbsd-arm64': 0.28.2
+      '@esbuild/openbsd-x64': 0.28.2
+      '@esbuild/openharmony-arm64': 0.28.2
+      '@esbuild/sunos-x64': 0.28.2
+      '@esbuild/win32-arm64': 0.28.2
+      '@esbuild/win32-ia32': 0.28.2
+      '@esbuild/win32-x64': 0.28.2
 
   estree-walker@3.0.3:
     dependencies:
@@ -936,6 +1257,10 @@ snapshots:
   hookable@6.1.1: {}
 
   import-without-cache@0.4.0: {}
+
+  js-yaml@4.3.1:
+    dependencies:
+      argparse: 2.0.1
 
   lightningcss-android-arm64@1.33.0:
     optional: true
@@ -1065,7 +1390,7 @@ snapshots:
 
   tree-kill@1.2.2: {}
 
-  tsdown@0.22.14(typescript@6.0.3):
+  tsdown@0.22.14(tsx@4.23.12)(typescript@6.0.3):
     dependencies:
       ansis: 4.3.1
       cac: 7.0.0
@@ -1083,12 +1408,19 @@ snapshots:
       unconfig-core: 7.5.0
       verkit: 0.3.2
     optionalDependencies:
+      tsx: 4.23.12
       typescript: 6.0.3
     transitivePeerDependencies:
       - '@typescript/native-preview'
       - '@volar/typescript'
       - oxc-resolver
       - vue-tsc
+
+  tsx@4.23.12:
+    dependencies:
+      esbuild: 0.28.2
+    optionalDependencies:
+      fsevents: 2.3.3
 
   typescript@6.0.3: {}
 
@@ -1101,7 +1433,7 @@ snapshots:
 
   verkit@0.3.2: {}
 
-  vite@8.2.1(@types/node@22.20.1):
+  vite@8.2.1(@types/node@22.20.1)(esbuild@0.28.2)(tsx@4.23.12):
     dependencies:
       lightningcss: 1.33.0
       picomatch: 4.0.5
@@ -1110,12 +1442,14 @@ snapshots:
       tinyglobby: 0.2.17
     optionalDependencies:
       '@types/node': 22.20.1
+      esbuild: 0.28.2
       fsevents: 2.3.3
+      tsx: 4.23.12
 
-  vitest@4.1.10(@types/node@22.20.1)(vite@8.2.1(@types/node@22.20.1)):
+  vitest@4.1.10(@types/node@22.20.1)(vite@8.2.1(@types/node@22.20.1)(esbuild@0.28.2)(tsx@4.23.12)):
     dependencies:
       '@vitest/expect': 4.1.10
-      '@vitest/mocker': 4.1.10(vite@8.2.1(@types/node@22.20.1))
+      '@vitest/mocker': 4.1.10(vite@8.2.1(@types/node@22.20.1)(esbuild@0.28.2)(tsx@4.23.12))
       '@vitest/pretty-format': 4.1.10
       '@vitest/runner': 4.1.10
       '@vitest/snapshot': 4.1.10
@@ -1132,7 +1466,7 @@ snapshots:
       tinyexec: 1.3.0
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.1
-      vite: 8.2.1(@types/node@22.20.1)
+      vite: 8.2.1(@types/node@22.20.1)(esbuild@0.28.2)(tsx@4.23.12)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.20.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,6 @@
+# pnpm 11 supply-chain / build-script policy. Committed so `pnpm install
+# --frozen-lockfile` in CI does not re-prompt for an undecided build script.
+allowBuilds:
+  # esbuild's binary ships via the platform-specific optional dependency
+  # (`@esbuild/linux-x64` etc.), so its postinstall is redundant — deny it.
+  esbuild: false

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,10 +1,6 @@
 /**
  * Error types for the multi-tenant core.
  *
- * Denials are typed so callers can distinguish "this session does not exist"
- * (`UnknownSessionError`, which does not leak whether a session id is valid)
- * from "this principal may not access this session" (`SessionAccessDeniedError`).
- *
  * @module dsh-multi-tenant/errors
  */
 
@@ -16,19 +12,35 @@ export class MultiTenantError extends Error {
   }
 }
 
-/** Thrown when a session id has no recorded owner. */
-export class UnknownSessionError extends MultiTenantError {
-  constructor(readonly sessionId: string) {
-    super(`Session "${sessionId}" has no recorded tenant owner`)
+/**
+ * Public authorization denial.
+ *
+ * Deliberately uniform and non-enumerating: the message carries no session
+ * existence, no owner tenant/user, and no internal reason. Unknown sessions,
+ * tenant mismatches, and user mismatches all surface as this same error, so the
+ * public API cannot be used to probe session existence or ownership.
+ */
+export class SessionAccessDeniedError extends MultiTenantError {
+  constructor() {
+    super('Access to session denied.')
   }
 }
 
-/** Thrown when a principal is denied access to a session it may not use. */
-export class SessionAccessDeniedError extends MultiTenantError {
-  constructor(
-    readonly sessionId: string,
-    readonly reason?: string,
-  ) {
-    super(`Access to session "${sessionId}" denied${reason ? `: ${reason}` : ''}`)
+/**
+ * Claim conflict: the session is already owned by another principal.
+ *
+ * The message does not reveal the existing owner's identity. This is thrown by
+ * `claimSession` (a server-side operation), not by the authorization path.
+ */
+export class SessionOwnershipConflictError extends MultiTenantError {
+  constructor() {
+    super('Session is already owned.')
+  }
+}
+
+/** Invalid principal / session input rejected at a runtime boundary. */
+export class ValidationError extends MultiTenantError {
+  constructor(message: string) {
+    super(message)
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,13 @@
 /**
  * dsh-multi-tenant — Multi-tenant SaaS extension for DeepSeek Harness (DSH).
  *
- * Exposes one Cordis service, `ctx.multiTenant`, that owns session ownership
- * and fail-closed authorization. Public surface is deliberately small: the
- * service, the identity/ownership types, the storage seam, and the errors.
- * Internal diagnostic types (access-denial reasons, decisions) are not
- * re-exported.
+ * Exposes two Cordis services:
+ *   - `ctx.tenantSessionStore` — the ownership-storage seam (abstract), with
+ *     the in-memory backend as the default provider.
+ *   - `ctx.multiTenant` — the session-ownership + authorization service.
+ *
+ * Public surface is deliberately small. Internal diagnostic types
+ * (access-denial reasons, decisions) are not re-exported.
  *
  * @module dsh-multi-tenant
  */
@@ -22,8 +24,8 @@ declare module '@deepseek-ai/cordis' {
 export { MultiTenantService }
 export default MultiTenantService
 
-export type { TenantPrincipal, SessionOwner, TenantSessionStore, ClaimResult } from './types.ts'
-export { InMemoryTenantSessionStore } from './store.ts'
+export { TenantSessionStore, InMemoryTenantSessionStore } from './store.ts'
+export type { TenantPrincipal, SessionOwner, ClaimResult } from './types.ts'
 export {
   MultiTenantError,
   SessionAccessDeniedError,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,11 @@
 /**
  * dsh-multi-tenant — Multi-tenant SaaS extension for DeepSeek Harness (DSH).
  *
- * Exposes a single Cordis service, `ctx.multiTenant`, that owns the mapping
- * between DSH sessions and the tenant/user that may access them. This first
- * milestone is the fail-closed core; auth, RPC, MCP, and audit layers build on
- * top of it.
+ * Exposes one Cordis service, `ctx.multiTenant`, that owns session ownership
+ * and fail-closed authorization. Public surface is deliberately small: the
+ * service, the identity/ownership types, the storage seam, and the errors.
+ * Internal diagnostic types (access-denial reasons, decisions) are not
+ * re-exported.
  *
  * @module dsh-multi-tenant
  */
@@ -21,9 +22,11 @@ declare module '@deepseek-ai/cordis' {
 export { MultiTenantService }
 export default MultiTenantService
 
-export type {
-  TenantPrincipal,
-  SessionOwner,
-  MultiTenantService as MultiTenantServiceContract,
-} from './types.ts'
-export { MultiTenantError, UnknownSessionError, SessionAccessDeniedError } from './errors.ts'
+export type { TenantPrincipal, SessionOwner, TenantSessionStore, ClaimResult } from './types.ts'
+export { InMemoryTenantSessionStore } from './store.ts'
+export {
+  MultiTenantError,
+  SessionAccessDeniedError,
+  SessionOwnershipConflictError,
+  ValidationError,
+} from './errors.ts'

--- a/src/service.ts
+++ b/src/service.ts
@@ -14,7 +14,7 @@
  */
 
 import { Service, type Context } from '@deepseek-ai/cordis'
-import { SessionAccessDeniedError, SessionOwnershipConflictError } from './errors.ts'
+import { MultiTenantError, SessionAccessDeniedError, SessionOwnershipConflictError } from './errors.ts'
 import type { TenantSessionStore } from './store.ts'
 import { validateSessionId, validateTenantPrincipal } from './validation.ts'
 import type { AccessDecision, SessionOwner, TenantPrincipal } from './types.ts'
@@ -48,8 +48,16 @@ export class MultiTenantService extends Service {
     validateTenantPrincipal(principal)
     const owner: SessionOwner = { tenantId: principal.tenantId, userId: principal.userId }
     const result = await this.store.claim(sessionId, owner)
-    if (result === 'conflict') {
-      throw new SessionOwnershipConflictError()
+    switch (result) {
+      case 'created':
+      case 'idempotent':
+        return
+      case 'conflict':
+        throw new SessionOwnershipConflictError()
+      default:
+        // Fail closed: a store result outside the ClaimResult contract must
+        // never be treated as a successful claim.
+        throw new MultiTenantError('tenant session store returned an invalid claim result')
     }
   }
 

--- a/src/service.ts
+++ b/src/service.ts
@@ -5,35 +5,30 @@
  * own and authorize access to opaque DSH session ids through a fail-closed,
  * durable-store-compatible ownership contract.
  *
- * The service is storage-agnostic: it depends only on {@link TenantSessionStore}
- * and never inspects the backing store. Ownership is claim-once (immutable); the
- * tenant boundary is unconditional and checked before any other consideration.
+ * The service is storage-agnostic: it consumes the `tenantSessionStore` service
+ * seam (a separate Cordis Service provider) and never constructs or inspects a
+ * backend itself. Ownership is claim-once and immutable; the tenant boundary is
+ * unconditional and checked before any other consideration.
  *
  * @module dsh-multi-tenant/service
  */
 
 import { Service, type Context } from '@deepseek-ai/cordis'
 import { SessionAccessDeniedError, SessionOwnershipConflictError } from './errors.ts'
-import { InMemoryTenantSessionStore } from './store.ts'
+import type { TenantSessionStore } from './store.ts'
 import { validateSessionId, validateTenantPrincipal } from './validation.ts'
-import type {
-  AccessDecision,
-  SessionOwner,
-  TenantPrincipal,
-  TenantSessionStore,
-} from './types.ts'
+import type { AccessDecision, SessionOwner, TenantPrincipal } from './types.ts'
 
 export class MultiTenantService extends Service {
-  private readonly store: TenantSessionStore
+  /** The ownership backend is provided by a separate Cordis service. */
+  static inject = ['tenantSessionStore']
 
-  /**
-   * @param ctx — Cordis context (the service registers itself as `multiTenant`).
-   * @param store — ownership store; defaults to an in-memory bootstrap store.
-   *   Inject a durable `TenantSessionStore` for production.
-   */
-  constructor(ctx: Context, store?: TenantSessionStore) {
+  constructor(ctx: Context) {
     super(ctx, 'multiTenant')
-    this.store = store ?? new InMemoryTenantSessionStore()
+  }
+
+  private get store(): TenantSessionStore {
+    return this.ctx.tenantSessionStore
   }
 
   /**
@@ -44,8 +39,9 @@ export class MultiTenantService extends Service {
    * - Already claimed by a different tenant/user → {@link SessionOwnershipConflictError};
    *   the existing owner is never overwritten.
    *
-   * There is deliberately no reassignment API: reassigning ownership is a
-   * high-privilege admin operation that belongs to a future Admin Plane.
+   * There is deliberately no reassignment or release API: ownership is
+   * immutable, and lifecycle cleanup belongs to a future Admin/Session-lifecycle
+   * plane, not this core.
    */
   async claimSession(sessionId: string, principal: TenantPrincipal): Promise<void> {
     validateSessionId(sessionId)
@@ -83,23 +79,6 @@ export class MultiTenantService extends Service {
     if (!decision.allowed) {
       throw new SessionAccessDeniedError()
     }
-  }
-
-  /**
-   * Release ownership of `sessionId`, but only for the current owner.
-   *
-   * A non-owner (different user, different tenant, or unknown session) is
-   * denied — the same non-enumerating denial as `assertSessionAccess`. There is
-   * no unconditional "delete someone else's ownership" API.
-   */
-  async releaseSession(sessionId: string, principal: TenantPrincipal): Promise<void> {
-    validateSessionId(sessionId)
-    validateTenantPrincipal(principal)
-    const owner = await this.store.get(sessionId)
-    if (!owner || owner.tenantId !== principal.tenantId || owner.userId !== principal.userId) {
-      throw new SessionAccessDeniedError()
-    }
-    await this.store.release(sessionId)
   }
 
   /**

--- a/src/service.ts
+++ b/src/service.ts
@@ -1,125 +1,130 @@
 /**
- * In-memory, fail-closed session-ownership service.
+ * The multi-tenant session-ownership service (`ctx.multiTenant`).
  *
- * This is the BOOTSTRAP / DEVELOPMENT implementation. It is backed by a
- * process-local `Map` and is lost on restart; it is **not** production
- * persistence and **not**, by itself, a production security boundary. The
- * durable `TenantSessionStore` and the surrounding defense-in-depth layers are
- * on the roadmap (see README).
+ * Responsibility, in one sentence: given an authenticated {@link TenantPrincipal},
+ * own and authorize access to opaque DSH session ids through a fail-closed,
+ * durable-store-compatible ownership contract.
+ *
+ * The service is storage-agnostic: it depends only on {@link TenantSessionStore}
+ * and never inspects the backing store. Ownership is claim-once (immutable); the
+ * tenant boundary is unconditional and checked before any other consideration.
  *
  * @module dsh-multi-tenant/service
  */
 
 import { Service, type Context } from '@deepseek-ai/cordis'
-import { MultiTenantError, SessionAccessDeniedError, UnknownSessionError } from './errors.ts'
+import { SessionAccessDeniedError, SessionOwnershipConflictError } from './errors.ts'
+import { InMemoryTenantSessionStore } from './store.ts'
+import { validateSessionId, validateTenantPrincipal } from './validation.ts'
 import type {
-  MultiTenantService as MultiTenantServiceContract,
+  AccessDecision,
   SessionOwner,
   TenantPrincipal,
+  TenantSessionStore,
 } from './types.ts'
 
-/** Internal result of an authorization decision. */
-type AccessDecision =
-  | { allowed: true }
-  | { allowed: false; error: MultiTenantError }
+export class MultiTenantService extends Service {
+  private readonly store: TenantSessionStore
 
-/**
- * `ctx.multiTenant` — the multi-tenant session-ownership service.
- *
- * Load it as a standard Cordis plugin (`ctx.plugin(MultiTenantService)`), then
- * consume it as `ctx.multiTenant`.
- */
-export class MultiTenantService extends Service implements MultiTenantServiceContract {
-  /** sessionId (opaque) → recorded owner. */
-  private readonly sessionOwners = new Map<string, SessionOwner>()
-
-  constructor(ctx: Context) {
+  /**
+   * @param ctx — Cordis context (the service registers itself as `multiTenant`).
+   * @param store — ownership store; defaults to an in-memory bootstrap store.
+   *   Inject a durable `TenantSessionStore` for production.
+   */
+  constructor(ctx: Context, store?: TenantSessionStore) {
     super(ctx, 'multiTenant')
+    this.store = store ?? new InMemoryTenantSessionStore()
   }
 
   /**
-   * Record that `sessionId` belongs to `principal`'s tenant/user.
+   * Claim ownership of `sessionId` for `principal`, exactly once.
    *
-   * The caller is responsible for establishing `principal` from a server-side
-   * authenticated identity. The service does not parse tenant identity out of
-   * the session id, and does not trust a client-supplied tenant id: it only
-   * stores what an authenticated boundary provides. Re-binding overwrites the
-   * previous owner; a real reassignment path belongs to a future, gated API.
+   * - Unclaimed → establishes ownership and succeeds.
+   * - Already claimed by the same tenant/user → idempotent success.
+   * - Already claimed by a different tenant/user → {@link SessionOwnershipConflictError};
+   *   the existing owner is never overwritten.
+   *
+   * There is deliberately no reassignment API: reassigning ownership is a
+   * high-privilege admin operation that belongs to a future Admin Plane.
    */
-  bindSession(sessionId: string, principal: TenantPrincipal): void {
-    if (!sessionId) {
-      throw new MultiTenantError('bindSession requires a non-empty sessionId')
+  async claimSession(sessionId: string, principal: TenantPrincipal): Promise<void> {
+    validateSessionId(sessionId)
+    validateTenantPrincipal(principal)
+    const owner: SessionOwner = { tenantId: principal.tenantId, userId: principal.userId }
+    const result = await this.store.claim(sessionId, owner)
+    if (result === 'conflict') {
+      throw new SessionOwnershipConflictError()
     }
-    this.sessionOwners.set(sessionId, {
-      tenantId: principal.tenantId,
-      userId: principal.userId,
-    })
   }
 
-  /** Return a copy of the recorded owner, or `undefined` if unknown. */
-  getSessionOwner(sessionId: string): SessionOwner | undefined {
-    const owner = this.sessionOwners.get(sessionId)
-    return owner ? { tenantId: owner.tenantId, userId: owner.userId } : undefined
+  /**
+   * Return the recorded owner, or `undefined` if unknown.
+   *
+   * This is a trusted-facing lookup (server components, audit, tests) and is
+   * NOT a non-enumerating surface; the authorization methods are.
+   */
+  async getSessionOwner(sessionId: string): Promise<SessionOwner | undefined> {
+    validateSessionId(sessionId)
+    return this.store.get(sessionId)
   }
 
   /** Fail-closed boolean authorization. Unknown session → `false`. */
-  canAccessSession(principal: TenantPrincipal, sessionId: string): boolean {
-    return this.resolveAccess(principal, sessionId).allowed
+  async canAccessSession(principal: TenantPrincipal, sessionId: string): Promise<boolean> {
+    return (await this.evaluateAccess(principal, sessionId)).allowed
   }
 
-  /** Authorization that throws `UnknownSessionError` / `SessionAccessDeniedError`. */
-  assertSessionAccess(principal: TenantPrincipal, sessionId: string): void {
-    const decision = this.resolveAccess(principal, sessionId)
-    if (!decision.allowed) throw decision.error
-  }
-
-  /** Forget the ownership binding. Unknown id is a no-op. */
-  unbindSession(sessionId: string): void {
-    this.sessionOwners.delete(sessionId)
-  }
-
-  private resolveAccess(principal: TenantPrincipal, sessionId: string): AccessDecision {
-    const owner = this.sessionOwners.get(sessionId)
-    if (!owner) {
-      return { allowed: false, error: new UnknownSessionError(sessionId) }
-    }
-    // The tenant boundary is unconditional: no role, present or future, may
-    // cross it. This is what keeps two tenants of one shared runtime apart.
-    if (principal.tenantId !== owner.tenantId) {
-      return {
-        allowed: false,
-        error: new SessionAccessDeniedError(
-          sessionId,
-          `principal tenant "${principal.tenantId}" does not match session tenant "${owner.tenantId}"`,
-        ),
-      }
-    }
-    if (principal.userId === owner.userId) {
-      return { allowed: true }
-    }
-    if (this.canElevatedAccess(principal, owner)) {
-      return { allowed: true }
-    }
-    return {
-      allowed: false,
-      error: new SessionAccessDeniedError(
-        sessionId,
-        `user "${principal.userId}" is not the session owner and holds no elevated role`,
-      ),
+  /**
+   * Authorization that throws on denial. The thrown {@link SessionAccessDeniedError}
+   * is uniform: it does not distinguish an unknown session from a foreign one,
+   * and it never carries owner tenant/user identity.
+   */
+  async assertSessionAccess(principal: TenantPrincipal, sessionId: string): Promise<void> {
+    const decision = await this.evaluateAccess(principal, sessionId)
+    if (!decision.allowed) {
+      throw new SessionAccessDeniedError()
     }
   }
 
   /**
-   * Extension point for tenant-admin / platform-admin elevation.
+   * Release ownership of `sessionId`, but only for the current owner.
    *
-   * The v0 core returns `false` by default: cross-user access is denied even
-   * for admin roles, because a role-based elevation rule is a security
-   * decision that belongs to a downstream tenant-aware authorization layer,
-   * not a guess here. Subclass and override to grant cross-user access *within*
-   * a tenant (e.g. `principal.roles.includes('tenant-admin')`). Cross-tenant
-   * access is never elevated — the tenant boundary above is unconditional.
+   * A non-owner (different user, different tenant, or unknown session) is
+   * denied — the same non-enumerating denial as `assertSessionAccess`. There is
+   * no unconditional "delete someone else's ownership" API.
    */
-  protected canElevatedAccess(_principal: TenantPrincipal, _owner: SessionOwner): boolean {
-    return false
+  async releaseSession(sessionId: string, principal: TenantPrincipal): Promise<void> {
+    validateSessionId(sessionId)
+    validateTenantPrincipal(principal)
+    const owner = await this.store.get(sessionId)
+    if (!owner || owner.tenantId !== principal.tenantId || owner.userId !== principal.userId) {
+      throw new SessionAccessDeniedError()
+    }
+    await this.store.release(sessionId)
+  }
+
+  /**
+   * Internal authorization decision with a diagnostic reason.
+   *
+   * `protected` so tests, future audit, and observability can inspect the
+   * reason. The PUBLIC API (`canAccessSession` / `assertSessionAccess`) never
+   * exposes it — the reason is diagnostic, not a transport value.
+   */
+  protected async evaluateAccess(principal: TenantPrincipal, sessionId: string): Promise<AccessDecision> {
+    validateSessionId(sessionId)
+    validateTenantPrincipal(principal)
+    const owner = await this.store.get(sessionId)
+    if (!owner) {
+      return { allowed: false, reason: 'UNKNOWN_SESSION' }
+    }
+    // The tenant boundary is unconditional and checked first: no role, present
+    // or future, may cross it. Cross-tenant inspection is a separate Admin /
+    // Audit Plane concern, not `canAccessSession`.
+    if (owner.tenantId !== principal.tenantId) {
+      return { allowed: false, reason: 'TENANT_MISMATCH' }
+    }
+    if (owner.userId !== principal.userId) {
+      return { allowed: false, reason: 'USER_MISMATCH' }
+    }
+    return { allowed: true }
   }
 }

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,0 +1,43 @@
+/**
+ * Development / bootstrap session-ownership store.
+ *
+ * Backed by a process-local `Map` and lost on restart. This is NOT production
+ * persistence — it exists so the core contract can be exercised now, and so a
+ * durable store (PostgreSQL / MySQL / Redis / remote authority) can be swapped
+ * in behind the same {@link TenantSessionStore} seam later.
+ *
+ * `claim` is atomic within a single JavaScript turn: the read and the write
+ * happen synchronously inside one async function body with no `await` between
+ * them, so there is no interleaving point for another claim to slip through.
+ * A durable implementation must preserve this atomicity (e.g. a unique
+ * `session_id` constraint with `INSERT … ON CONFLICT`).
+ *
+ * @module dsh-multi-tenant/store
+ */
+
+import type { ClaimResult, SessionOwner, TenantSessionStore } from './types.ts'
+
+export class InMemoryTenantSessionStore implements TenantSessionStore {
+  private readonly owners = new Map<string, SessionOwner>()
+
+  async claim(sessionId: string, owner: SessionOwner): Promise<ClaimResult> {
+    const existing = this.owners.get(sessionId)
+    if (!existing) {
+      this.owners.set(sessionId, { tenantId: owner.tenantId, userId: owner.userId })
+      return 'created'
+    }
+    if (existing.tenantId === owner.tenantId && existing.userId === owner.userId) {
+      return 'idempotent'
+    }
+    return 'conflict'
+  }
+
+  async get(sessionId: string): Promise<SessionOwner | undefined> {
+    const owner = this.owners.get(sessionId)
+    return owner ? { tenantId: owner.tenantId, userId: owner.userId } : undefined
+  }
+
+  async release(sessionId: string): Promise<void> {
+    this.owners.delete(sessionId)
+  }
+}

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,26 +1,55 @@
 /**
- * Development / bootstrap session-ownership store.
+ * Tenant-session-store service seam (`ctx.tenantSessionStore`).
  *
- * Backed by a process-local `Map` and lost on restart. This is NOT production
- * persistence — it exists so the core contract can be exercised now, and so a
- * durable store (PostgreSQL / MySQL / Redis / remote authority) can be swapped
- * in behind the same {@link TenantSessionStore} seam later.
- *
- * `claim` is atomic within a single JavaScript turn: the read and the write
- * happen synchronously inside one async function body with no `await` between
- * them, so there is no interleaving point for another claim to slip through.
- * A durable implementation must preserve this atomicity (e.g. a unique
- * `session_id` constraint with `INSERT … ON CONFLICT`).
+ * Ownership is claim-once and immutable: there is deliberately NO release /
+ * delete in the v0 contract. DSH session-lifecycle cleanup (actually ending a
+ * session) is a separate concern to be designed against DSH's real Session
+ * lifecycle later — it is not exposed here as an unconditional hazard.
  *
  * @module dsh-multi-tenant/store
  */
 
-import type { ClaimResult, SessionOwner, TenantSessionStore } from './types.ts'
+import { Service, type Context } from '@deepseek-ai/cordis'
+import type { ClaimResult, SessionOwner } from './types.ts'
 
-export class InMemoryTenantSessionStore implements TenantSessionStore {
+declare module '@deepseek-ai/cordis' {
+  interface Context {
+    tenantSessionStore: TenantSessionStore
+  }
+}
+
+/**
+ * The ownership-storage seam. Backends store the tenant/user that claimed each
+ * opaque session id. `claim` MUST be atomic — a single operation, not a
+ * get-then-set — so a durable backend can map it to `INSERT … ON CONFLICT`
+ * over a unique `session_id`. A future durable backend replaces the provider
+ * of this service without touching `MultiTenantService`.
+ */
+export abstract class TenantSessionStore extends Service {
+  constructor(ctx: Context) {
+    super(ctx, 'tenantSessionStore')
+  }
+
+  abstract claim(sessionId: string, owner: SessionOwner): Promise<ClaimResult>
+  abstract get(sessionId: string): Promise<SessionOwner | undefined>
+}
+
+/**
+ * Development / bootstrap backend backed by a process-local `Map`.
+ *
+ * `claim` is atomic within a single JavaScript turn: the read and the write
+ * happen synchronously inside one async function body with no `await` between
+ * them, so no other claim can interleave. Lost on restart; NOT production
+ * persistence.
+ */
+export class InMemoryTenantSessionStore extends TenantSessionStore {
   private readonly owners = new Map<string, SessionOwner>()
 
-  async claim(sessionId: string, owner: SessionOwner): Promise<ClaimResult> {
+  constructor(ctx: Context) {
+    super(ctx)
+  }
+
+  override async claim(sessionId: string, owner: SessionOwner): Promise<ClaimResult> {
     const existing = this.owners.get(sessionId)
     if (!existing) {
       this.owners.set(sessionId, { tenantId: owner.tenantId, userId: owner.userId })
@@ -32,12 +61,10 @@ export class InMemoryTenantSessionStore implements TenantSessionStore {
     return 'conflict'
   }
 
-  async get(sessionId: string): Promise<SessionOwner | undefined> {
+  override async get(sessionId: string): Promise<SessionOwner | undefined> {
     const owner = this.owners.get(sessionId)
     return owner ? { tenantId: owner.tenantId, userId: owner.userId } : undefined
   }
-
-  async release(sessionId: string): Promise<void> {
-    this.owners.delete(sessionId)
-  }
 }
+
+export default InMemoryTenantSessionStore

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,5 @@
 /**
- * Core multi-tenant identity, ownership, and storage-seam types.
+ * Core multi-tenant identity, ownership, and decision types.
  *
  * Identifier semantics: `sessionId`, `tenantId`, and `userId` are all OPAQUE
  * strings. The core never parses structure out of them — no UUID or numeric-id
@@ -44,28 +44,13 @@ export interface SessionOwner {
  * Result of an atomic ownership claim.
  *
  * `claim` returns one of these; it never throws on a conflicting owner (the
- * service maps `'conflict'` to a public error). Keeping the result as a plain
- * discriminated string means a durable store can implement it without leaking
- * the existing owner back through the seam.
+ * service maps `'conflict'` to a public error). A plain discriminated string
+ * keeps the seam from leaking the existing owner back to the caller.
  */
 export type ClaimResult =
   | 'created'
   | 'idempotent'
   | 'conflict'
-
-/**
- * Storage seam for session ownership.
- *
- * `claim` MUST be atomic — a single operation, not a get-then-set — so a
- * durable implementation can map it to `INSERT … ON CONFLICT` over a unique
- * `session_id`. The service is unaware of the backing store (Map / SQL /
- * Redis) and treats it as the single source of truth for ownership.
- */
-export interface TenantSessionStore {
-  claim(sessionId: string, owner: SessionOwner): Promise<ClaimResult>
-  get(sessionId: string): Promise<SessionOwner | undefined>
-  release(sessionId: string): Promise<void>
-}
 
 /**
  * Internal diagnostic reason for an access denial.
@@ -79,8 +64,10 @@ export type AccessDenialReason =
   | 'TENANT_MISMATCH'
   | 'USER_MISMATCH'
 
-/** Internal authorization decision with an optional diagnostic reason. */
-export interface AccessDecision {
-  allowed: boolean
-  reason?: AccessDenialReason
-}
+/**
+ * Internal authorization decision, as a discriminated union: an allowed
+ * decision carries no reason, and a denial always carries one.
+ */
+export type AccessDecision =
+  | { allowed: true }
+  | { allowed: false; reason: AccessDenialReason }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,10 +1,10 @@
 /**
- * Core multi-tenant identity and authorization types.
+ * Core multi-tenant identity, ownership, and storage-seam types.
  *
- * These are the "seam" types shared by every future layer (HTTP auth, RPC
- * authorization, MCP credential pools). They are intentionally minimal: a
- * principal is an authenticated identity, and an owner is the subset of that
- * identity recorded against a session.
+ * Identifier semantics: `sessionId`, `tenantId`, and `userId` are all OPAQUE
+ * strings. The core never parses structure out of them — no UUID or numeric-id
+ * assumptions, no `tenantId:userId` join rules, no prefix-based authorization.
+ * Identity is an exact-match on the authenticated value.
  *
  * @module dsh-multi-tenant/types
  */
@@ -12,28 +12,28 @@
 /**
  * An authenticated caller identity, established by a server-side boundary.
  *
- * A `TenantPrincipal` is **never** assembled from client-supplied fields: the
- * authenticated request boundary derives it (e.g. from a verified session
- * token or an authenticated API key) and hands it to this service. The service
- * trusts the principal it is given, but does not trust a tenant id that
- * arrives out-of-band.
+ * A `TenantPrincipal` is never assembled from client-supplied fields: the
+ * authenticated transport derives it (verified session token, authenticated
+ * API key, …) and hands it to this core. The core trusts the principal it is
+ * given but never trusts a tenant id that arrives out-of-band.
  */
 export interface TenantPrincipal {
-  /** Opaque tenant identifier. Server-derived; never parsed from a session id. */
+  /** Opaque tenant identifier. Never parsed out of a session id. */
   tenantId: string
   /** User identifier, unique within the tenant. */
   userId: string
-  /** Roles the user holds within the tenant (e.g. `member`, `tenant-admin`). */
+  /**
+   * Roles the user holds within the tenant. Present for future authorization
+   * layers; the v0 core does NOT consult roles for access — ownership only.
+   */
   roles: readonly string[]
 }
 
 /**
- * The recorded owner of a session.
+ * The recorded owner of a session — the minimal authorization binding.
  *
- * This is the minimal authorization binding: which tenant and user a session
- * belongs to. It is deliberately smaller than `TenantPrincipal` — roles are an
- * attribute of the *caller* at request time, not a property pinned to the
- * session.
+ * Deliberately smaller than `TenantPrincipal`: roles are an attribute of the
+ * *caller* at request time, not a property pinned to the session.
  */
 export interface SessionOwner {
   tenantId: string
@@ -41,22 +41,46 @@ export interface SessionOwner {
 }
 
 /**
- * Public contract of the multi-tenant service (provided as `ctx.multiTenant`).
+ * Result of an atomic ownership claim.
  *
- * The concrete implementation is `MultiTenantService` in `./service.ts`, which
- * extends Cordis `Service`. This interface exists so consumers can type
- * decorators, mocks, or a future durable `TenantSessionStore`-backed
- * implementation against the same surface.
+ * `claim` returns one of these; it never throws on a conflicting owner (the
+ * service maps `'conflict'` to a public error). Keeping the result as a plain
+ * discriminated string means a durable store can implement it without leaking
+ * the existing owner back through the seam.
  */
-export interface MultiTenantService {
-  /** Record `sessionId` as owned by `principal`'s tenant/user. */
-  bindSession(sessionId: string, principal: TenantPrincipal): void
-  /** Return the recorded owner, or `undefined` if the session is unknown. */
-  getSessionOwner(sessionId: string): SessionOwner | undefined
-  /** Fail-closed boolean: may `principal` access `sessionId`? */
-  canAccessSession(principal: TenantPrincipal, sessionId: string): boolean
-  /** Like `canAccessSession`, but throws a specific error on denial. */
-  assertSessionAccess(principal: TenantPrincipal, sessionId: string): void
-  /** Forget the ownership binding for `sessionId`. */
-  unbindSession(sessionId: string): void
+export type ClaimResult =
+  | 'created'
+  | 'idempotent'
+  | 'conflict'
+
+/**
+ * Storage seam for session ownership.
+ *
+ * `claim` MUST be atomic — a single operation, not a get-then-set — so a
+ * durable implementation can map it to `INSERT … ON CONFLICT` over a unique
+ * `session_id`. The service is unaware of the backing store (Map / SQL /
+ * Redis) and treats it as the single source of truth for ownership.
+ */
+export interface TenantSessionStore {
+  claim(sessionId: string, owner: SessionOwner): Promise<ClaimResult>
+  get(sessionId: string): Promise<SessionOwner | undefined>
+  release(sessionId: string): Promise<void>
+}
+
+/**
+ * Internal diagnostic reason for an access denial.
+ *
+ * This is an INTERNAL value for tests, audit, and observability. It is never
+ * returned through the public authorization API, which deliberately collapses
+ * all denials into a single non-enumerating error.
+ */
+export type AccessDenialReason =
+  | 'UNKNOWN_SESSION'
+  | 'TENANT_MISMATCH'
+  | 'USER_MISMATCH'
+
+/** Internal authorization decision with an optional diagnostic reason. */
+export interface AccessDecision {
+  allowed: boolean
+  reason?: AccessDenialReason
 }

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -1,0 +1,63 @@
+/**
+ * Runtime invariant validation for opaque identifiers and principals.
+ *
+ * TypeScript types are not a security boundary: a JS caller can pass an empty
+ * or over-long string through a typed signature. These helpers reject such
+ * input at the service boundary. They are internal — not part of the package's
+ * public surface.
+ *
+ * @module dsh-multi-tenant/validation
+ */
+
+import { ValidationError } from './errors.ts'
+import type { TenantPrincipal } from './types.ts'
+
+export const MAX_IDENTIFIER_LENGTH = 256
+export const MAX_ROLE_COUNT = 32
+export const MAX_ROLE_LENGTH = 64
+
+/** An opaque identifier must be a non-empty, trimmed string of bounded length. */
+function requireOpaqueId(value: unknown, label: string): void {
+  if (typeof value !== 'string') {
+    throw new ValidationError(`${label} must be a string`)
+  }
+  if (value.length === 0) {
+    throw new ValidationError(`${label} must not be empty`)
+  }
+  if (value !== value.trim()) {
+    throw new ValidationError(`${label} must not have surrounding whitespace`)
+  }
+  if (value.length > MAX_IDENTIFIER_LENGTH) {
+    throw new ValidationError(`${label} exceeds ${MAX_IDENTIFIER_LENGTH} characters`)
+  }
+}
+
+/** Reject an invalid `sessionId`. */
+export function validateSessionId(sessionId: unknown): void {
+  requireOpaqueId(sessionId, 'sessionId')
+}
+
+/** Reject a malformed principal (empty/whitespace/over-long identity, bad roles). */
+export function validateTenantPrincipal(principal: unknown): void {
+  if (typeof principal !== 'object' || principal === null) {
+    throw new ValidationError('principal must be an object')
+  }
+  const p = principal as TenantPrincipal
+  requireOpaqueId(p.tenantId, 'tenantId')
+  requireOpaqueId(p.userId, 'userId')
+
+  if (!Array.isArray(p.roles)) {
+    throw new ValidationError('roles must be an array')
+  }
+  if (p.roles.length > MAX_ROLE_COUNT) {
+    throw new ValidationError(`roles exceeds ${MAX_ROLE_COUNT} entries`)
+  }
+  for (const role of p.roles) {
+    if (typeof role !== 'string' || role.length === 0 || role !== role.trim()) {
+      throw new ValidationError('roles must contain only non-empty strings without surrounding whitespace')
+    }
+    if (role.length > MAX_ROLE_LENGTH) {
+      throw new ValidationError(`a role exceeds ${MAX_ROLE_LENGTH} characters`)
+    }
+  }
+}

--- a/tests/bundle.manifest.test.ts
+++ b/tests/bundle.manifest.test.ts
@@ -19,9 +19,20 @@ describe('DeepSeek Harness bundle contract', () => {
     expect(existsSync(patchPath)).toBe(true)
   })
 
-  it('inserts this package as a Cordis row under a stable id', () => {
+  it('exposes the service and store seams as package entry points', () => {
+    const main = packageManifest.exports?.['.'] as { import?: string; types?: string } | undefined
+    const store = packageManifest.exports?.['./store'] as { import?: string; types?: string } | undefined
+    expect(main?.import).toBe('./dist/index.mjs')
+    expect(main?.types).toBe('./dist/index.d.mts')
+    expect(store?.import).toBe('./dist/store.mjs')
+    expect(store?.types).toBe('./dist/store.d.mts')
+  })
+
+  it('assembles the store provider and the service as two rows', () => {
     const patch = readFileSync(patchPath, 'utf8')
     expect(patch).toContain('insert:')
+    expect(patch).toContain('id: tenant-session-store')
+    expect(patch).toContain('name: dsh-multi-tenant/store')
     expect(patch).toContain('id: multi-tenant')
     expect(patch).toContain('name: dsh-multi-tenant')
   })

--- a/tests/loader.integration.test.ts
+++ b/tests/loader.integration.test.ts
@@ -5,6 +5,12 @@ import { describe, expect, it } from 'vitest'
 
 describe('real Cordis Loader composition', () => {
   it('loads dsh-multi-tenant through the Loader and authorizes via ctx.multiTenant', async () => {
+    // Boundary: this exercises the REAL Cordis Loader + Include path over
+    // `demo/cordis.yml`, proving the plugin is a genuine loadable Cordis
+    // Service (both the store seam and the service), NOT a mock construction.
+    // It resolves entries by relative SOURCE path (`../src/*.ts`); it does not
+    // exercise the packaged `exports`/`dsh.bundle` name resolution, which the
+    // static `bundle.manifest.test.ts` covers.
     const projectRoot = resolve(import.meta.dirname, '..')
     const demoScript = resolve(projectRoot, 'demo/run-loader.ts')
     const child = spawn(process.execPath, ['--import', 'tsx', demoScript], {

--- a/tests/loader.integration.test.ts
+++ b/tests/loader.integration.test.ts
@@ -1,0 +1,30 @@
+import { spawn } from 'node:child_process'
+import { once } from 'node:events'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+describe('real Cordis Loader composition', () => {
+  it('loads dsh-multi-tenant through the Loader and authorizes via ctx.multiTenant', async () => {
+    const projectRoot = resolve(import.meta.dirname, '..')
+    const demoScript = resolve(projectRoot, 'demo/run-loader.ts')
+    const child = spawn(process.execPath, ['--import', 'tsx', demoScript], {
+      cwd: resolve(projectRoot, 'demo'),
+      env: { ...process.env, FORCE_COLOR: '0' },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+    const stdout: Buffer[] = []
+    const stderr: Buffer[] = []
+    child.stdout.on('data', (chunk) => stdout.push(Buffer.from(chunk)))
+    child.stderr.on('data', (chunk) => stderr.push(Buffer.from(chunk)))
+    const [code] = (await once(child, 'close')) as [number | null]
+    const output = Buffer.concat(stdout).toString('utf8')
+    const errorOutput = Buffer.concat(stderr).toString('utf8')
+
+    expect(code, errorOutput).toBe(0)
+    expect(output).toContain('"owner":{"tenantId":"acme","userId":"alice"}')
+    expect(output).toContain('"sameAllowed":true')
+    expect(output).toContain('"crossTenantAllowed":false')
+    expect(output).toContain('"denialName":"SessionAccessDeniedError"')
+    expect(output).toContain('"denialMessage":"Access to session denied."')
+  }, 30_000)
+})

--- a/tests/multi-tenant.test.ts
+++ b/tests/multi-tenant.test.ts
@@ -2,13 +2,14 @@ import { Context } from '@deepseek-ai/cordis'
 import { beforeEach, describe, expect, it } from 'vitest'
 import {
   InMemoryTenantSessionStore,
+  MultiTenantError,
   MultiTenantService,
   SessionAccessDeniedError,
   SessionOwnershipConflictError,
   TenantSessionStore,
   ValidationError,
 } from '../src/index.ts'
-import type { AccessDecision, SessionOwner, TenantPrincipal } from '../src/types.ts'
+import type { AccessDecision, ClaimResult, SessionOwner, TenantPrincipal } from '../src/types.ts'
 
 const alice: TenantPrincipal = { tenantId: 'acme', userId: 'alice', roles: ['member'] }
 const bob: TenantPrincipal = { tenantId: 'acme', userId: 'bob', roles: ['member'] }
@@ -209,5 +210,25 @@ describe('TenantSessionStore service seam', () => {
 
     const store = ctx.tenantSessionStore as RecordingStore
     expect(store.claims).toEqual(['s1', 's1'])
+  })
+
+  it('fails closed when the store returns an invalid claim result', async () => {
+    class InvalidStore extends TenantSessionStore {
+      constructor(ctx: Context) {
+        super(ctx)
+      }
+      override async claim(): Promise<ClaimResult> {
+        return 'bogus' as unknown as ClaimResult
+      }
+      override async get(): Promise<SessionOwner | undefined> {
+        return undefined
+      }
+    }
+
+    const ctx = new Context()
+    await ctx.plugin(InvalidStore)
+    await ctx.plugin(MultiTenantService)
+
+    await expect(ctx.multiTenant.claimSession('s1', alice)).rejects.toThrow(MultiTenantError)
   })
 })

--- a/tests/multi-tenant.test.ts
+++ b/tests/multi-tenant.test.ts
@@ -1,9 +1,11 @@
 import { Context } from '@deepseek-ai/cordis'
 import { beforeEach, describe, expect, it } from 'vitest'
 import {
+  InMemoryTenantSessionStore,
   MultiTenantService,
   SessionAccessDeniedError,
   SessionOwnershipConflictError,
+  TenantSessionStore,
   ValidationError,
 } from '../src/index.ts'
 import type { AccessDecision, SessionOwner, TenantPrincipal } from '../src/types.ts'
@@ -20,6 +22,7 @@ describe('MultiTenantService', () => {
 
   beforeEach(async () => {
     ctx = new Context()
+    await ctx.plugin(InMemoryTenantSessionStore)
     await ctx.plugin(MultiTenantService)
     multiTenant = ctx.multiTenant
   })
@@ -64,9 +67,7 @@ describe('MultiTenantService', () => {
       expect(rejected[0]?.reason).toBeInstanceOf(SessionOwnershipConflictError)
       const owner = await multiTenant.getSessionOwner('s1')
       expect(owner).not.toBeUndefined()
-      const winnerIsAlice = owner?.userId === 'alice'
-      const winnerIsBob = owner?.userId === 'bob'
-      expect(winnerIsAlice || winnerIsBob).toBe(true)
+      expect(owner?.userId === 'alice' || owner?.userId === 'bob').toBe(true)
     })
   })
 
@@ -97,9 +98,7 @@ describe('MultiTenantService', () => {
 
     it('does not let any role cross the tenant boundary', async () => {
       await multiTenant.claimSession('s1', alice)
-      // tenant-admin in a DIFFERENT tenant → denied (boundary is unconditional)
       await expect(multiTenant.canAccessSession(foreignAdmin, 's1')).resolves.toBe(false)
-      // tenant-admin in the SAME tenant but different user → still denied (ownership only, no RBAC yet)
       await expect(multiTenant.canAccessSession(acmeAdmin, 's1')).resolves.toBe(false)
     })
 
@@ -122,30 +121,6 @@ describe('MultiTenantService', () => {
       expect(message).not.toContain('alice')
       expect(message).not.toContain('bob')
       expect(message).toContain('denied')
-    })
-  })
-
-  describe('release', () => {
-    it('lets the owner release', async () => {
-      await multiTenant.claimSession('s1', alice)
-      await expect(multiTenant.releaseSession('s1', alice)).resolves.toBeUndefined()
-      await expect(multiTenant.getSessionOwner('s1')).resolves.toBeUndefined()
-    })
-
-    it('denies release by a different user', async () => {
-      await multiTenant.claimSession('s1', alice)
-      await expect(multiTenant.releaseSession('s1', bob)).rejects.toThrow(SessionAccessDeniedError)
-      await expect(multiTenant.getSessionOwner('s1')).resolves.toEqual({ tenantId: 'acme', userId: 'alice' })
-    })
-
-    it('denies release by a different tenant', async () => {
-      await multiTenant.claimSession('s1', alice)
-      await expect(multiTenant.releaseSession('s1', eve)).rejects.toThrow(SessionAccessDeniedError)
-      await expect(multiTenant.getSessionOwner('s1')).resolves.toEqual({ tenantId: 'acme', userId: 'alice' })
-    })
-
-    it('denies release of an unknown session', async () => {
-      await expect(multiTenant.releaseSession('missing', alice)).rejects.toThrow(SessionAccessDeniedError)
     })
   })
 
@@ -193,6 +168,7 @@ async function captureDenial(fn: () => Promise<unknown>): Promise<Error | undefi
 describe('internal access decision (diagnostic reason)', () => {
   it('classifies unknown / tenant-mismatch / user-mismatch distinctly', async () => {
     const ctx = new Context()
+    await ctx.plugin(InMemoryTenantSessionStore)
     await ctx.plugin(InspectableMultiTenantService)
     const svc = ctx.multiTenant as InspectableMultiTenantService
     await svc.claimSession('s1', alice)
@@ -204,26 +180,34 @@ describe('internal access decision (diagnostic reason)', () => {
   })
 })
 
-describe('TenantSessionStore seam', () => {
-  it('accepts an injected store and does not assume Map backing', async () => {
-    const owners = new Map<string, SessionOwner>()
-    const store = {
-      async claim(sessionId: string, owner: SessionOwner) {
-        if (owners.has(sessionId)) return 'conflict' as const
-        owners.set(sessionId, owner)
+describe('TenantSessionStore service seam', () => {
+  it('consumes a swappable tenantSessionStore provider, not a fixed backend', async () => {
+    class RecordingStore extends TenantSessionStore {
+      readonly claims: string[] = []
+      private readonly owners = new Map<string, SessionOwner>()
+      constructor(ctx: Context) {
+        super(ctx)
+      }
+      override async claim(sessionId: string, owner: SessionOwner) {
+        this.claims.push(sessionId)
+        if (this.owners.has(sessionId)) return 'conflict' as const
+        this.owners.set(sessionId, owner)
         return 'created' as const
-      },
-      async get(sessionId: string) {
-        return owners.get(sessionId)
-      },
-      async release(sessionId: string) {
-        owners.delete(sessionId)
-      },
+      }
+      override async get(sessionId: string) {
+        return this.owners.get(sessionId)
+      }
     }
+
     const ctx = new Context()
-    const service = new MultiTenantService(ctx, store)
-    await service.claimSession('s1', alice)
-    await expect(service.getSessionOwner('s1')).resolves.toEqual({ tenantId: 'acme', userId: 'alice' })
-    await expect(service.claimSession('s1', bob)).rejects.toThrow(SessionOwnershipConflictError)
+    await ctx.plugin(RecordingStore)
+    await ctx.plugin(MultiTenantService)
+
+    await ctx.multiTenant.claimSession('s1', alice)
+    await expect(ctx.multiTenant.getSessionOwner('s1')).resolves.toEqual({ tenantId: 'acme', userId: 'alice' })
+    await expect(ctx.multiTenant.claimSession('s1', bob)).rejects.toThrow(SessionOwnershipConflictError)
+
+    const store = ctx.tenantSessionStore as RecordingStore
+    expect(store.claims).toEqual(['s1', 's1'])
   })
 })

--- a/tests/multi-tenant.test.ts
+++ b/tests/multi-tenant.test.ts
@@ -3,13 +3,16 @@ import { beforeEach, describe, expect, it } from 'vitest'
 import {
   MultiTenantService,
   SessionAccessDeniedError,
-  UnknownSessionError,
+  SessionOwnershipConflictError,
+  ValidationError,
 } from '../src/index.ts'
-import type { SessionOwner, TenantPrincipal } from '../src/index.ts'
+import type { AccessDecision, SessionOwner, TenantPrincipal } from '../src/types.ts'
 
 const alice: TenantPrincipal = { tenantId: 'acme', userId: 'alice', roles: ['member'] }
 const bob: TenantPrincipal = { tenantId: 'acme', userId: 'bob', roles: ['member'] }
 const eve: TenantPrincipal = { tenantId: 'evilcorp', userId: 'alice', roles: ['member'] }
+const acmeAdmin: TenantPrincipal = { tenantId: 'acme', userId: 'root', roles: ['tenant-admin'] }
+const foreignAdmin: TenantPrincipal = { tenantId: 'evilcorp', userId: 'root', roles: ['tenant-admin', 'platform-admin'] }
 
 describe('MultiTenantService', () => {
   let ctx: Context
@@ -21,80 +24,206 @@ describe('MultiTenantService', () => {
     multiTenant = ctx.multiTenant
   })
 
-  it('records the correct owner after bindSession', () => {
-    multiTenant.bindSession('s1', alice)
-    expect(multiTenant.getSessionOwner('s1')).toEqual({ tenantId: 'acme', userId: 'alice' })
-  })
-
-  it('allows the same tenant + same user', () => {
-    multiTenant.bindSession('s1', alice)
-    expect(multiTenant.canAccessSession(alice, 's1')).toBe(true)
-    expect(() => multiTenant.assertSessionAccess(alice, 's1')).not.toThrow()
-  })
-
-  it('denies a different tenant', () => {
-    multiTenant.bindSession('s1', alice)
-    expect(multiTenant.canAccessSession(eve, 's1')).toBe(false)
-    expect(() => multiTenant.assertSessionAccess(eve, 's1')).toThrow(SessionAccessDeniedError)
-  })
-
-  it('denies a different user in the same tenant by default', () => {
-    multiTenant.bindSession('s1', alice)
-    expect(multiTenant.canAccessSession(bob, 's1')).toBe(false)
-    expect(() => multiTenant.assertSessionAccess(bob, 's1')).toThrow(SessionAccessDeniedError)
-  })
-
-  it('denies an unknown session (fail closed)', () => {
-    expect(multiTenant.getSessionOwner('missing')).toBeUndefined()
-    expect(multiTenant.canAccessSession(alice, 'missing')).toBe(false)
-    expect(() => multiTenant.assertSessionAccess(alice, 'missing')).toThrow(UnknownSessionError)
-  })
-
-  it('throws a clear, specific error from assertSessionAccess', () => {
-    multiTenant.bindSession('s1', alice)
-    let caught: unknown
-    try {
-      multiTenant.assertSessionAccess(eve, 's1')
-    } catch (error) {
-      caught = error
-    }
-    expect(caught).toBeInstanceOf(SessionAccessDeniedError)
-    expect((caught as Error).message).toContain('denied')
-    expect((caught as Error).message).toContain('tenant')
-  })
-
-  it('denies after unbindSession', () => {
-    multiTenant.bindSession('s1', alice)
-    multiTenant.unbindSession('s1')
-    expect(multiTenant.getSessionOwner('s1')).toBeUndefined()
-    expect(multiTenant.canAccessSession(alice, 's1')).toBe(false)
-    expect(() => multiTenant.assertSessionAccess(alice, 's1')).toThrow(UnknownSessionError)
-  })
-
-  describe('extension point: elevated roles', () => {
-    it('can grant cross-user access within a tenant via a subclass', async () => {
-      class TenantAdminService extends MultiTenantService {
-        protected override canElevatedAccess(principal: TenantPrincipal, owner: SessionOwner): boolean {
-          return principal.tenantId === owner.tenantId && principal.roles.includes('tenant-admin')
-        }
-      }
-
-      const adminCtx = new Context()
-      await adminCtx.plugin(TenantAdminService)
-      const admin = adminCtx.multiTenant
-
-      const tenantAdmin: TenantPrincipal = { tenantId: 'acme', userId: 'root', roles: ['tenant-admin'] }
-      const foreignAdmin: TenantPrincipal = { tenantId: 'evilcorp', userId: 'root', roles: ['tenant-admin'] }
-
-      admin.bindSession('s1', alice)
-
-      // A tenant-admin within the same tenant can access another user's session.
-      expect(admin.canAccessSession(tenantAdmin, 's1')).toBe(true)
-      expect(() => admin.assertSessionAccess(tenantAdmin, 's1')).not.toThrow()
-
-      // The tenant boundary is unconditional, even for an admin role.
-      expect(admin.canAccessSession(foreignAdmin, 's1')).toBe(false)
-      expect(() => admin.assertSessionAccess(foreignAdmin, 's1')).toThrow(SessionAccessDeniedError)
+  describe('ownership claim', () => {
+    it('succeeds on the first claim', async () => {
+      await expect(multiTenant.claimSession('s1', alice)).resolves.toBeUndefined()
+      await expect(multiTenant.getSessionOwner('s1')).resolves.toEqual({ tenantId: 'acme', userId: 'alice' })
     })
+
+    it('is idempotent for the same owner', async () => {
+      await multiTenant.claimSession('s1', alice)
+      await expect(multiTenant.claimSession('s1', alice)).resolves.toBeUndefined()
+      await expect(multiTenant.getSessionOwner('s1')).resolves.toEqual({ tenantId: 'acme', userId: 'alice' })
+    })
+
+    it('conflicts for a different user in the same tenant', async () => {
+      await multiTenant.claimSession('s1', alice)
+      await expect(multiTenant.claimSession('s1', bob)).rejects.toThrow(SessionOwnershipConflictError)
+    })
+
+    it('conflicts for a different tenant', async () => {
+      await multiTenant.claimSession('s1', alice)
+      await expect(multiTenant.claimSession('s1', eve)).rejects.toThrow(SessionOwnershipConflictError)
+    })
+
+    it('never overwrites the original owner on conflict', async () => {
+      await multiTenant.claimSession('s1', alice)
+      await expect(multiTenant.claimSession('s1', eve)).rejects.toThrow(SessionOwnershipConflictError)
+      await expect(multiTenant.getSessionOwner('s1')).resolves.toEqual({ tenantId: 'acme', userId: 'alice' })
+    })
+
+    it('resolves a concurrent double-claim to exactly one owner', async () => {
+      const results = await Promise.allSettled([
+        multiTenant.claimSession('s1', alice),
+        multiTenant.claimSession('s1', bob),
+      ])
+      const fulfilled = results.filter((r): r is PromiseFulfilledResult<void> => r.status === 'fulfilled')
+      const rejected = results.filter((r): r is PromiseRejectedResult => r.status === 'rejected')
+      expect(fulfilled).toHaveLength(1)
+      expect(rejected).toHaveLength(1)
+      expect(rejected[0]?.reason).toBeInstanceOf(SessionOwnershipConflictError)
+      const owner = await multiTenant.getSessionOwner('s1')
+      expect(owner).not.toBeUndefined()
+      const winnerIsAlice = owner?.userId === 'alice'
+      const winnerIsBob = owner?.userId === 'bob'
+      expect(winnerIsAlice || winnerIsBob).toBe(true)
+    })
+  })
+
+  describe('authorization', () => {
+    it('allows the same tenant + same owner', async () => {
+      await multiTenant.claimSession('s1', alice)
+      await expect(multiTenant.canAccessSession(alice, 's1')).resolves.toBe(true)
+      await expect(multiTenant.assertSessionAccess(alice, 's1')).resolves.toBeUndefined()
+    })
+
+    it('denies a different tenant', async () => {
+      await multiTenant.claimSession('s1', alice)
+      await expect(multiTenant.canAccessSession(eve, 's1')).resolves.toBe(false)
+      await expect(multiTenant.assertSessionAccess(eve, 's1')).rejects.toThrow(SessionAccessDeniedError)
+    })
+
+    it('denies a different user in the same tenant', async () => {
+      await multiTenant.claimSession('s1', alice)
+      await expect(multiTenant.canAccessSession(bob, 's1')).resolves.toBe(false)
+      await expect(multiTenant.assertSessionAccess(bob, 's1')).rejects.toThrow(SessionAccessDeniedError)
+    })
+
+    it('denies an unknown session (fail closed)', async () => {
+      await expect(multiTenant.getSessionOwner('missing')).resolves.toBeUndefined()
+      await expect(multiTenant.canAccessSession(alice, 'missing')).resolves.toBe(false)
+      await expect(multiTenant.assertSessionAccess(alice, 'missing')).rejects.toThrow(SessionAccessDeniedError)
+    })
+
+    it('does not let any role cross the tenant boundary', async () => {
+      await multiTenant.claimSession('s1', alice)
+      // tenant-admin in a DIFFERENT tenant → denied (boundary is unconditional)
+      await expect(multiTenant.canAccessSession(foreignAdmin, 's1')).resolves.toBe(false)
+      // tenant-admin in the SAME tenant but different user → still denied (ownership only, no RBAC yet)
+      await expect(multiTenant.canAccessSession(acmeAdmin, 's1')).resolves.toBe(false)
+    })
+
+    it('surfaces a uniform error for unknown vs foreign sessions', async () => {
+      await multiTenant.claimSession('s1', alice)
+      const unknown = await captureDenial(() => multiTenant.assertSessionAccess(alice, 'missing'))
+      const foreign = await captureDenial(() => multiTenant.assertSessionAccess(eve, 's1'))
+      expect(unknown).toBeInstanceOf(SessionAccessDeniedError)
+      expect(foreign).toBeInstanceOf(SessionAccessDeniedError)
+      expect(unknown?.message).toBe(foreign?.message)
+      expect(unknown?.message).toBe('Access to session denied.')
+    })
+
+    it('does not leak owner identity in the public error', async () => {
+      await multiTenant.claimSession('s1', alice)
+      const error = await captureDenial(() => multiTenant.assertSessionAccess(eve, 's1'))
+      const message = error?.message ?? ''
+      expect(message).not.toContain('acme')
+      expect(message).not.toContain('evilcorp')
+      expect(message).not.toContain('alice')
+      expect(message).not.toContain('bob')
+      expect(message).toContain('denied')
+    })
+  })
+
+  describe('release', () => {
+    it('lets the owner release', async () => {
+      await multiTenant.claimSession('s1', alice)
+      await expect(multiTenant.releaseSession('s1', alice)).resolves.toBeUndefined()
+      await expect(multiTenant.getSessionOwner('s1')).resolves.toBeUndefined()
+    })
+
+    it('denies release by a different user', async () => {
+      await multiTenant.claimSession('s1', alice)
+      await expect(multiTenant.releaseSession('s1', bob)).rejects.toThrow(SessionAccessDeniedError)
+      await expect(multiTenant.getSessionOwner('s1')).resolves.toEqual({ tenantId: 'acme', userId: 'alice' })
+    })
+
+    it('denies release by a different tenant', async () => {
+      await multiTenant.claimSession('s1', alice)
+      await expect(multiTenant.releaseSession('s1', eve)).rejects.toThrow(SessionAccessDeniedError)
+      await expect(multiTenant.getSessionOwner('s1')).resolves.toEqual({ tenantId: 'acme', userId: 'alice' })
+    })
+
+    it('denies release of an unknown session', async () => {
+      await expect(multiTenant.releaseSession('missing', alice)).rejects.toThrow(SessionAccessDeniedError)
+    })
+  })
+
+  describe('runtime validation', () => {
+    it('rejects an empty sessionId', async () => {
+      await expect(multiTenant.claimSession('', alice)).rejects.toThrow(ValidationError)
+    })
+
+    it('rejects an empty tenantId', async () => {
+      await expect(multiTenant.claimSession('s1', { ...alice, tenantId: '' })).rejects.toThrow(ValidationError)
+    })
+
+    it('rejects a whitespace-only tenantId', async () => {
+      await expect(multiTenant.claimSession('s1', { ...alice, tenantId: '   ' })).rejects.toThrow(ValidationError)
+    })
+
+    it('rejects an empty userId', async () => {
+      await expect(multiTenant.claimSession('s1', { ...alice, userId: '' })).rejects.toThrow(ValidationError)
+    })
+
+    it('rejects an invalid role entry', async () => {
+      await expect(
+        multiTenant.claimSession('s1', { ...alice, roles: ['member', ''] }),
+      ).rejects.toThrow(ValidationError)
+    })
+  })
+})
+
+/** A test subclass that exposes the internal denial reason for assertions. */
+class InspectableMultiTenantService extends MultiTenantService {
+  async reason(principal: TenantPrincipal, sessionId: string): Promise<AccessDecision> {
+    return this.evaluateAccess(principal, sessionId)
+  }
+}
+
+async function captureDenial(fn: () => Promise<unknown>): Promise<Error | undefined> {
+  try {
+    await fn()
+  } catch (error) {
+    return error as Error
+  }
+  return undefined
+}
+
+describe('internal access decision (diagnostic reason)', () => {
+  it('classifies unknown / tenant-mismatch / user-mismatch distinctly', async () => {
+    const ctx = new Context()
+    await ctx.plugin(InspectableMultiTenantService)
+    const svc = ctx.multiTenant as InspectableMultiTenantService
+    await svc.claimSession('s1', alice)
+
+    await expect(svc.reason(alice, 'missing')).resolves.toEqual({ allowed: false, reason: 'UNKNOWN_SESSION' })
+    await expect(svc.reason(eve, 's1')).resolves.toEqual({ allowed: false, reason: 'TENANT_MISMATCH' })
+    await expect(svc.reason(bob, 's1')).resolves.toEqual({ allowed: false, reason: 'USER_MISMATCH' })
+    await expect(svc.reason(alice, 's1')).resolves.toEqual({ allowed: true })
+  })
+})
+
+describe('TenantSessionStore seam', () => {
+  it('accepts an injected store and does not assume Map backing', async () => {
+    const owners = new Map<string, SessionOwner>()
+    const store = {
+      async claim(sessionId: string, owner: SessionOwner) {
+        if (owners.has(sessionId)) return 'conflict' as const
+        owners.set(sessionId, owner)
+        return 'created' as const
+      },
+      async get(sessionId: string) {
+        return owners.get(sessionId)
+      },
+      async release(sessionId: string) {
+        owners.delete(sessionId)
+      },
+    }
+    const ctx = new Context()
+    const service = new MultiTenantService(ctx, store)
+    await service.claimSession('s1', alice)
+    await expect(service.getSessionOwner('s1')).resolves.toEqual({ tenantId: 'acme', userId: 'alice' })
+    await expect(service.claimSession('s1', bob)).rejects.toThrow(SessionOwnershipConflictError)
   })
 })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,5 +20,5 @@
     "rootDir": ".",
     "outDir": "dist/types"
   },
-  "include": ["src", "tests"]
+  "include": ["src", "tests", "demo"]
 }

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'tsdown'
 
 export default defineConfig({
-  entry: ['src/index.ts'],
+  entry: ['src/index.ts', 'src/store.ts'],
   format: ['esm'],
   dts: true,
   sourcemap: true,


### PR DESCRIPTION
## Summary

Second milestone for `dsh-multi-tenant`: harden the core contract rather than add features. The goal was to make the core boring, explicit, fail-closed, stable, and extensible.

## What changed

- **Claim-once, immutable ownership** — `bindSession` → `claimSession`. A conflicting claim throws `SessionOwnershipConflictError` and never overwrites. There is deliberately no reassignment or release API.
- **Store as a Cordis Service seam** — `TenantSessionStore` is an abstract `Service` (`ctx.tenantSessionStore`), with `InMemoryTenantSessionStore` as the default provider. `MultiTenantService` declares `static inject = ['tenantSessionStore']` and never touches a backend directly; a durable backend swaps the provider without changing the service.
- **Exhaustive, fail-closed claim handling** — only `'created'`/`'idempotent'` succeed; `'conflict'` throws; any invalid store result throws (never silently treated as success).
- **Async contract** — all service methods return `Promise` so a durable store can be adopted without a breaking change.
- **Error privacy** — `assertSessionAccess` throws one uniform, non-enumerating `SessionAccessDeniedError` (`"Access to session denied."`); unknown vs foreign sessions are indistinguishable, and no owner identity leaks. Internal `AccessDenialReason` stays internal.
- **Discriminated-union decision** — `AccessDecision = { allowed: true } | { allowed: false; reason }`.
- **Runtime validation** — rejects empty/whitespace/over-long `tenantId`/`userId`/`sessionId` and malformed `roles`.
- **Real Loader integration test** — loads both the store seam and the service through `@deepseek-ai/cordis-plugin-loader` + `include`, not mock construction.
- **Minimal CI** — `pnpm install --frozen-lockfile` / typecheck / test / build on push + PR.
- **Focused README** — rewritten around "what this core does / does not do".

## Deliberately NOT in this PR

No auth, web, WebSocket, MCP, audit, UI, RBAC framework, or durable store implementation — those stay on the roadmap. Ownership is immutable: no release/reassign is exposed.

## Verification

- `pnpm typecheck` ✅
- `pnpm test` ✅ — 25 tests (unit + security + Loader integration)
- `pnpm build` ✅
- `pnpm install --frozen-lockfile` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)
