### PR TITLE
feat: M3 closeout — six-layer architecture + admission-decorator runtime proof

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -11,18 +11,38 @@ Statuses: ✅ done · 🚧 next (settled) · ⏳ deferred (decision-gated).
   provider). `packages/multi-tenant`.
 - ✅ **Monorepo** — pnpm workspace with `packages/`, shared `tsconfig.base.json`,
   delegated root scripts, CI.
-- ✅ **Web seam spike** — Seam Map, executable facade prototype (6 security
-  invariants), and ADR in `packages/multi-tenant-web`. Concluded that web
-  enforcement is blocked on an upstream per-connection seam (H3).
+- ✅ **Web seam spike (M2)** — Seam Map, executable facade prototype (6 security
+  invariants), and the converged web ADR. Concluded that web enforcement is
+  blocked on an upstream per-connection seam (H3).
 - ✅ **Kernel engineering harness** — `TenantSessionStore` contract suite
   (`dsh-multi-tenant/testing`), architecture gate (`pnpm verify`), package
   smoke (`pnpm smoke`), compatibility policy (`docs/reference/compatibility.md`).
+- ✅ **Architecture convergence (M3)** — six-layer architecture
+  (`docs/specs/architecture.md`), the Agent `setup` hook confirmed as the
+  admission point, and "H3-only" established as a **hypothesis**: enforcement is
+  *statically* solvable via a `ctx.agents` decorator + `ApiProxy` facade. The
+  **runtime proof is deferred to M4** — the static conclusions are not yet
+  demonstrated against the real DSH runtime.
 
 ## Next (settled)
 
-- 🚧 **H3 upstream proposal** — file the request/connection-scoped principal
-  seam against `deepseek-ai/deepseek-harness` (the one remaining upstream gap),
-  then build the enforcement (`ctx.agents` decorator + `ApiProxy` facade).
+- 🚧 **M4 — Real integration proof.** Demonstrate the M3 claims against the real
+  DSH runtime *before* filing the upstream proposal:
+  1. **Admission decorator** ✅ — wrap the real `AgentService`; assert the
+     admission runs inside `setup`, before `sessions.enter`, for
+     create / fork / subagent / resume. Proven by
+     `scripts/admission-decorator-probe.mjs` (`docs/specs/admission-composition.md`
+     §5): a decorator joins every `setup` and the admission runs before
+     visibility on all four paths — no new admission seam needed.
+  2. **Real `ApiProxy` facade** — drop the spike `ApiSurface`; classify the real
+     `@deepseek-ai/dsh-host-apiproxy` surface exhaustively (ALLOW / GUARD /
+     FILTER / DENY) so a new DSH method fails to compile, not silently passes.
+  3. **Real transport prototype** — HTTP / WS / respond / mux / host against the
+     real runtime (still `X-Test-Tenant` / `X-Test-User`), locking the six
+     tenant-isolation invariants.
+- 🚧 **M5 — Upstream proposal + web enforcement.** File the request/connection-
+  scoped principal seam (plus any other seam M4 surfaces), then build the
+  enforcement on top of it.
 
 ## Deferred (decision-gated)
 
@@ -44,13 +64,18 @@ Statuses: ✅ done · 🚧 next (settled) · ⏳ deferred (decision-gated).
 - **M1 — Kernel hardening** ✅ contract-test harness, architecture gate, package
   smoke, compatibility policy.
 - **M2 — Session genesis spike** ✅ `setup` hook confirmed as the admission
-  point; H3-only upstream proposal (fork / subagent / resume solvable today).
-- **M3 — Real web seam spike v2** ✅ converged: H3-only upstream seam
-  (request-scoped principal); enforcement solvable via `ctx.agents` decorator +
-  `ApiProxy` facade.
-- **M4 — Web enforcement.**
-- **M5 — Providers** durable stores, auth.
-- **M6 — MCP / audit / full-stack preset.**
+  point; fork / subagent / resume solvable today.
+- **M3 — Architecture convergence** ✅ *static only*: six-layer architecture,
+  H3-only as a hypothesis; enforcement statically solvable via `ctx.agents`
+  decorator + `ApiProxy` facade.
+- **M4 — Real integration proof** 🚧 admission decorator, real `ApiProxy`
+  facade + exhaustive classification, real HTTP/WS transport prototype.
+- **M5 — Upstream proposal + web enforcement.**
+- **M6 — Providers** durable stores, auth.
+- **M7 — MCP / audit / full-stack preset.**
+- **M8 — End-to-end tenant-isolation suite** — the executable "crown" that proves
+  Tenant A can never touch Tenant B across auth → HTTP/WS → ApiProxy → session →
+  agent → MCP → storage.
 
 Each milestone is gated by its predecessor's decision; deferred items above are
 pulled forward only when their gate (a decision or an upstream seam) closes.

--- a/ROADMAP.zh-CN.md
+++ b/ROADMAP.zh-CN.md
@@ -8,12 +8,17 @@
 
 - ✅ **内核核心** —— `TenantPrincipal` / `SessionOwner`、一次性认领所有权、默认拒绝式授权、`TenantSessionStore` service seam（内存提供方）。`packages/multi-tenant`。
 - ✅ **Monorepo** —— pnpm 工作区含 `packages/`、共享 `tsconfig.base.json`、委托式根脚本、CI。
-- ✅ **Web seam spike** —— Seam Map、可执行 facade 原型（6 条安全不变量）、以及 `packages/multi-tenant-web` 中的 ADR。结论：web 强制被一个上游 per-connection seam（H3）所阻塞。
+- ✅ **Web seam spike（M2）** —— Seam Map、可执行 facade 原型（6 条安全不变量）、以及收敛后的 web ADR。结论：web 强制被一个上游 per-connection seam（H3）所阻塞。
 - ✅ **内核工程脚手架** —— `TenantSessionStore` 契约套件（`dsh-multi-tenant/testing`）、架构门（`pnpm verify`）、包冒烟（`pnpm smoke`）、兼容性政策（`docs/reference/compatibility.md`）。
+- ✅ **架构收敛（M3）** —— 六层架构（`docs/specs/architecture.md`）、Agent `setup` 钩子被确认为准入点，并把「H3-only」确立为**假设**：强制通过 `ctx.agents` 装饰器 + `ApiProxy` facade 是*静态*可解的。**运行时证明被推迟到 M4** —— 静态结论尚未在真实 DSH runtime 上得到演示。
 
 ## 下一步（已确定）
 
-- 🚧 **H3 上游提案** —— 针对 `deepseek-ai/deepseek-harness` 提交 request/connection-scoped principal seam（唯一剩余的上游缺口），然后构建强制（`ctx.agents` 装饰器 + `ApiProxy` facade）。
+- 🚧 **M4 — 真实集成证明。** 在提交上游提案*之前*，用真实 DSH runtime 演示 M3 的结论：
+  1. **准入装饰器** ✅ —— 包装真实的 `AgentService`；断言准入在 `setup` 内、先于 `sessions.enter` 执行，覆盖 create / fork / subagent / resume。已由 `scripts/admission-decorator-probe.mjs`（`docs/specs/admission-composition.md` §5）证明：装饰器能加入每一次 `setup`，且准入在四条路径上都先于可见 —— 无需新的准入 seam。
+  2. **真实 `ApiProxy` facade** —— 删掉 spike 的 `ApiSurface`；对真实 `@deepseek-ai/dsh-host-apiproxy` surface 做穷举分类（ALLOW / GUARD / FILTER / DENY），使新增的 DSH 方法**编译失败**，而非默默通过。
+  3. **真实 transport 原型** —— 对真实 runtime 跑 HTTP / WS / respond / mux / host（仍用 `X-Test-Tenant` / `X-Test-User`），锁死六条租户隔离不变量。
+- 🚧 **M5 — 上游提案 + Web 强制。** 提交 request/connection-scoped principal seam（以及 M4 暴露的任何其他 seam），然后在其上构建强制。
 
 ## 延后（由决策门控）
 
@@ -27,10 +32,12 @@
 
 - **M0 — 工程地基** ✅ monorepo、包规则、规格/ADR 纪律、CI。
 - **M1 — 内核加固** ✅ 契约测试脚手架、架构门、包冒烟、兼容性政策。
-- **M2 — 会话创生 spike** ✅ 确认 `setup` 钩子为准入点；H3-only 上游提案（fork / subagent / resume 今天即可解决）。
-- **M3 — 真实 web seam spike v2** ✅ 收敛：H3-only 上游 seam（request-scoped principal）；强制可通过 `ctx.agents` 装饰器 + `ApiProxy` facade 解决。
-- **M4 — Web 强制。**
-- **M5 — 提供方** 持久存储、认证。
-- **M6 — MCP / audit / 全栈 preset。**
+- **M2 — 会话创生 spike** ✅ 确认 `setup` 钩子为准入点；fork / subagent / resume 今天即可解决。
+- **M3 — 架构收敛** ✅ *仅静态*：六层架构、H3-only 作为假设；强制通过 `ctx.agents` 装饰器 + `ApiProxy` facade 静态可解。
+- **M4 — 真实集成证明** 🚧 准入装饰器、真实 `ApiProxy` facade + 穷举分类、真实 HTTP/WS transport 原型。
+- **M5 — 上游提案 + Web 强制。**
+- **M6 — 提供方** 持久存储、认证。
+- **M7 — MCP / audit / 全栈 preset。**
+- **M8 — 端到端租户隔离套件** —— 可执行的「皇冠」：证明租户 A 跨 auth → HTTP/WS → ApiProxy → session → agent → MCP → storage 绝不触及租户 B。
 
 每个里程碑由其前驱的决策门控；上表延后项仅当其门（一个决策或一个上游 seam）闭合时才会被提前。

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,6 +17,7 @@ Navigation hub for `dsh-multi-tenant` documentation.
 
 ## Specs & analysis
 
+- [Architecture — six layers](./specs/architecture.md) — the global six-layer map
 - [Session genesis map](./specs/session-genesis-map.md) — the `prepare → setup → enter → announce` lifecycle
 - [Admission composition](./specs/admission-composition.md) — how a plugin joins every Agent `setup` (M3.0)
 - [Web seam map](./specs/web-seam-map.md) — the five authorization surfaces

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -17,6 +17,7 @@
 
 ## 规格与分析
 
+- [架构 —— 六层](./specs/architecture.zh-CN.md) — 全局六层图
 - [会话创生图](./specs/session-genesis-map.zh-CN.md) — `prepare → setup → enter → announce` 生命周期
 - [准入组合](./specs/admission-composition.zh-CN.md) — 插件如何加入每一次 Agent `setup`（M3.0）
 - [Web seam 图](./specs/web-seam-map.zh-CN.md) — 五个授权 surface

--- a/docs/specs/admission-composition.md
+++ b/docs/specs/admission-composition.md
@@ -5,7 +5,7 @@
 > Static proof of how a third-party Cordis plugin can reliably join every Agent
 > `setup`. Source read at `deepseek-ai/deepseek-harness` @
 > `47f943859bef60e4160492346772ded9b24f765a`. Runtime proof of the chosen
-> candidate is M3.1's first step.
+> candidate landed in M4 (②-A) — see §5 and `scripts/admission-decorator-probe.mjs`.
 
 ## 1. The composition mechanism
 
@@ -84,8 +84,33 @@ This matches the M2 ADR: **only top-level create needs H3**.
   *unfailing* and carries the identity via `options`; **A** is user-config, **B**
   does not exist.
 - **D** (an upstream global setup-contribution middleware) is the cleaner
-  alternative if wrapping `ctx.agents` proves too invasive in M3.1.
+  alternative if wrapping `ctx.agents` proves too invasive in M3.1. **M4 (②-A)
+  shows it is not required** — C holds at runtime.
 
-M3.1's first step is the runtime proof of **C** — wrap `ctx.agents`, assert the
-admission runs inside `setup` before `sessions.enter`, for the three
-identity-bearing paths.
+## 5. Runtime proof (M4 · ②-A)
+
+`scripts/admission-decorator-probe.mjs` wraps the **real** `AgentRegistry`
+(`ctx.agents`, `@deepseek-ai/dsh-agent`) and runs admission against the **real**
+`AgentLoop` (`@deepseek-ai/dsh-agent-loop@0.1.0-rc.6`) + `SessionStore`
+(`@deepseek-ai/dsh-session@0.1.0-rc.6`). The `llm` / `tools` / `systemPrompt`
+services are structurally injected but not exercised by the create → setup →
+enter path, so they are no-op stubs; `sessionPersistence` is a minimal stub for
+the resume path.
+
+Result — for all four genesis paths the admission ran inside `setup`, and the
+session was **not yet in the store** at admission time (i.e. before
+`sessions.enter`), then was present after create/resume resolved:
+
+| Path | Identity available in `options` | Admission before `sessions.enter` |
+| --- | --- | --- |
+| create | `sessionId` | ✅ |
+| fork | `meta.parentSession` | ✅ |
+| subagent | `meta.origin === 'subagent'` + `meta.parentSession` | ✅ |
+| resume | `resumeSessionId` | ✅ |
+
+This proves **C is composable** (a plugin can wrap `ctx.agents` and prepend to
+`setup`) and that the admission point is **before visibility** for every path.
+What it does *not* yet prove (②-C) is that a plugin installs the wrap
+*unfailingly before the host's own `create` calls* in a live deployment — that is
+the transport prototype's job. The upstream gap therefore remains **H3 only**
+(identity for top-level `create`), not a new admission seam.

--- a/docs/specs/admission-composition.zh-CN.md
+++ b/docs/specs/admission-composition.zh-CN.md
@@ -2,7 +2,7 @@
 
 # M3.0 — Agent Setup 准入组合
 
-> 关于第三方 Cordis 插件如何可靠地加入每一次 Agent `setup` 的静态证明。源码阅读于 `deepseek-ai/deepseek-harness` @ `47f943859bef60e4160492346772ded9b24f765a`。所选候选的运行时证明是 M3.1 的第一步。
+> 关于第三方 Cordis 插件如何可靠地加入每一次 Agent `setup` 的静态证明。源码阅读于 `deepseek-ai/deepseek-harness` @ `47f943859bef60e4160492346772ded9b24f765a`。所选候选的运行时证明已在 M4（②-A）完成 —— 见 §5 与 `scripts/admission-decorator-probe.mjs`。
 
 ## 1. 组合机制
 
@@ -70,6 +70,19 @@ create(options) {
 
 - setup 是一个组合窗口，但**不是一个公开 seam**：`composeAgent` 是一个私有闭包，其函数体固定为 `installSelection` + `mountPreset`。
 - **C**（`ctx.agents` 装饰器）是唯一*无条件*且通过 `options` 携带身份的插件侧机制；**A** 是用户配置，**B** 不存在。
-- **D**（上游全局 setup 贡献中间件）是若 M3.1 中包装 `ctx.agents` 被证明过于侵入时更干净的备选。
+- **D**（上游全局 setup 贡献中间件）是若 M3.1 中包装 `ctx.agents` 被证明过于侵入时更干净的备选。**M4（②-A）表明它并非必需** —— C 在运行时成立。
 
-M3.1 的第一步是对 **C** 的运行时证明 —— 包装 `ctx.agents`，断言准入在 `sessions.enter` 之前于 `setup` 内运行，覆盖三条携带身份的路径。
+## 5. 运行时证明（M4 · ②-A）
+
+`scripts/admission-decorator-probe.mjs` 包装**真实**的 `AgentRegistry`（`ctx.agents`、`@deepseek-ai/dsh-agent`），并针对**真实**的 `AgentLoop`（`@deepseek-ai/dsh-agent-loop@0.1.0-rc.6`）+ `SessionStore`（`@deepseek-ai/dsh-session@0.1.0-rc.6`）运行准入。`llm` / `tools` / `systemPrompt` 服务在结构上被注入，但 create → setup → enter 路径并不会触及它们，因此用空操作 stub；`sessionPersistence` 是 resume 路径的最小 stub。
+
+结果 —— 四条创生路径的准入都在 `setup` 内运行，且在准入时刻会话**尚未入 store**（即在 `sessions.enter` 之前），随后在 create/resume 完成时已存在：
+
+| 路径 | `options` 中可得的身份 | 准入先于 `sessions.enter` |
+| --- | --- | --- |
+| create | `sessionId` | ✅ |
+| fork | `meta.parentSession` | ✅ |
+| subagent | `meta.origin === 'subagent'` + `meta.parentSession` | ✅ |
+| resume | `resumeSessionId` | ✅ |
+
+这证明 **C 是可组合的**（插件可以包装 `ctx.agents` 并在 `setup` 前追加准入），且准入点在每条路径上都是**可见之前**的。它尚未证明的（②-C）是：在真实部署中插件能否*在宿主的 `create` 调用之前无条件地安装*该包装 —— 那是 transport 原型的职责。因此上游缺口仍是**仅 H3**（顶层 `create` 的身份），而非新的准入 seam。

--- a/docs/specs/architecture.md
+++ b/docs/specs/architecture.md
@@ -1,0 +1,119 @@
+[简体中文](./architecture.zh-CN.md) | English
+
+# Architecture — six layers
+
+The project is **one composable plugin family**, organized into six layers. The
+kernel owns only the cross-suite tenant primitives; every layer above it is a
+replaceable capability, and every layer below the kernel is a swappable
+provider. This document is the global map the individual ADRs and Seam Maps are
+anchored to.
+
+## The six layers
+
+| # | Layer | Artifact | Responsibility | Status |
+| --- | --- | --- | --- | --- |
+| ① | **Kernel** | `dsh-multi-tenant` | `TenantPrincipal` / `SessionOwner`, claim-once ownership, fail-closed authorization, the `TenantSessionStore` contract. | ✅ test-pinned, prerelease contract |
+| ② | **Ownership provider** | `TenantSessionStore` impls | Persist ownership (memory / PostgreSQL / Redis / MySQL / third-party). Proven by the shared contract suite. | ✅ seam + in-memory default; durable providers deferred |
+| ③ | **Genesis admission** | `ctx.agents` decorator | Join every Agent `setup`; establish / inherit / restore ownership before `sessions.enter`. | 🚧 statically designed, runtime proof is M4 |
+| ④ | **Identity plane** | transport + auth provider | Turn an authenticated HTTP/WS request into a request/connection-scoped `TenantPrincipal`. **H3 lives here.** | ⏳ the one upstream gap |
+| ⑤ | **Enforcement plane** | `dsh-multi-tenant-web` | A tenant-bound `ApiProxy`: point guard, collection projection, respond guard, mux filter, host filter/deny. | 🚧 facade prototype only |
+| ⑥ | **Distribution / preset** | the official SaaS stack | Compose core + store + web + auth + MCP + audit, each piece replaceable. | ⏳ |
+
+## Diagram
+
+```mermaid
+flowchart TD
+    subgraph L4["④ Identity Plane"]
+        direction TB
+        HTTP["HTTP / WebSocket"] --> AUTH["Auth Provider<br/>(JWT / OIDC / API key)"]
+        AUTH --> PRINCIPAL["Request / connection-scoped<br/>TenantPrincipal"]
+    end
+
+    PRINCIPAL -->|"create / fork / subagent / resume"| GENESIS
+    PRINCIPAL -->|"guard / filter"| ENFORCE
+
+    subgraph L3["③ Genesis Admission"]
+        GENESIS["AgentSetup hook<br/>establish / inherit / restore"]
+    end
+
+    subgraph L5["⑤ Enforcement Plane"]
+        ENFORCE["tenant-bound ApiProxy<br/>guard / filter / respond / deny"]
+    end
+
+    GENESIS --> KERNEL
+    ENFORCE --> KERNEL
+
+    subgraph L1["① Kernel"]
+        KERNEL["dsh-multi-tenant<br/>TenantPrincipal · SessionOwner<br/>ownership + fail-closed authorization"]
+    end
+
+    KERNEL --> STORE
+
+    subgraph L2["② Ownership Provider"]
+        STORE["TenantSessionStore contract"]
+        STORE --> MEM["Memory"]
+        STORE --> PG["PostgreSQL"]
+        STORE --> REDIS["Redis"]
+        STORE --> THIRD["third-party"]
+    end
+
+    subgraph L6["⑥ Distribution / Preset"]
+        PRESET["official SaaS stack<br/>core + store + web + auth + MCP + audit"]
+    end
+
+    PRESET -.-> L1
+    PRESET -.-> L2
+    PRESET -.-> L3
+    PRESET -.-> L4
+    PRESET -.-> L5
+```
+
+## Request flow
+
+1. **④ Identity** — an HTTP request or WS upgrade is authenticated; the auth
+   provider (JWT / OIDC / API key) yields a `TenantPrincipal` bound to the
+   request/connection scope. The kernel never sees the auth mechanism.
+2. **③ Genesis** — on `create` / `fork` / `subagent` / `resume`, the admission
+   decorator joins the Agent `setup` hook and establishes (create), inherits
+   (fork / subagent), or restores (resume) ownership — all before
+   `sessions.enter`, so there is no ownership window.
+3. **⑤ Enforcement** — the tenant-bound `ApiProxy` guards point methods, filters
+   collections and streams, and denies unclassifiable frames — fail-closed.
+4. **① Kernel** — `MultiTenantService` authorizes against `TenantSessionStore`
+   (claim-once, immutable, tenant boundary unconditional).
+5. **② Provider** — ownership persists to memory / PostgreSQL / Redis / … behind
+   the `TenantSessionStore` contract.
+
+## Dependency direction (one-way)
+
+```
+Kernel primitives  ◀──  capability contracts  ◀──  providers
+```
+
+- The **kernel** has **zero** transport/vendor dependencies — it never knows
+  JWT / PostgreSQL / HTTP / MCP / Redis. Enforced by `scripts/verify-packages.mjs`.
+- **Capability** packages (③ genesis admission, ⑤ enforcement) own their own
+  contracts and may depend on the kernel's primitives.
+- **Providers** (②) depend on the contract they implement; sibling capabilities
+  do not reach through each other's implementations.
+
+## H3 is a hypothesis, not a conclusion
+
+The static analysis (M2/M3) concludes the upstream proposal shrinks to **H3
+only** — a request/connection-scoped principal seam. That is the current
+*hypothesis*; the `ctx.agents` decorator (③) has not yet been runtime-proven to
+join *every* `setup`. If M4 shows a decorator cannot reliably participate, then
+admission composability (③) becomes a second upstream gap (an `AgentSetup`
+contribution registry or agent-creation middleware). The upstream proposal is
+written only after M4's real-runtime proof.
+
+## Layer → doc map
+
+| Layer | Docs |
+| --- | --- |
+| ① Kernel | `../README.md` core package, `./session-genesis-map.md` |
+| ② Provider | `dsh-multi-tenant/testing` contract suite |
+| ③ Genesis admission | `./session-genesis-map.md`, `./admission-composition.md`, `../adr/session-genesis.md` |
+| ④ Identity plane | `../adr/web-enforcement.md` (H3) |
+| ⑤ Enforcement | `./web-seam-map.md`, `../adr/web-enforcement.md` |
+| ⑥ Preset | `../../ROADMAP.md` (M6/M7) |

--- a/docs/specs/architecture.zh-CN.md
+++ b/docs/specs/architecture.zh-CN.md
@@ -1,0 +1,98 @@
+[English](./architecture.md) | 简体中文
+
+# 架构 —— 六层
+
+本项目是**一个可组合的插件家族**，组织为六层。内核只拥有跨套件的租户原语；其上每一层都是可替换的能力，其下每一层都是可替换的提供方。本文档是各 ADR 与 Seam Map 所锚定的全局图。
+
+## 六层
+
+| # | 层 | 产物 | 职责 | 状态 |
+| --- | --- | --- | --- | --- |
+| ① | **内核** | `dsh-multi-tenant` | `TenantPrincipal` / `SessionOwner`、一次性认领所有权、默认拒绝式授权、`TenantSessionStore` 契约。 | ✅ 已由测试锁定，契约预发布 |
+| ② | **所有权提供方** | `TenantSessionStore` 实现 | 持久化所有权（内存 / PostgreSQL / Redis / MySQL / 第三方）。由共享契约套件证明。 | ✅ seam + 内存默认；持久提供方延后 |
+| ③ | **创生准入** | `ctx.agents` 装饰器 | 加入每一次 Agent `setup`；在 `sessions.enter` 之前建立 / 继承 / 恢复所有权。 | 🚧 静态设计完成，运行时证明属 M4 |
+| ④ | **身份平面** | transport + auth 提供方 | 把一次已认证的 HTTP/WS 请求变成 request/connection-scoped `TenantPrincipal`。**H3 在这里。** | ⏳ 唯一的上游缺口 |
+| ⑤ | **强制平面** | `dsh-multi-tenant-web` | 租户绑定的 `ApiProxy`：point guard、collection 投影、respond guard、mux filter、host filter/deny。 | 🚧 仅 facade 原型 |
+| ⑥ | **分发 / preset** | 官方 SaaS 栈 | 组合 core + store + web + auth + MCP + audit，每一块可替换。 | ⏳ |
+
+## 图示
+
+```mermaid
+flowchart TD
+    subgraph L4["④ Identity Plane"]
+        direction TB
+        HTTP["HTTP / WebSocket"] --> AUTH["Auth Provider<br/>(JWT / OIDC / API key)"]
+        AUTH --> PRINCIPAL["Request / connection-scoped<br/>TenantPrincipal"]
+    end
+
+    PRINCIPAL -->|"create / fork / subagent / resume"| GENESIS
+    PRINCIPAL -->|"guard / filter"| ENFORCE
+
+    subgraph L3["③ Genesis Admission"]
+        GENESIS["AgentSetup hook<br/>establish / inherit / restore"]
+    end
+
+    subgraph L5["⑤ Enforcement Plane"]
+        ENFORCE["tenant-bound ApiProxy<br/>guard / filter / respond / deny"]
+    end
+
+    GENESIS --> KERNEL
+    ENFORCE --> KERNEL
+
+    subgraph L1["① Kernel"]
+        KERNEL["dsh-multi-tenant<br/>TenantPrincipal · SessionOwner<br/>ownership + fail-closed authorization"]
+    end
+
+    KERNEL --> STORE
+
+    subgraph L2["② Ownership Provider"]
+        STORE["TenantSessionStore contract"]
+        STORE --> MEM["Memory"]
+        STORE --> PG["PostgreSQL"]
+        STORE --> REDIS["Redis"]
+        STORE --> THIRD["third-party"]
+    end
+
+    subgraph L6["⑥ Distribution / Preset"]
+        PRESET["official SaaS stack<br/>core + store + web + auth + MCP + audit"]
+    end
+
+    PRESET -.-> L1
+    PRESET -.-> L2
+    PRESET -.-> L3
+    PRESET -.-> L4
+    PRESET -.-> L5
+```
+
+## 请求流
+
+1. **④ 身份** —— 一次 HTTP 请求或 WS 升级被认证；auth 提供方（JWT / OIDC / API key）产出一个绑定到 request/connection 作用域的 `TenantPrincipal`。内核永远看不到认证机制。
+2. **③ 创生** —— 在 `create` / `fork` / `subagent` / `resume` 上，准入装饰器加入 Agent `setup` 钩子，并建立（create）、继承（fork / subagent）、恢复（resume）所有权 —— 全部在 `sessions.enter` 之前，因此没有所有权窗口。
+3. **⑤ 强制** —— 租户绑定的 `ApiProxy` 守卫 point 方法、过滤 collection 与流、并拒绝不可分类的 frame —— 默认拒绝。
+4. **① 内核** —— `MultiTenantService` 对 `TenantSessionStore` 授权（一次性认领、不可变、租户边界无条件）。
+5. **② 提供方** —— 所有权在 `TenantSessionStore` 契约之后持久化到内存 / PostgreSQL / Redis / …。
+
+## 依赖方向（单向）
+
+```
+内核原语  ◀──  能力契约  ◀──  提供方
+```
+
+- **内核**有**零** transport/vendor 依赖 —— 它永远不感知 JWT / PostgreSQL / HTTP / MCP / Redis。由 `scripts/verify-packages.mjs` 强制。
+- **能力**包（③ 创生准入、⑤ 强制）拥有自己的契约，且可以依赖内核原语。
+- **提供方**（②）依赖其所实现的契约；兄弟能力不穿透彼此的实现。
+
+## H3 是假设，不是结论
+
+静态分析（M2/M3）得出上游提案收窄为**仅 H3** —— 一个 request/connection-scoped principal seam。这是当前的*假设*；`ctx.agents` 装饰器（③）尚未被运行时证明能加入*每一次* `setup`。若 M4 表明装饰器无法可靠参与，则准入组合性（③）会成为第二个上游缺口（一个 `AgentSetup` 贡献注册表或 agent 创建中间件）。上游提案要等 M4 的真实 runtime 证明之后才写。
+
+## 层 → 文档对照
+
+| 层 | 文档 |
+| --- | --- |
+| ① 内核 | `../README.md` 核心包、`./session-genesis-map.md` |
+| ② 提供方 | `dsh-multi-tenant/testing` 契约套件 |
+| ③ 创生准入 | `./session-genesis-map.md`、`./admission-composition.md`、`../adr/session-genesis.md` |
+| ④ 身份平面 | `../adr/web-enforcement.md`（H3） |
+| ⑤ 强制 | `./web-seam-map.md`、`../adr/web-enforcement.md` |
+| ⑥ preset | `../../ROADMAP.md`（M6/M7） |

--- a/scripts/admission-decorator-probe.mjs
+++ b/scripts/admission-decorator-probe.mjs
@@ -1,0 +1,113 @@
+#!/usr/bin/env node
+/**
+ * Admission-decorator runtime proof (M4 · ②-A): confirm that a plugin can wrap
+ * `ctx.agents` (the real AgentRegistry) so that a tenant-admission callback runs
+ * inside the Agent `setup` hook — BEFORE `sessions.enter` — for all four genesis
+ * paths, against a real `@deepseek-ai/dsh-agent-loop` runtime.
+ *
+ *   P1  create    — admission sees `options.sessionId`; store not yet entered.
+ *   P2  fork      — admission sees `options.meta.parentSession`; store not yet entered.
+ *   P3  subagent  — admission sees `options.meta.origin === 'subagent'` + `parentSession`.
+ *   P4  resume    — admission sees `options.resumeSessionId`; store not yet entered.
+ *
+ * The `llm` / `tools` / `systemPrompt` services are structurally injected by the
+ * AgentLoop but are NOT exercised by the create → setup → enter path, so they are
+ * provided as no-op stubs; `sessionPersistence` is a minimal stub that yields a
+ * fresh prepared session for the resume path.
+ *
+ * Run from the repo root: `node scripts/admission-decorator-probe.mjs`.
+ * Installs the pinned prerelease into a throwaway temp dir (not the workspace).
+ */
+import { execFileSync } from 'node:child_process'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+const tmp = mkdtempSync(join(tmpdir(), 'dsh-mt-admission-'))
+try {
+  writeFileSync(join(tmp, 'package.json'), JSON.stringify({ name: 'admission-probe', private: true, type: 'module' }))
+  execFileSync('pnpm', [
+    'add',
+    '@deepseek-ai/dsh-agent-loop@0.1.0-rc.6',
+    '@deepseek-ai/dsh-agent@0.1.0-rc.6',
+    '@deepseek-ai/dsh-session@0.1.0-rc.6',
+    '@deepseek-ai/cordis@4.0.1',
+  ], { cwd: tmp, stdio: 'ignore' })
+
+  writeFileSync(join(tmp, 'probe.mjs'), [
+    'import { Context } from "@deepseek-ai/cordis";',
+    'import SessionStore, { SessionPreparation } from "@deepseek-ai/dsh-session";',
+    'import AgentRegistry from "@deepseek-ai/dsh-agent";',
+    'import AgentLoop from "@deepseek-ai/dsh-agent-loop";',
+    '',
+    'const seen = [];',
+    'const ctx = new Context();',
+    'try {',
+    '  await ctx.plugin(SessionStore);',
+    '  await ctx.plugin(AgentRegistry);',
+    '  ctx.provide("systemPrompt", { variable() {} });',
+    '  ctx.provide("llm", {});',
+    '  ctx.provide("tools", {});',
+    '  ctx.provide("sessionPersistence", {',
+    '    prepare: (id) => SessionPreparation.create(ctx.sessions.prepare(id, {}))',
+    '  });',
+    '  await ctx.plugin(AgentLoop, { agents: [] });',
+    '',
+    '  // The decorator: a plugin wraps the real AgentRegistry, prepending an',
+    '  // admission callback to `options.setup` on both `create` and `resume`.',
+    '  const decorate = (agents) => {',
+    '    const origCreate = agents.create.bind(agents);',
+    '    const origResume = agents.resume.bind(agents);',
+    '    agents.create = async (options) => {',
+    '      const original = options.setup;',
+    '      options.setup = async (agentCtx) => {',
+    '        seen.push({ via: "create", sessionId: options.sessionId,',
+    '          parentSession: options.meta?.parentSession, origin: options.meta?.origin,',
+    '          inStore: ctx.sessions.get(options.sessionId) !== undefined });',
+    '        return original?.(agentCtx);',
+    '      };',
+    '      return origCreate(options);',
+    '    };',
+    '    agents.resume = async (options) => {',
+    '      const original = options.setup;',
+    '      options.setup = async (agentCtx) => {',
+    '        seen.push({ via: "resume", resumeSessionId: options.resumeSessionId,',
+    '          inStore: ctx.sessions.get(options.resumeSessionId) !== undefined });',
+    '        return original?.(agentCtx);',
+    '      };',
+    '      return origResume(options);',
+    '    };',
+    '  };',
+    '  decorate(ctx.agents);',
+    '',
+    '  const parent = await ctx.agents.create({ sessionId: "p1", setup: async () => {} });',
+    '  const forked = await ctx.agents.create({ sessionId: "c1", meta: { parentSession: "p1" }, setup: async () => {} });',
+    '  const subagent = await ctx.agents.create({ sessionId: "c2", meta: { parentSession: "p1", origin: "subagent" }, setup: async () => {} });',
+    '  const resumed = await ctx.agents.resume({ resumeSessionId: "r1", setup: async () => {} });',
+    '',
+    '  const inStore = (id) => ctx.sessions.get(id) !== undefined;',
+    '  const result = { seen, afterCreate: { p1: inStore("p1"), c1: inStore("c1"), c2: inStore("c2"), r1: inStore("r1") } };',
+    '',
+    '  // Assertions.',
+    '  const assert = (cond, msg) => { if (!cond) throw new Error("ASSERT FAILED: " + msg); };',
+    '  const [P1, P2, P3, P4] = seen;',
+    '  assert(P1 && P1.via === "create" && P1.sessionId === "p1" && P1.inStore === false, "P1 create: admission runs in setup before enter");',
+    '  assert(P2 && P2.via === "create" && P2.parentSession === "p1" && P2.inStore === false, "P2 fork: parentSession available, before enter");',
+    '  assert(P3 && P3.via === "create" && P3.origin === "subagent" && P3.parentSession === "p1" && P3.inStore === false, "P3 subagent: origin+parent available, before enter");',
+    '  assert(P4 && P4.via === "resume" && P4.resumeSessionId === "r1" && P4.inStore === false, "P4 resume: resumeSessionId available, before enter");',
+    '  assert(result.afterCreate.p1 && result.afterCreate.c1 && result.afterCreate.c2 && result.afterCreate.r1, "all sessions entered after create/resume");',
+    '',
+    '  console.log(JSON.stringify(result));',
+    '  await Promise.all([parent.dispose(), forked.dispose(), subagent.dispose(), resumed.dispose()]);',
+    '} finally {',
+    '  ctx.dispose?.();',
+    '}',
+  ].join('\n'))
+
+  const out = execFileSync('node', ['probe.mjs'], { cwd: tmp, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] })
+  const result = JSON.parse(out.trim())
+  const rows = result.seen.map((s) => `${s.via.padEnd(6)} ${s.sessionId ?? s.resumeSessionId}  inStore@setup=${s.inStore}`).join('\n')
+  console.log('Admission decorator proof passed — admission runs in setup, before sessions.enter, for all four paths:\n' + rows)
+} finally {
+  rmSync(tmp, { recursive: true, force: true })
+}


### PR DESCRIPTION
## Summary

Absorbs the review that M3's "closure" was **static-only**, then closes the first gap: the **admission-decorator runtime proof (②-A)**. Adds the global six-layer architecture view and relabels the roadmap honestly.

## What changed

### ① Global view + honest roadmap

- **`docs/specs/architecture.md`** (+ zh-CN) — the six-layer global map:
  `① Kernel → ② Ownership Provider → ③ Genesis Admission → ④ Identity Plane → ⑤ Enforcement Plane → ⑥ Distribution/Preset`, with a mermaid diagram, one-way dependency direction, and the note that **"H3-only" is a hypothesis, not a conclusion**. Linked from the docs index.
- **`ROADMAP.md`** (+ zh-CN) — relabel M3 as *static* convergence (runtime proof deferred), insert **M4 = Real Integration Proof**, renumber M5–M8.

### ②-A Admission-decorator runtime proof

- **`scripts/admission-decorator-probe.mjs`** — self-contained runtime probe (same pattern as the M2 `session-genesis-probe.mjs`): boots the **real** `AgentRegistry` + `AgentLoop` + `SessionStore` (`@deepseek-ai/*@0.1.0-rc.6`) with no-op `llm`/`tools`/`systemPrompt` stubs (structurally injected, not exercised by the create→setup→enter path) and a minimal `sessionPersistence` stub, wraps `ctx.agents`, and **asserts** the admission runs inside `setup` **before** `sessions.enter`.

  Result — all four genesis paths pass:

  | Path | Identity in `options` | Admission before `sessions.enter` |
  | --- | --- | --- |
  | create | `sessionId` | ✅ |
  | fork | `meta.parentSession` | ✅ |
  | subagent | `meta.origin === 'subagent'` + `meta.parentSession` | ✅ |
  | resume | `resumeSessionId` | ✅ |

- **`docs/specs/admission-composition.md`** §5 (+ zh-CN) — records the result: candidate C (`ctx.agents` decorator) is now **runtime-proven**; the upstream gap remains **H3 only** (identity for top-level `create`), not a new admission seam.

## Not changed / still open

- ②-B (real `ApiProxy` facade + exhaustive classification) and ②-C (real HTTP/WS transport prototype) remain the next M4 steps.
- No package code or metadata changes; `pnpm verify` passes.

## How to verify

```sh
node scripts/admission-decorator-probe.mjs
```