### PR TITLE
docs: final polish — freeze the engineering foundation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,9 +27,10 @@ proposal).
   package may be a *pure provider* or a *pure integration*; extract a separate
   package only when a provider gains independent install / replace / lifecycle
   value.
-- **Do not scaffold empty packages.** Create a package only when a second real
-  implementation of a seam exists, or when the seam is a distinct security
-  surface of its own.
+- **Do not scaffold speculative packages.** Create a package only when an
+  independent composition / replacement / dependency / versioning / lifecycle /
+  security boundary has been *demonstrated* — justified in an ADR, not by a
+  code-size or implementation-count threshold.
 - Directory names are short (`multi-tenant`); npm names are the published
   identity (`dsh-multi-tenant`). They need not match.
 
@@ -47,12 +48,18 @@ package that owns their contract. Sibling capabilities do not reach through one
 another's implementations. A pull request that adds a transport/vendor
 dependency into the kernel is rejected.
 
-## Contract tests
+## Tests: contract vs conformance
 
-Every replaceable seam has a shared contract-test suite. A third-party
-implementation must pass the same suite as the default provider. This is what
-makes "default ≠ only" hold: a replacement is proven by the contract, not by
-fiat.
+Two test kinds prove different things:
+
+- **Contract Test Suite** — for a *provider seam* (e.g. `TenantSessionStore`).
+  Any implementation must pass the same suite as the default provider. This is
+  what makes "default ≠ only" hold: a replacement is proven by the contract,
+  not by fiat.
+- **Conformance / Invariant Suite** — for a *security or integration
+  capability* (e.g. web enforcement). It asserts the tenant-isolation
+  invariants (A cannot list / history / mux / respond B; concurrent principals
+  never cross-talk), which no single provider's unit test can prove.
 
 ## Definition of done
 

--- a/README.md
+++ b/README.md
@@ -3,8 +3,9 @@
 Composable multi-tenant / SaaS plugin suite for
 [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) (DSH).
 
-> **Phase: engineering foundation.** The kernel contract is stable; the suite
-> grows around it one plugin at a time. See [ROADMAP.md](./ROADMAP.md).
+> **Phase: engineering foundation.** The kernel baseline is established and
+> test-pinned; its public contract remains prerelease. The suite grows around it
+> one plugin at a time. See [ROADMAP.md](./ROADMAP.md).
 
 ## What this is
 
@@ -22,9 +23,10 @@ plugin's unit test can prove.
 
 ## Guiding principles
 
-- **Three layers, native vocabulary** — *Contract* (a native DSH/Cordis seam:
+- **Typical capability layering** — *Contract* (a native DSH/Cordis seam:
   Service, event, or protocol) → *Provider* (plugin) → *Composition*
-  (`cordis.patch.yml` bundle). No abstractions beyond what DSH already has.
+  (`cordis.patch.yml` bundle), *where applicable*. Pure integration /
+  security-boundary plugins compose directly against native seams.
 - **One-way dependency** — the kernel owns only the minimal cross-suite tenant
   primitives and depends on nothing transport- or vendor-specific (no JWT, no
   PostgreSQL, no HTTP, no MCP, no Redis); capability packages own their own


### PR DESCRIPTION
## Summary

Final wording pass on the engineering foundation, then freeze it. Four sentence-level fixes from review, nothing more.

## What changed

- **README** — "kernel contract is stable" → "kernel baseline is established and test-pinned; its public contract remains prerelease" (resolves the contradiction with M2's possible kernel delta).
- **README** — "Three layers" → "Typical capability layering … where applicable; pure integration/security-boundary plugins compose directly against native seams."
- **CONTRIBUTING** — package creation gated by a *demonstrated independent boundary* (composition / replacement / dependency / versioning / lifecycle / security), justified in an ADR — not a code-size or implementation-count threshold.
- **CONTRIBUTING** — split tests into **Contract Test Suite** (provider seam) vs **Conformance / Invariant Suite** (security/integration capability).

## Freeze

This is the last change to the README + CONTRIBUTING philosophy layer. Future architecture decisions belong in ADR / Seam Map / capability specs / test suites, not in CONTRIBUTING.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
