### PR TITLE
docs: align Seam Map / web ADR evidence with converged conclusions

### DIFF
--- a/docs/adr/web-enforcement.md
+++ b/docs/adr/web-enforcement.md
@@ -17,7 +17,7 @@ multi-tenancy across DSH Web's surfaces.
 | Concern | Status |
 | --- | --- |
 | **H1 — session genesis** | **resolved (M2)** — the Agent `setup` hook is the before-visibility async admission point; no core change. |
-| **Admission composability** | **resolved (M3.0)** — a plugin joins every `setup` via the `ctx.agents` decorator (identity via `options`); no new seam. |
+| **Admission composability** | **runtime-proven (M4 ②-A)** — a plugin wraps `ctx.agents` and its admission runs inside `setup` before `sessions.enter`; *unfailing* scope installation (before the host's own `create`) is ②-C. |
 | **Enforcement surfaces** (unary guard/filter, mux/host stream filter, respond guard) | **solvable** — the closure-bound `ApiProxy` facade (PR #2's `bind-tenant.ts`) wraps the session-bearing methods and streams. |
 | **Ghost ownership** | **v0-safe tombstone** (M2) — session ids must not be reusable; cleanup semantics deferred. |
 
@@ -45,6 +45,8 @@ Explicitly **not** required:
 
 ## Next
 
-File the H3 upstream proposal (request/connection-scoped principal seam), then
-build the enforcement: `ctx.agents` decorator (admission) + `ApiProxy` facade
-(guard/filter/respond) against the real DSH runtime.
+②-A (admission decorator) is runtime-proven via
+`scripts/admission-decorator-probe.mjs`. Remaining M4 work: ②-B (real `ApiProxy`
+facade + exhaustive classification) and ②-C (real HTTP/WS transport prototype).
+Then file the H3 upstream proposal (request/connection-scoped principal seam)
+and build the full enforcement on top of it.

--- a/docs/adr/web-enforcement.zh-CN.md
+++ b/docs/adr/web-enforcement.zh-CN.md
@@ -13,7 +13,7 @@
 | 关注点 | 状态 |
 | --- | --- |
 | **H1 — 会话创生** | **已解决（M2）** —— Agent `setup` 钩子是可见之前的异步准入点；无需内核改动。 |
-| **准入组合性** | **已解决（M3.0）** —— 插件通过 `ctx.agents` 装饰器加入每一次 `setup`（身份经 `options`）；无需新 seam。 |
+| **准入组合性** | **运行时已证（M4 ②-A）** —— 插件包装 `ctx.agents`，其准入在 `setup` 内、`sessions.enter` 之前运行；*无条件* scope 安装（先于宿主自身的 `create`）仍属 ②-C。 |
 | **强制 surface**（unary guard/filter、mux/host 流 filter、respond guard） | **可解决** —— 闭包绑定的 `ApiProxy` facade（PR #2 的 `bind-tenant.ts`）包装承载会话的方法与流。 |
 | **幽灵所有权** | **v0 安全墓碑**（M2） —— 会话 id 必须不可复用；清理语义延后。 |
 
@@ -33,4 +33,4 @@ facade 接收一个 `TenantPrincipal`，但 principal 在 **RPC 边界被丢弃*
 
 ## 下一步
 
-提交 H3 上游提案（request/connection-scoped principal seam），然后基于真实 DSH 运行时构建强制：`ctx.agents` 装饰器（准入）+ `ApiProxy` facade（guard/filter/respond）。
+②-A（准入装饰器）已由 `scripts/admission-decorator-probe.mjs` 运行时证明。剩余 M4 工作：②-B（真实 `ApiProxy` facade + 穷举分类）与 ②-C（真实 HTTP/WS transport 原型）。然后提交 H3 上游提案（request/connection-scoped principal seam）并在此之上构建完整强制。

--- a/docs/specs/web-seam-map.md
+++ b/docs/specs/web-seam-map.md
@@ -5,6 +5,12 @@
 > Based on `deepseek-ai/deepseek-harness` @ `47f943859bef60e4160492346772ded9b24f765a`
 > (master, 2026-08-15). Preliminary verdicts are refined by the executable
 > prototype; final verdicts land in `../adr/web-enforcement.md`.
+>
+> **Converged since this map was written** (see the ADR): **H1** (create→claim
+> atomicity) is resolved by the Agent `setup` hook — admission runs before
+> `sessions.enter` (runtime-proven M4 ②-A). **H4** (respond) is solvable via the
+> facade's `api.respond` wrap. **H3** (principal propagation) remains the one
+> upstream gap; **H2** (resource model) stays deferred.
 
 ## 1. Summary
 
@@ -25,7 +31,7 @@ DSH Web exposes **five** authorization-relevant surfaces, organized by
 |---|---|---|---|---|---|---|
 | Session | `history` `prompt` `rename` `fork` `cancel` `models` `selectModel` `attachment` `updateQueue` | Point | Guard | `/api` unary | handler `(endpoint, payload, signal)`; payload carries `sessionId` | **Guardable**; principal propagation open (→H3) |
 | Session | `list` `search` | Collection | Filter | `/api` unary | `session.list`/`session.search` return everything (no `sessionId`) | **Filterable**; same propagation issue (→H3) |
-| Session | `create` `fork` | Create | Atomic claim | `session.create` lifecycle | `create(id?: SessionId)` — client may pre-allocate; claim happens after | **NOT atomic today** (→H1) |
+| Session | `create` `fork` | Create | Atomic claim | Agent `setup` hook | admission in `setup` runs before `sessions.enter` (no window) | **Atomic via `setup`** (H1 resolved — ADR) |
 | Session | mux frames | Stream | Filter | `events.mux` | all-session aggregated (`ctx.sessions.list()` loop); every frame except `stream/error` is `sessionId`-keyed | **Filterable only via facade/upstream** (→H3) |
 | Approval/Question | `respond` | Response | Guard | `/api/respond` | `clientResponseSchema`, not a `ClientRequest`; not in `rpc.intercept()` | **Not covered by unary intercept** (→H4) |
 | Workspace | host frames | Stream | Filter / deny | `events.host` | `HostFrame` mixes session + workspace + host-global | **Requires resource model** (→H2) |
@@ -108,7 +114,7 @@ Approval/question is server-initiated: `approval/requested` → browser answers 
 `ClientRequest`. The unary `rpc.intercept()` path decodes `ClientRequest` only;
 `toFetchHandler` special-cases `/api/respond`. The response payload carries
 `sessionId`, so ownership **is** checkable — but there is no shared seam with the
-unary path (→H4).
+unary path (→H4). Resolved by the facade's `api.respond` wrap (ADR).
 
 ## 6. Seams and gaps (→ Hard Conclusions)
 
@@ -116,8 +122,8 @@ unary path (→H4).
 |---|---|---|
 | Unary handler has no principal/Request | `ConnectionRpcHandler = (endpoint, payload, signal)` | H3 |
 | Mux/host streams are global | `WebSocketDownlinks` holds one `ApiProxy`; `events.mux` aggregates `ctx.sessions.list()` | H3 |
-| `/api/respond` bypasses unary intercept | `clientResponseSchema` special-case in `toFetchHandler` | H4 |
-| create→claim race | `session.create(id?: SessionId)`; core has no `release`/`reassign` | H1 |
+| `/api/respond` bypasses unary intercept | `clientResponseSchema` special-case in `toFetchHandler` | ~~H4~~ resolved (facade `api.respond` wrap) |
+| ~~create→claim race~~ | `session.create(id?: SessionId)`; core has no `release`/`reassign` | ~~H1~~ resolved (`setup` hook, M4 ②-A) |
 | host stream exposes Workspace + host-global | `HostFrame` union includes `workspace-*`, `remote-event` | H2 |
 
 ## 7. Ecosystem notes

--- a/docs/specs/web-seam-map.zh-CN.md
+++ b/docs/specs/web-seam-map.zh-CN.md
@@ -4,6 +4,8 @@
 
 > 基于 `deepseek-ai/deepseek-harness` @ `47f943859bef60e4160492346772ded9b24f765a`
 > （master，2026-08-15）。初步判定由可执行原型细化；最终判定落在 `../adr/web-enforcement.md`。
+>
+> **本图成文后已收敛**（见 ADR）：**H1**（create→claim 原子性）由 Agent `setup` 钩子解决 —— 准入在 `sessions.enter` 之前运行（M4 ②-A 运行时证明）。**H4**（respond）可经 facade 的 `api.respond` 包装解决。**H3**（principal 传播）仍是唯一上游缺口；**H2**（资源模型）仍延后。
 
 ## 1. 概述
 
@@ -23,7 +25,7 @@ DSH Web 暴露**五个**与授权相关的 surface，按 **Resource × Access Sh
 |---|---|---|---|---|---|---|
 | Session | `history` `prompt` `rename` `fork` `cancel` `models` `selectModel` `attachment` `updateQueue` | Point | Guard | `/api` unary | handler `(endpoint, payload, signal)`；payload 携带 `sessionId` | **可守卫**；principal 传播待定（→H3） |
 | Session | `list` `search` | Collection | Filter | `/api` unary | `session.list`/`session.search` 返回全部（无 `sessionId`） | **可过滤**；同一传播问题（→H3） |
-| Session | `create` `fork` | Create | Atomic claim | `session.create` 生命周期 | `create(id?: SessionId)` —— 客户端可预分配；认领发生在其后 | **今天非原子**（→H1） |
+| Session | `create` `fork` | Create | Atomic claim | Agent `setup` 钩子 | 准入在 `setup` 内、`sessions.enter` 之前运行（无窗口） | **经 `setup` 原子**（H1 已解决 — ADR） |
 | Session | mux frames | Stream | Filter | `events.mux` | 全 session 聚合（`ctx.sessions.list()` 循环）；除 `stream/error` 外的每个 frame 都以 `sessionId` 为键 | **仅能经 facade/上游过滤**（→H3） |
 | Approval/Question | `respond` | Response | Guard | `/api/respond` | `clientResponseSchema`，非 `ClientRequest`；不在 `rpc.intercept()` 内 | **未被 unary intercept 覆盖**（→H4） |
 | Workspace | host frames | Stream | Filter / deny | `events.host` | `HostFrame` 混合 session + workspace + host-global | **需要资源模型**（→H2） |
@@ -89,7 +91,7 @@ type HostFrame =
 
 ## 5. `/api/respond`（双向）
 
-Approval/question 是服务端发起的：`approval/requested` → 浏览器应答 → 携带 `ClientResponse`（`clientResponseSchema`）的 `POST /api/respond`，**而非** `ClientRequest`。unary `rpc.intercept()` 路径只解码 `ClientRequest`；`toFetchHandler` 特判 `/api/respond`。响应 payload 携带 `sessionId`，因此所有权**是**可检查的 —— 但与 unary 路径之间没有共享 seam（→H4）。
+Approval/question 是服务端发起的：`approval/requested` → 浏览器应答 → 携带 `ClientResponse`（`clientResponseSchema`）的 `POST /api/respond`，**而非** `ClientRequest`。unary `rpc.intercept()` 路径只解码 `ClientRequest`；`toFetchHandler` 特判 `/api/respond`。响应 payload 携带 `sessionId`，因此所有权**是**可检查的 —— 但与 unary 路径之间没有共享 seam（→H4）。经 facade 的 `api.respond` 包装解决（ADR）。
 
 ## 6. Seam 与缺口（→ 硬结论）
 
@@ -97,8 +99,8 @@ Approval/question 是服务端发起的：`approval/requested` → 浏览器应�
 |---|---|---|
 | Unary handler 无 principal/Request | `ConnectionRpcHandler = (endpoint, payload, signal)` | H3 |
 | Mux/host 流是全局的 | `WebSocketDownlinks` 持有一个 `ApiProxy`；`events.mux` 聚合 `ctx.sessions.list()` | H3 |
-| `/api/respond` 绕过 unary intercept | `toFetchHandler` 中的 `clientResponseSchema` 特例 | H4 |
-| create→claim 竞态 | `session.create(id?: SessionId)`；core 无 `release`/`reassign` | H1 |
+| `/api/respond` 绕过 unary intercept | `toFetchHandler` 中的 `clientResponseSchema` 特例 | ~~H4~~ 已解决（facade `api.respond` 包装） |
+| ~~create→claim 竞态~~ | `session.create(id?: SessionId)`；core 无 `release`/`reassign` | ~~H1~~ 已解决（`setup` 钩子，M4 ②-A） |
 | host 流暴露 Workspace + host-global | `HostFrame` union 含 `workspace-*`、`remote-event` | H2 |
 
 ## 7. 生态备注


### PR DESCRIPTION
## Summary

Small follow-up to PR #13 — closes the two review points that PR #13 did not touch, so the ADR and Spec no longer disagree.

## Changes

### web-seam-map.md (+ zh-CN)
- **H1** (`create→claim` atomicity): was `**NOT atomic today** (→H1)` / `create→claim race → H1`. Now marked **resolved** — the Agent `setup` hook runs admission before `sessions.enter` (runtime-proven in M4 ②-A), so there is no ownership window.
- **H4** (respond): was `→ H4`. Now marked **resolved** via the facade's `api.respond` wrap.
- Added a "converged since" note at the top mapping H1/H4 → resolved, H3 → open, H2 → deferred.

### web-enforcement.md (+ zh-CN)
- `Admission composability → resolved (M3.0)` is now `runtime-proven (M4 ②-A)`, explicitly noting that the *unfailing* scope installation (before the host's own `create`) remains ②-C — so the word "resolved" no longer overstates it.
- Updated the Next section: ②-A done, ②-B/②-C remain, then the H3 upstream proposal.

## Notes on the other two review points (no action needed)
- **M3 status** and the **stale "ADR in packages/multi-tenant-web" path** were already fixed by PR #13 (M3 = "static only" + M4 integration proof; the Done bullet now says "the converged web ADR").

No code or package metadata changes.