### PR TITLE
fix: M1 review follow-ups (real tarball smoke, gate coverage)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -45,8 +45,8 @@ Statuses: ✅ done · 🚧 next (settled) · ⏳ deferred (decision-gated).
 
 - **M0 — Engineering foundation** ✅ monorepo, package rules, spec/ADR
   discipline, CI.
-- **M1 — Kernel hardening** 🚧 extract the shared contract-test harness; pin the
-  current kernel contract with tests; publication/version policy.
+- **M1 — Kernel hardening** ✅ contract-test harness, architecture gate, package
+  smoke, compatibility policy.
 - **M2 — Session genesis spike** create / fork / subagent / resume →
   ownership-before-visibility; decide whether the seam is upstream or a kernel
   delta.

--- a/packages/multi-tenant/src/testing.ts
+++ b/packages/multi-tenant/src/testing.ts
@@ -29,8 +29,8 @@ async function withStore<T>(
   fn: (store: TenantSessionStore) => Promise<T>,
 ): Promise<T> {
   const ctx = new Context()
-  const store = await factory(ctx)
   try {
+    const store = await factory(ctx)
     return await fn(store)
   } finally {
     await ctx.fiber.dispose()
@@ -40,7 +40,7 @@ async function withStore<T>(
 /**
  * Assert that `factory` produces stores satisfying the `TenantSessionStore`
  * contract: atomic claim, idempotent same-owner claim, conflict (never
- * overwrite), `get` semantics, defensive copy, and atomic concurrency.
+ * overwrite), `get` semantics, and atomic concurrency.
  */
 export async function assertTenantSessionStoreContract(factory: TenantSessionStoreFactory): Promise<void> {
   const alice: SessionOwner = { tenantId: 'acme', userId: 'alice' }

--- a/scripts/package-smoke.mjs
+++ b/scripts/package-smoke.mjs
@@ -1,21 +1,36 @@
 #!/usr/bin/env node
 /**
  * Package smoke (M1.3): prove the kernel's published tarball is a valid
- * distributable. Build → pack → verify tarball contents and exports → run the
- * built dist through a minimal claim/access smoke.
+ * distributable for an external consumer. Build → pack → verify tarball
+ * contents and every `exports` target → install the tarball into a clean
+ * temp consumer → import the published subpaths and run a claim/access smoke.
  *
  * Run from the repo root: `node scripts/package-smoke.mjs`.
  */
 import { execFileSync } from 'node:child_process'
-import { mkdtempSync, readFileSync, readdirSync, rmSync } from 'node:fs'
+import { mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 const root = fileURLToPath(new URL('..', import.meta.url))
 const pkgDir = join(root, 'packages', 'multi-tenant')
+const pkg = JSON.parse(readFileSync(join(pkgDir, 'package.json'), 'utf8'))
+
+/** Recursively collect every file-path string leaf under an `exports` map. */
+function collectTargets(exports, acc = []) {
+  if (typeof exports === 'string') {
+    acc.push(exports)
+    return acc
+  }
+  if (exports && typeof exports === 'object') {
+    for (const value of Object.values(exports)) collectTargets(value, acc)
+  }
+  return acc
+}
 
 const tmp = mkdtempSync(join(tmpdir(), 'dsh-mt-pack-'))
+const consumer = mkdtempSync(join(tmpdir(), 'dsh-mt-consumer-'))
 try {
   // 1. fresh build, then pack.
   execFileSync('pnpm', ['--filter', 'dsh-multi-tenant', 'build'], { cwd: root, stdio: 'ignore' })
@@ -26,7 +41,7 @@ try {
   const tarball = readdirSync(tmp).find(f => f.endsWith('.tgz'))
   if (!tarball) throw new Error('pnpm pack produced no tarball')
 
-  // 2. verify the tarball ships the intended files and no exports target is missing.
+  // 2. verify the tarball ships the intended files and every exports target.
   const listing = execFileSync('tar', ['-tzf', join(tmp, tarball)], { encoding: 'utf8' })
   const lines = listing.split('\n')
   const has = f => lines.some(line => line === f || line.endsWith(`/${f}`))
@@ -35,41 +50,31 @@ try {
   const missing = required.filter(f => !has(f))
   if (missing.length) throw new Error(`tarball is missing: ${missing.join(', ')}`)
 
-  const pkg = JSON.parse(readFileSync(join(pkgDir, 'package.json'), 'utf8'))
-  const targets = [
-    pkg.exports?.['.']?.import,
-    pkg.exports?.['.']?.types,
-    pkg.exports?.['./store']?.import,
-    pkg.exports?.['./testing']?.import,
-    pkg.exports?.['./cordis.patch.yml'],
-  ].filter(Boolean)
+  const targets = collectTargets(pkg.exports)
   const unresolved = targets.filter(t => !has(t.replace(/^\.\//, '')))
   if (unresolved.length) throw new Error(`exports targets missing from tarball: ${unresolved.join(', ')}`)
 
-  // 3. run the built dist through a claim/access smoke (resolves `@deepseek-ai/cordis`
-  //    from the package's own node_modules).
-  execFileSync(
-    'node',
-    [
-      '--input-type=module',
-      '--eval',
-      [
-        'const { Context } = await import("@deepseek-ai/cordis");',
-        'const { default: Store } = await import("./dist/store.mjs");',
-        'const { default: Service } = await import("./dist/index.mjs");',
-        'const ctx = new Context();',
-        'await ctx.plugin(Store);',
-        'await ctx.plugin(Service);',
-        'const alice = { tenantId: "acme", userId: "alice", roles: ["member"] };',
-        'await ctx.multiTenant.claimSession("s1", alice);',
-        'if ((await ctx.multiTenant.canAccessSession(alice, "s1")) !== true) throw new Error("dist smoke: same-user should be allowed");',
-        'console.log("dist smoke passed");',
-      ].join('\n'),
-    ],
-    { cwd: pkgDir, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] },
-  )
+  // 3. install the tarball into a clean consumer and exercise the published subpaths.
+  writeFileSync(join(consumer, 'package.json'), JSON.stringify({ name: 'smoke-consumer', private: true, type: 'module' }))
+  execFileSync('pnpm', ['add', join(tmp, tarball), '@deepseek-ai/cordis@4.0.1'], { cwd: consumer, stdio: 'ignore' })
+  writeFileSync(join(consumer, 'smoke.mjs'), [
+    'import { Context } from "@deepseek-ai/cordis";',
+    'import Store from "dsh-multi-tenant/store";',
+    'import Service from "dsh-multi-tenant";',
+    'import { assertTenantSessionStoreContract } from "dsh-multi-tenant/testing";',
+    'const ctx = new Context();',
+    'await ctx.plugin(Store);',
+    'await ctx.plugin(Service);',
+    'const alice = { tenantId: "acme", userId: "alice", roles: ["member"] };',
+    'await ctx.multiTenant.claimSession("s1", alice);',
+    'if ((await ctx.multiTenant.canAccessSession(alice, "s1")) !== true) throw new Error("smoke: same-user should be allowed");',
+    'await assertTenantSessionStoreContract(async (c) => { await c.plugin(Store); return c.tenantSessionStore });',
+    'console.log("consumer smoke passed");',
+  ].join('\n'))
+  execFileSync('node', ['smoke.mjs'], { cwd: consumer, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] })
 
   console.log(`package smoke passed: ${tarball}`)
 } finally {
   rmSync(tmp, { recursive: true, force: true })
+  rmSync(consumer, { recursive: true, force: true })
 }

--- a/scripts/verify-packages.mjs
+++ b/scripts/verify-packages.mjs
@@ -36,7 +36,7 @@ for (const name of readdirSync(packagesDir)) {
   }
 
   if (pkg.name === 'dsh-multi-tenant') {
-    const runtime = { ...(pkg.dependencies ?? {}), ...(pkg.peerDependencies ?? {}) }
+    const runtime = { ...(pkg.dependencies ?? {}), ...(pkg.peerDependencies ?? {}), ...(pkg.optionalDependencies ?? {}) }
     for (const dep of Object.keys(runtime)) {
       if (!KERNEL_RUNTIME_ALLOWLIST.has(dep)) {
         errors.push(`${label}: runtime dependency "${dep}" is not allowed in the kernel`)


### PR DESCRIPTION
## Summary

Follow-up fixes for the merged M1 (PR #6), from code review. No new features.

## What changed

- **Package smoke now tests the real tarball, not local dist** — installs the packed tarball into a clean temp consumer, then imports `dsh-multi-tenant` / `/store` / `/testing` and runs claim/access + the full contract suite.
- **Exports targets are collected recursively** (not hardcoded), so a new subpath can't be silently skipped.
- **Contract suite disposes its Context even when the provider factory throws** (startup-failure path).
- **`verify-packages` covers `optionalDependencies`** in the kernel runtime gate.
- **ROADMAP marks M1 done** (was 🚧, inconsistent with the Done section).

## Verification

- `pnpm typecheck` ✅ · `pnpm test` ✅ · `pnpm verify` ✅ · `pnpm smoke` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)
