### PR TITLE
docs: session genesis map (M2 spike, static)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -35,8 +35,9 @@ Statuses: ✅ done · 🚧 next (settled) · ⏳ deferred (decision-gated).
   tenant-owned. Product decision; until then, v0 denies non-session host frames.
 - ⏳ **Auth providers** (JWT / OIDC / API key). Post-H3; `TenantPrincipalResolver`
   placement still undecided.
-- ⏳ **Durable stores** (PostgreSQL / Redis / MySQL). Create packages only when a
-  real second implementation lands.
+- ⏳ **Durable stores** (PostgreSQL / Redis / MySQL). Create a provider package
+  once an independent composition / replacement / dependency / lifecycle
+  boundary is demonstrated.
 - ⏳ **Public-contract freeze** for `dsh-multi-tenant-web` (name and surface are
   provisional until H3 resolves).
 - ⏳ Tenant-aware MCP, audit/usage, billing/UI.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -15,19 +15,17 @@ Statuses: ✅ done · 🚧 next (settled) · ⏳ deferred (decision-gated).
 - ✅ **Kernel engineering harness** — `TenantSessionStore` contract suite
   (`dsh-multi-tenant/testing`), architecture gate (`pnpm verify`), package
   smoke (`pnpm smoke`), compatibility policy (`docs/compatibility.md`).
+- ✅ **Session Genesis Spike (M2)** — mapped create / fork / subagent / resume
+  against the real `@deepseek-ai/dsh-session` lifecycle (static map + runtime
+  probe). Concluded the ownership-admission seam belongs **upstream** (B), not a
+  kernel-contract delta (`docs/session-genesis-adr.md`).
 
 ## Next (settled)
 
-- 🚧 **H1 — Session Genesis Ownership.** Establish (or inherit, for fork /
-  subagent) ownership *before* a session becomes visible, for every genesis
-  path — create, fork, subagent, resume/attach. Determine whether the required
-  seam belongs upstream in DSH's lifecycle or needs a kernel-contract delta;
-  do not change the kernel until this is proven. (Kernel,
-  `packages/multi-tenant`.)
-- 🚧 **H3 — request/connection-scoped principal binding.** State the upstream
-  requirement (principal scoped to request/connection, non-ambient, enforceable
-  across unary / respond / stream lifetime), with a per-connection `ApiProxy`
-  seam as the preferred candidate, against `deepseek-ai/deepseek-harness`.
+- 🚧 **Upstream seam proposal** — one proposal combining the session-genesis
+  admission seam (async, before `enter`, identity-carrying for
+  create/fork/subagent/resume) with a request/connection-scoped principal,
+  against `deepseek-ai/deepseek-harness` (resolves H1 + H3 as a single seam).
 
 ## Deferred (decision-gated)
 
@@ -48,9 +46,8 @@ Statuses: ✅ done · 🚧 next (settled) · ⏳ deferred (decision-gated).
   discipline, CI.
 - **M1 — Kernel hardening** ✅ contract-test harness, architecture gate, package
   smoke, compatibility policy.
-- **M2 — Session genesis spike** create / fork / subagent / resume →
-  ownership-before-visibility; decide whether the seam is upstream or a kernel
-  delta.
+- **M2 — Session genesis spike** ✅ map + runtime probe + ADR → the seam is
+  upstream (B), not a kernel delta.
 - **M3 — Real web seam spike v2** real `ApiProxy` types, connection lifecycle,
   `respond`, `mux`/`host` → minimal upstream requirement.
 - **M4 — Web enforcement.**

--- a/docs/session-genesis-adr.md
+++ b/docs/session-genesis-adr.md
@@ -1,0 +1,68 @@
+# ADR — Session Genesis Ownership
+
+> Status: **spike conclusion (proposed)**. Based on the static
+> `session-genesis-map.md` plus a runtime probe against
+> `@deepseek-ai/dsh-session@0.1.0-rc.6` (probe output below).
+
+## Confirmed findings
+
+The runtime probe confirmed the static map:
+
+```json
+{ "F1": {"visibleAtCreated": true},
+  "F2_sync": {"threw": true, "sessionCount": 0},
+  "F2_async": {"threw": false, "sessionCount": 1} }
+```
+
+- **F1** — when `session/created` fires, the session is **already** in the store
+  (`get`-visible). It is not a before-visibility admission point.
+- **F2** — a **synchronous** `session/created` throw vetoes publication (store
+  entry rolled back); an **async** listener's rejection is logged, not vetoed.
+  Ownership claim is async, so it cannot ride this veto.
+- **F3** — the principal is dropped at the RPC boundary
+  (`(endpoint, payload, signal)`); no genesis path carries it.
+- **F4** — fork / subagent carry `meta.parentSession`; ownership is inheritance.
+- **F5** — resume restores from persistence; ownership is restoration, not claim.
+
+## Decision
+
+### A — existing seam sufficient → **ruled out**
+
+`session/created` fires after store entry (F1), cannot veto async claims (F2),
+and has no principal (F3). There is no existing before-visibility,
+async-compatible, identity-carrying admission point.
+
+### B — DSH needs a minimal session-genesis admission seam → **required**
+
+Propose an upstream seam, awaited between `prepare` and `enter`, that carries
+the identity to claim with:
+
+| Path | Identity carried |
+| --- | --- |
+| create | the authenticated `TenantPrincipal` |
+| fork / subagent | the parent `sessionId` (owner inherits) |
+| resume | the `sessionId` (owner restored, not re-claimed) |
+
+This is **the same transport seam H3 needs** — a request/connection-scoped
+principal at genesis. H1 and H3 are one upstream problem, not two.
+
+### C — core contract change → **not required, minor optional**
+
+The existing `claimSession` + `getSessionOwner` already express inheritance
+(lookup parent owner → claim child) and restoration (durable store read, no
+re-claim). A small convenience — accept a `SessionOwner` directly, or add
+`claimInherited(childId, parentId)` — removes the awkwardness of reconstructing
+a fake `TenantPrincipal`, but is not a blocker.
+
+## Consequence for the kernel
+
+No kernel change now. The kernel's `claim-once` + fail-closed semantics survive
+this spike intact. The unblock is upstream (B) + a durable `TenantSessionStore`
+(M5) for cross-restart restoration — not a contract delta.
+
+## Next
+
+- Upstream proposal: a session-genesis admission seam (async, before `enter`,
+  identity-carrying) — combined with the H3 request-scoped-principal seam.
+- M3 (web seam) proceeds against this same upstream seam rather than opening a
+  separate design surface.

--- a/docs/session-genesis-map.md
+++ b/docs/session-genesis-map.md
@@ -1,0 +1,103 @@
+# Session Genesis Map
+
+> Static analysis of DSH's session lifecycle. Based on
+> `deepseek-ai/deepseek-harness` @ `47f943859bef60e4160492346772ded9b24f765a`.
+> This is the **static** half of the M2 spike; a runtime probe confirms it next.
+
+## 1. The publication transaction (`prepare → enter → announce`)
+
+The session store (`packages/core/session/src/index.ts`, `SessionStore extends
+Service`) splits creation into three **public** primitives, folded into one
+synchronous `ctx.effect`:
+
+```
+prepare(id?, options)        # construct Session (mint or validate id, freeze header). NOT in store.
+        │
+enter(session)               # store.set(id, entry) + install publication hooks. RETURNS detach disposer.
+        │                    #   → `ctx.sessions.get`/`.list`/`history` now see it.
+announce(session)            # emit `session/created` (synchronous dispatch).
+        │                    #   → mux `session/subscribed`, `host/session-added` broadcast from listeners.
+        ▼
+visible (list + mux + host)
+```
+
+Key facts from the source:
+
+- `enter` and `announce` run **back-to-back synchronously** inside the effect,
+  so the intermediate state ("in store but not announced") is **not observable**
+  by any async observer — there is no cross-tick window.
+- `announce` dispatches `session/created` **synchronously**. A synchronous
+  listener that **throws** vetoes publication: the effect-yielded detach rolls
+  back `enter`. An **async** listener's rejection is only logged — **too late to
+  veto** (`announce` body: "rejection is too late to roll back").
+- `create()` is a convenience wrapper (`prepare` → effect(`enter` → `announce`)).
+
+## 2. Genesis paths
+
+| Path | Entry (RPC) | Owner source | Goes through | First visible | Rollback |
+| --- | --- | --- | --- | --- | --- |
+| **create** | `session.create` | the caller principal — **not carried** | `ensureSession` → `ctx.agents.create({sessionId, meta})` → `prepare/enter/announce` | `enter` → `list`/`get`; `announce` → `mux`/`host` | sync `session/created` throw rolls back `enter` |
+| **fork** | `session.fork` | **inherit parent** | `ctx.agents.create({sessionId: childId, meta: {parentSession: source.id, seedLength}})` | same as create | same |
+| **subagent** | `subagent.*` (spawn) | **inherit parent** | `ctx.agents.create({origin:'subagent', parentSession, …})` via `ctx.subagents` | same as create | same |
+| **resume** | `session.create` (preallocated id) / `history` / `prompt` | **restore persisted** | `persistence.list().find(id)` → `ctx.agents.resume({resumeSessionId})` | `enter`/`announce` on the restored session | same |
+
+Details:
+
+- **create** (`packages/host/apiproxy/src/api-proxy.ts` `ensureSession`, ~L1618):
+  dedups via a `sessionCreations` map, checks `ctx.sessions.get` / `ctx.agents.get`
+  for an already-live session, then `ctx.agents.create(...)`.
+- **fork** (~L2363): `ctx.agents.create({sessionId: childId, seed: events.slice(0,cut),
+  meta: {parentSession: source.id, …}})` — the child's owner must be the parent's.
+- **resume** (~L1640): when the client preallocated an id that exists in
+  `sessionPersistence`, it `inspect`s + `ctx.agents.resume(...)` — ownership must
+  be **restored**, not re-claimed.
+
+## 3. Ownership hook candidates
+
+| Candidate | Sync veto? | Before store entry? | Principal available? | Verdict |
+| --- | --- | --- | --- | --- |
+| `session/created` listener | ✅ (throw) | ❌ fires **after** `enter` | ❌ | natural event, but claim is async (no veto) and no principal |
+| `prepare`/`enter`/`announce` primitives | ✅ (own the transaction) | ✅ (between `prepare` and `enter`) | ❌ (caller supplies it) | invasive: re-implement the agent factory's transaction |
+| wrap `ctx.agents` / `ctx.sessions` | ✅ (interpose) | ✅ | ❌ (RPC handler already dropped it) | same principal-loss problem |
+| new DSH lifecycle seam | TBD | TBD | TBD | does not exist today |
+
+## 4. Key findings
+
+- **F1 — no observable window, but no hook either.** `enter`→`announce` are
+  synchronous, so `list`/`mux`/`host` can't observe a half-created session. But
+  there is no seam to establish ownership *before* `enter`.
+- **F2 — `session/created` is sync-veto-only.** Ownership claim is **async**
+  (`TenantSessionStore.claim` returns a Promise, for durable stores). An async
+  `session/created` listener cannot veto — its rejection is logged. So the event
+  cannot itself be the ownership-admission point.
+- **F3 — H1 and H3 are coupled.** The principal is dropped at the RPC boundary
+  (`ConnectionRpcHandler = (endpoint, payload, signal)`). Even with a
+  before-visibility hook, there is no principal to claim with. Session genesis
+  cannot be solved independently of principal propagation.
+- **F4 — fork/subagent are inheritance, not fresh claim.** They carry
+  `meta.parentSession`. Ownership must be *derived from the parent*, which a
+  `claimSession(principal)` call does not express — it would need a
+  `claimChild(parentSessionId, childSessionId)` or equivalent.
+- **F5 — resume is restoration, not claim.** A resumed session's ownership must
+  be restored from persisted state; the current `claimSession` (claim-once,
+  conflict on existing) would treat a legitimate resume as a conflict.
+
+## 5. Invariant assessment (static)
+
+| Invariant | Static status |
+| --- | --- |
+| 1. No ownership window | ⚠️ no observable window (synchronous), but no hook to claim *before* `enter` |
+| 2. Child inheritance explicit | ⚠️ `parentSession` meta exists, but no seam to perform the inheritance |
+| 3. No ghost ownership on failure | ⚠️ sync `session/created` throw rolls back `enter` — but claim is async, so it can't ride that rollback |
+| 4. Resume doesn't steal | ❌ `claimSession` would conflict on a legitimate resume; needs a restore path |
+| 5. Concurrent genesis unique | ✅ `sessionCreations` dedup map + `enter` collision check give one winner |
+
+## 6. Preliminary lean (static only)
+
+The `session/created` event + the `prepare/enter/announce` primitives are the
+only existing seams, and **neither can carry a before-visibility, async,
+principal-carrying ownership admission**. Two coupled gaps block a clean
+conclusion-A: (a) no principal at genesis (H3), and (b) no admission hook that
+fits the async claim (H1). The next step is the **runtime probe** — confirm on a
+real DSH runtime that (1) a synchronous `session/created` listener fires after
+`enter`, and (2) an async claim cannot veto — before committing the ADR to A/B/C.

--- a/scripts/session-genesis-probe.mjs
+++ b/scripts/session-genesis-probe.mjs
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+/**
+ * Session genesis runtime probe (M2): confirm the static Genesis Map findings
+ * against a real `@deepseek-ai/dsh-session` runtime.
+ *
+ *   F1  — `session/created` fires AFTER the session is already in the store
+ *         (get-visible), so it is not a before-visibility admission point.
+ *   F2  — a synchronous `session/created` throw vetoes publication (rolls the
+ *         store entry back); an async listener's rejection is logged, not
+ *         vetoed.
+ *
+ * Run from the repo root: `node scripts/session-genesis-probe.mjs`.
+ * Installs the pinned prerelease into a throwaway temp dir (not the workspace).
+ */
+import { execFileSync } from 'node:child_process'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+const tmp = mkdtempSync(join(tmpdir(), 'dsh-mt-genesis-'))
+try {
+  writeFileSync(join(tmp, 'package.json'), JSON.stringify({ name: 'genesis-probe', private: true, type: 'module' }))
+  execFileSync('pnpm', ['add', '@deepseek-ai/dsh-session@0.1.0-rc.6', '@deepseek-ai/cordis@4.0.1'], {
+    cwd: tmp,
+    stdio: 'ignore',
+  })
+  writeFileSync(join(tmp, 'probe.mjs'), [
+    'import { Context } from "@deepseek-ai/cordis";',
+    'import SessionStore from "@deepseek-ai/dsh-session";',
+    '',
+    'const results = {};',
+    '',
+    '// F1: is the session already get-visible when `session/created` fires?',
+    '{',
+    '  const ctx = new Context();',
+    '  await ctx.plugin(SessionStore);',
+    '  let visibleAtCreated = null;',
+    '  ctx.on("session/created", (session) => { visibleAtCreated = ctx.sessions.get(session.id) !== undefined; });',
+    '  const session = ctx.sessions.create();',
+    '  results.F1 = { visibleAtCreated, idExistsAfter: ctx.sessions.get(session.id) !== undefined };',
+    '}',
+    '',
+    '// F2a: a synchronous throw vetoes publication.',
+    '{',
+    '  const ctx = new Context();',
+    '  await ctx.plugin(SessionStore);',
+    '  ctx.on("session/created", () => { throw new Error("sync veto"); });',
+    '  let threw = false;',
+    '  try { ctx.sessions.create(); } catch { threw = true; }',
+    '  results.F2_sync = { threw, sessionCount: ctx.sessions.list().length };',
+    '}',
+    '',
+    '// F2b: an async rejection is logged, not vetoed.',
+    '{',
+    '  const ctx = new Context();',
+    '  await ctx.plugin(SessionStore);',
+    '  ctx.on("session/created", async () => { throw new Error("async veto"); });',
+    '  let threw = false;',
+    '  try { ctx.sessions.create(); } catch { threw = true; }',
+    '  await new Promise(r => setTimeout(r, 20));',
+    '  results.F2_async = { threw, sessionCount: ctx.sessions.list().length };',
+    '}',
+    '',
+    'console.log(JSON.stringify(results));',
+  ].join('\n'))
+  const out = execFileSync('node', ['probe.mjs'], { cwd: tmp, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] })
+  console.log(out.trim())
+} finally {
+  rmSync(tmp, { recursive: true, force: true })
+}


### PR DESCRIPTION
## Summary

M2 Session Genesis Spike — **static** half. Maps DSH's session lifecycle and finds whether a clean before-visibility ownership hook exists.

## What this adds

`docs/session-genesis-map.md` — the publication transaction (`prepare → enter → announce`), the four genesis paths (create / fork / subagent / resume), ownership-hook candidates, five invariant assessments, and a preliminary lean.

## Key findings

- **F1** — `enter` (store/list visibility) → `announce` (`mux`/`host`) run back-to-back synchronously, so there is **no observable cross-tick window** — but also no seam to claim *before* `enter`.
- **F2** — `session/created` is **sync-veto-only** (a throwing sync listener rolls back `enter`; an async listener's rejection is only logged). Ownership claim is **async** (durable-store seam), so it cannot ride that veto.
- **F3** — **H1 and H3 are coupled**: the principal is dropped at the RPC boundary, so even a before-visibility hook has no principal to claim with.
- **F4** — fork/subagent carry `meta.parentSession` → ownership must be *inherited*, which `claimSession` can't express.
- **F5** — resume is *restoration*, which claim-once `claimSession` would reject as a conflict.

Also fixes the stale ROADMAP "second implementation" wording → "demonstrated independent boundary".

## Next

Runtime probe against real `@deepseek-ai/dsh-session` to confirm F1/F2 before the ADR converges on A/B/C.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
