### PR TITLE
docs: soften over-prescribed boundaries

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,10 +18,15 @@ proposal).
 
 ## Package conventions
 
-- One package = one **replaceable capability** (a Cordis service seam). Never a
-  code-size threshold, and never a fragment of a single security invariant.
-- A package ships: its **Service definition** (the contract), its **default
-  provider**, and a `cordis.patch.yml` bundle row that composes it.
+- One package = one **independently composable / replaceable capability**, or
+  one **indivisible security boundary**. Never a code-size threshold, and never
+  a fragment of a single security invariant.
+- Prefer **native DSH/Cordis seams** (Service, event/waterfall, typed
+  protocol). Do not invent a Service merely to create a package boundary.
+- **Contract and default implementation may co-locate** (especially early). A
+  package may be a *pure provider* or a *pure integration*; extract a separate
+  package only when a provider gains independent install / replace / lifecycle
+  value.
 - **Do not scaffold empty packages.** Create a package only when a second real
   implementation of a seam exists, or when the seam is a distinct security
   surface of its own.
@@ -31,13 +36,16 @@ proposal).
 ## Dependency direction (non-negotiable)
 
 ```
-Core ──▶ Contract ◀── Provider
+Kernel primitives ◀── capability contracts ◀── providers
 ```
 
-The kernel's contracts have zero transport/vendor dependencies. Providers
-depend on the kernel's contract; the kernel never knows JWT / PostgreSQL /
-HTTP / MCP / Redis. A pull request that adds such a dependency into the kernel
-is rejected.
+The kernel owns only the minimal cross-suite tenant primitives (identity,
+ownership, authorization) and has zero transport/vendor dependencies — it never
+knows JWT / PostgreSQL / HTTP / MCP / Redis. Capability packages own their own
+contracts and may depend on the kernel's primitives. Providers depend on the
+package that owns their contract. Sibling capabilities do not reach through one
+another's implementations. A pull request that adds a transport/vendor
+dependency into the kernel is rejected.
 
 ## Contract tests
 

--- a/README.md
+++ b/README.md
@@ -22,12 +22,13 @@ plugin's unit test can prove.
 
 ## Guiding principles
 
-- **Three layers, native vocabulary** — *Contract* (abstract `Service`) →
-  *Provider* (plugin) → *Composition* (`cordis.patch.yml` bundle). No
-  abstractions beyond what DSH already has.
-- **One-way dependency** — everything depends on the kernel's contracts; the
-  kernel depends on nothing transport- or vendor-specific (no JWT, no
-  PostgreSQL, no HTTP, no MCP, no Redis).
+- **Three layers, native vocabulary** — *Contract* (a native DSH/Cordis seam:
+  Service, event, or protocol) → *Provider* (plugin) → *Composition*
+  (`cordis.patch.yml` bundle). No abstractions beyond what DSH already has.
+- **One-way dependency** — the kernel owns only the minimal cross-suite tenant
+  primitives and depends on nothing transport- or vendor-specific (no JWT, no
+  PostgreSQL, no HTTP, no MCP, no Redis); capability packages own their own
+  contracts and may depend on the kernel's primitives.
 - **Split by replaceable capability, not size** — and a single security
   invariant is not split across packages.
 - **Default ≠ only** — the suite ships defaults; third parties may swap any

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -15,15 +15,19 @@ Statuses: ✅ done · 🚧 next (settled) · ⏳ deferred (decision-gated).
 
 ## Next (settled)
 
-- 🚧 **H1 — claim-at-create.** Add an atomic ownership-claim seam to session
-  creation so a session is owned *before* it becomes visible to mux/list. This
-  is the one core-contract delta from the ADR. (Kernel, `packages/multi-tenant`.)
+- 🚧 **H1 — Session Genesis Ownership.** Establish (or inherit, for fork /
+  subagent) ownership *before* a session becomes visible, for every genesis
+  path — create, fork, subagent, resume/attach. Determine whether the required
+  seam belongs upstream in DSH's lifecycle or needs a kernel-contract delta;
+  do not change the kernel until this is proven. (Kernel,
+  `packages/multi-tenant`.)
 - 🚧 **Contract-test extraction.** Promote the store contract assertions to a
   shared suite any `TenantSessionStore` implementation must pass — the concrete
   form of "default ≠ only".
-- 🚧 **H3 — upstream seam proposal.** File the per-connection `ApiProxy` seam
-  proposal against `deepseek-ai/deepseek-harness` (unblocks real web
-  enforcement).
+- 🚧 **H3 — request/connection-scoped principal binding.** State the upstream
+  requirement (principal scoped to request/connection, non-ambient, enforceable
+  across unary / respond / stream lifetime), with a per-connection `ApiProxy`
+  seam as the preferred candidate, against `deepseek-ai/deepseek-harness`.
 
 ## Deferred (decision-gated)
 
@@ -37,9 +41,20 @@ Statuses: ✅ done · 🚧 next (settled) · ⏳ deferred (decision-gated).
   provisional until H3 resolves).
 - ⏳ Tenant-aware MCP, audit/usage, billing/UI.
 
-## Sequencing
+## Milestones
 
-The suite is grown in this order: **stabilize the kernel → establish the
-contract-test pattern → unblock the web seam upstream → then fan out providers.**
-Each deferred item above is pulled forward only when its gate (a decision or an
-upstream seam) closes.
+- **M0 — Engineering foundation** ✅ monorepo, package rules, spec/ADR
+  discipline, CI.
+- **M1 — Kernel hardening** 🚧 extract the shared contract-test harness; pin the
+  current kernel contract with tests; publication/version policy.
+- **M2 — Session genesis spike** create / fork / subagent / resume →
+  ownership-before-visibility; decide whether the seam is upstream or a kernel
+  delta.
+- **M3 — Real web seam spike v2** real `ApiProxy` types, connection lifecycle,
+  `respond`, `mux`/`host` → minimal upstream requirement.
+- **M4 — Web enforcement.**
+- **M5 — Providers** durable stores, auth.
+- **M6 — MCP / audit / full-stack preset.**
+
+Each milestone is gated by its predecessor's decision; deferred items above are
+pulled forward only when their gate (a decision or an upstream seam) closes.


### PR DESCRIPTION
## Summary

Apply the code-review feedback on PR #3: soften three over-prescribed boundaries so the docs don't force unnatural architecture.

## What changed

- **Contract ≠ abstract Service** — restated as a *native DSH/Cordis seam* (Service, event, or protocol); "do not invent a Service merely to create a package boundary."
- **Kernel ≠ all contracts** — the kernel owns only the minimal cross-suite tenant primitives; capability packages own their own contracts; providers depend on the package that owns their contract; siblings don't reach through each other.
- **Package ≠ Service + provider** — contract and default may co-locate (especially early); a package may be a pure provider or pure integration.
- **H1 → "Session Genesis Ownership"** — the *requirement* (ownership-before-visibility across create/fork/subagent/resume) with the solution (upstream vs kernel delta) left unproven.
- **H3 → "request/connection-scoped principal binding"** — the *requirement* first, per-connection `ApiProxy` as preferred candidate.
- **Milestones M0–M6** replace the one-line sequencing; M1 is "stabilize + test-pin", not "freeze" (so a later spike can still amend the kernel under test).

No behavior/code change — docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
