### PR TITLE
docs: engineering foundation (positioning, standards, roadmap)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,54 @@
+# Contributing
+
+## Development model: spec-driven, then test-driven
+
+This repository develops by **spec first, test second, implementation third**.
+
+1. **Spec** — a capability starts as a written spec: a *Seam Map* (surfaces +
+   gaps), a contract sketch, or an *ADR* that records the decision. No
+   implementation until the contract is written down.
+2. **Test** — write the contract test *before* the implementation. A provider's
+   contract test is a **shared suite** that any implementation of that seam must
+   pass.
+3. **Implement** — the smallest thing that satisfies the spec and the test.
+
+Current spec artifacts: `packages/multi-tenant-web/SEAM-MAP.md` (web surfaces)
+and `packages/multi-tenant-web/ADR.md` (hard conclusions + upstream seam
+proposal).
+
+## Package conventions
+
+- One package = one **replaceable capability** (a Cordis service seam). Never a
+  code-size threshold, and never a fragment of a single security invariant.
+- A package ships: its **Service definition** (the contract), its **default
+  provider**, and a `cordis.patch.yml` bundle row that composes it.
+- **Do not scaffold empty packages.** Create a package only when a second real
+  implementation of a seam exists, or when the seam is a distinct security
+  surface of its own.
+- Directory names are short (`multi-tenant`); npm names are the published
+  identity (`dsh-multi-tenant`). They need not match.
+
+## Dependency direction (non-negotiable)
+
+```
+Core ──▶ Contract ◀── Provider
+```
+
+The kernel's contracts have zero transport/vendor dependencies. Providers
+depend on the kernel's contract; the kernel never knows JWT / PostgreSQL /
+HTTP / MCP / Redis. A pull request that adds such a dependency into the kernel
+is rejected.
+
+## Contract tests
+
+Every replaceable seam has a shared contract-test suite. A third-party
+implementation must pass the same suite as the default provider. This is what
+makes "default ≠ only" hold: a replacement is proven by the contract, not by
+fiat.
+
+## Definition of done
+
+- Spec / ADR updated wherever behavior is decided.
+- Contract and unit tests green (`pnpm test`).
+- `pnpm typecheck` and `pnpm build` green.
+- No transport/vendor dependency leaked into the kernel.

--- a/README.md
+++ b/README.md
@@ -1,21 +1,46 @@
 # dsh-multi-tenant
 
-Multi-tenant SaaS extension for DeepSeek Harness (DSH): tenant identity,
-session ownership, authorization boundaries, tenant-aware MCP, and audit.
+Composable multi-tenant / SaaS plugin suite for
+[DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) (DSH).
 
-A pnpm monorepo of [Cordis](https://github.com/cordiverse/cordis) plugins for
-[DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness).
+> **Phase: engineering foundation.** The kernel contract is stable; the suite
+> grows around it one plugin at a time. See [ROADMAP.md](./ROADMAP.md).
 
-> **Status: early development / architecture bootstrap.** The core is a
-> fail-closed ownership + authorization contract; the web integration is still
-> an active seam spike. See each package's README for its own status.
+## What this is
+
+A **plugin family**, not a single plugin. A kernel — `dsh-multi-tenant` — owns
+the tenant/session contract (identity, ownership, fail-closed authorization).
+This repository ships the official default implementations (storage, web
+enforcement, …) as independently publishable [Cordis](https://github.com/cordiverse/cordis)
+plugins, each following DSH's service/bundle logic and each replaceable by a
+third-party implementation that passes the same contract tests.
+
+Maintaining a complete default stack matters because a single party can then
+hold the **end-to-end tenant-isolation invariant** — tenant A can never touch
+tenant B across auth → RPC → session → MCP → downstream — something no single
+plugin's unit test can prove.
+
+## Guiding principles
+
+- **Three layers, native vocabulary** — *Contract* (abstract `Service`) →
+  *Provider* (plugin) → *Composition* (`cordis.patch.yml` bundle). No
+  abstractions beyond what DSH already has.
+- **One-way dependency** — everything depends on the kernel's contracts; the
+  kernel depends on nothing transport- or vendor-specific (no JWT, no
+  PostgreSQL, no HTTP, no MCP, no Redis).
+- **Split by replaceable capability, not size** — and a single security
+  invariant is not split across packages.
+- **Default ≠ only** — the suite ships defaults; third parties may swap any
+  layer, if it passes the same contract test.
+
+See [CONTRIBUTING.md](./CONTRIBUTING.md) for how development is done here.
 
 ## Packages
 
-| Package | Role |
-| --- | --- |
-| [`dsh-multi-tenant`](./packages/multi-tenant) | Core: `ctx.multiTenant` + `ctx.tenantSessionStore`, claim-once ownership, fail-closed authorization. |
-| [`dsh-multi-tenant-web`](./packages/multi-tenant-web) | Web integration: principal binding, unary RPC guard, mux/host filtering, `/api/respond` ownership. (early spike) |
+| Package | npm | Role |
+| --- | --- | --- |
+| [`packages/multi-tenant`](./packages/multi-tenant) | `dsh-multi-tenant` | Kernel: `ctx.multiTenant` + `ctx.tenantSessionStore`, claim-once ownership, fail-closed authorization. |
+| [`packages/multi-tenant-web`](./packages/multi-tenant-web) | `dsh-multi-tenant-web` | Web enforcement: principal binding, RPC/mux/WS guard (early spike). |
 
 ## Development
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,45 @@
+# Roadmap
+
+Statuses: ✅ done · 🚧 next (settled) · ⏳ deferred (decision-gated).
+
+## Done
+
+- ✅ **Kernel core** — `TenantPrincipal` / `SessionOwner`, claim-once ownership,
+  fail-closed authorization, `TenantSessionStore` service seam (in-memory
+  provider). `packages/multi-tenant`.
+- ✅ **Monorepo** — pnpm workspace with `packages/`, shared `tsconfig.base.json`,
+  delegated root scripts, CI.
+- ✅ **Web seam spike** — Seam Map, executable facade prototype (6 security
+  invariants), and ADR in `packages/multi-tenant-web`. Concluded that web
+  enforcement is blocked on an upstream per-connection seam (H3).
+
+## Next (settled)
+
+- 🚧 **H1 — claim-at-create.** Add an atomic ownership-claim seam to session
+  creation so a session is owned *before* it becomes visible to mux/list. This
+  is the one core-contract delta from the ADR. (Kernel, `packages/multi-tenant`.)
+- 🚧 **Contract-test extraction.** Promote the store contract assertions to a
+  shared suite any `TenantSessionStore` implementation must pass — the concrete
+  form of "default ≠ only".
+- 🚧 **H3 — upstream seam proposal.** File the per-connection `ApiProxy` seam
+  proposal against `deepseek-ai/deepseek-harness` (unblocks real web
+  enforcement).
+
+## Deferred (decision-gated)
+
+- ⏳ **H2 — resource model.** Whether Workspace and host-global frames are
+  tenant-owned. Product decision; until then, v0 denies non-session host frames.
+- ⏳ **Auth providers** (JWT / OIDC / API key). Post-H3; `TenantPrincipalResolver`
+  placement still undecided.
+- ⏳ **Durable stores** (PostgreSQL / Redis / MySQL). Create packages only when a
+  real second implementation lands.
+- ⏳ **Public-contract freeze** for `dsh-multi-tenant-web` (name and surface are
+  provisional until H3 resolves).
+- ⏳ Tenant-aware MCP, audit/usage, billing/UI.
+
+## Sequencing
+
+The suite is grown in this order: **stabilize the kernel → establish the
+contract-test pattern → unblock the web seam upstream → then fan out providers.**
+Each deferred item above is pulled forward only when its gate (a decision or an
+upstream seam) closes.


### PR DESCRIPTION
## Summary

Lay the engineering foundation: reposition the repo as a composable plugin suite, encode the development model, and settle the roadmap. No feature code.

## What changed

- **`README.md`** — reposition from "a plugin" to "a plugin family": a kernel (`dsh-multi-tenant`) plus official default implementations, with the four guiding principles (three layers / one-way dependency / split by capability / default ≠ only).
- **`CONTRIBUTING.md`** — the spec-driven + test-driven development model, package conventions ("one package = one replaceable capability", "no empty packages"), the non-negotiable dependency-direction rule, and the contract-test contract for providers.
- **`ROADMAP.md`** — done / next / deferred, sequenced by the ADR's hard conclusions (H1 claim-at-create → contract-test extraction → H3 upstream proposal → then fan out providers).

## Deliberately NOT in this PR

No core contract change (H1), no contract-test extraction, no new packages — those are the settled *next* items in the roadmap, not this round.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
