### PR TITLE
fix(web): harden tenant RPC classification before transport integration

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -13,42 +13,43 @@ Statuses: ✅ done · 🚧 next (settled) · ⏳ deferred (decision-gated).
   delegated root scripts, CI.
 - ✅ **Web seam spike (M2)** — Seam Map, executable facade prototype (6 security
   invariants), and the converged web ADR. Concluded that web enforcement is
-  blocked on an upstream per-connection seam (H3).
+  blocked on a transport principal-binding problem (H3 hypothesis).
 - ✅ **Kernel engineering harness** — `TenantSessionStore` contract suite
   (`dsh-multi-tenant/testing`), architecture gate (`pnpm verify`), package
   smoke (`pnpm smoke`), compatibility policy (`docs/reference/compatibility.md`).
 - ✅ **Architecture convergence (M3)** — six-layer architecture
   (`docs/specs/architecture.md`), the Agent `setup` hook confirmed as the
-  admission point, and "H3-only" established as a **hypothesis**: enforcement is
-  *statically* solvable via a `ctx.agents` decorator + `ApiProxy` facade. The
-  **runtime proof is deferred to M4** — the static conclusions are not yet
-  demonstrated against the real DSH runtime.
+  admission point, and "H3-only" established as a **hypothesis** to verify with
+  real transport evidence in M4.
 
 ## Next (settled)
 
 - 🚧 **M4 — Real integration proof.** Demonstrate the M3 claims against the real
   DSH runtime *before* filing the upstream proposal:
-  1. **Admission decorator** ✅ — wrap the real `AgentService`; assert the
-     admission runs inside `setup`, before `sessions.enter`, for
-     create / fork / subagent / resume. Proven by
-     `scripts/admission-decorator-probe.mjs` (`docs/specs/admission-composition.md`
-     §5): a decorator joins every `setup` and the admission runs before
-     visibility on all four paths — no new admission seam needed.
-  2. **Real `ApiProxy` facade** ✅ — dropped the spike `ApiSurface`; classified the
-     real `@deepseek-ai/dsh-host-apiproxy` surface exhaustively (ALLOW / GUARD /
-     FILTER / DENY, 52 methods) so a new DSH method fails to compile. Streams
-     (`events`) / `respond` / `downloads` are denied until ②-C / H4.
+  1. **Admission decorator** ✅ — real `AgentService`, create / fork / subagent /
+     resume, admission inside `setup` before `sessions.enter`.
+  2. **Real `ApiProxy` facade** ✅ — the spike `ApiSurface` is gone; the real
+     `RpcMethodMap` is exhaustively classified at compile time. The v0 security
+     policy is fail-closed: GUARD session points, FILTER only `session.list`,
+     ADMIT `session.create` (denied until the admission bridge is installed),
+     and DENY search / host-global / deployment-management surfaces that do not
+     yet have tenant-safe semantics. Streams / `respond` / `downloads` remain
+     denied pending ②-C.
   3. **Real transport prototype** — HTTP / WS / respond / mux / host against the
-     real runtime (still `X-Test-Tenant` / `X-Test-User`), locking the six
-     tenant-isolation invariants.
+     real runtime (still `X-Test-Tenant` / `X-Test-User`), locking the tenant-
+     isolation invariants, `rpcId → sessionId` respond correlation, and
+     unfailing installation ordering.
 - 🚧 **M5 — Upstream proposal + web enforcement.** File the request/connection-
-  scoped principal seam (plus any other seam M4 surfaces), then build the
-  enforcement on top of it.
+  scoped principal seam (plus any other seam M4 actually proves necessary),
+  then build the full enforcement on top of it.
 
 ## Deferred (decision-gated)
 
 - ⏳ **H2 — resource model.** Whether Workspace and host-global frames are
   tenant-owned. Product decision; until then, v0 denies non-session host frames.
+- ⏳ **Tenant-scoped search.** `session.search` is globally ranked/capped today;
+  it stays denied until a visibility predicate / scoped candidate set preserves
+  correct search semantics.
 - ⏳ **Auth providers** (JWT / OIDC / API key). Post-H3; `TenantPrincipalResolver`
   placement still undecided.
 - ⏳ **Durable stores** (PostgreSQL / Redis / MySQL). Create a provider package
@@ -66,11 +67,10 @@ Statuses: ✅ done · 🚧 next (settled) · ⏳ deferred (decision-gated).
   smoke, compatibility policy.
 - **M2 — Session genesis spike** ✅ `setup` hook confirmed as the admission
   point; fork / subagent / resume solvable today.
-- **M3 — Architecture convergence** ✅ *static only*: six-layer architecture,
-  H3-only as a hypothesis; enforcement statically solvable via `ctx.agents`
-  decorator + `ApiProxy` facade.
-- **M4 — Real integration proof** 🚧 admission decorator, real `ApiProxy`
-  facade + exhaustive classification, real HTTP/WS transport prototype.
+- **M3 — Architecture convergence** ✅ six-layer architecture and H3-only as a
+  hypothesis.
+- **M4 — Real integration proof** 🚧 admission decorator and real unary
+  `ApiProxy` are proven; real HTTP/WS transport remains.
 - **M5 — Upstream proposal + web enforcement.**
 - **M6 — Providers** durable stores, auth.
 - **M7 — MCP / audit / full-stack preset.**

--- a/ROADMAP.zh-CN.md
+++ b/ROADMAP.zh-CN.md
@@ -8,21 +8,22 @@
 
 - ✅ **内核核心** —— `TenantPrincipal` / `SessionOwner`、一次性认领所有权、默认拒绝式授权、`TenantSessionStore` service seam（内存提供方）。`packages/multi-tenant`。
 - ✅ **Monorepo** —— pnpm 工作区含 `packages/`、共享 `tsconfig.base.json`、委托式根脚本、CI。
-- ✅ **Web seam spike（M2）** —— Seam Map、可执行 facade 原型（6 条安全不变量）、以及收敛后的 web ADR。结论：web 强制被一个上游 per-connection seam（H3）所阻塞。
+- ✅ **Web seam spike（M2）** —— Seam Map、可执行 facade 原型（6 条安全不变量）、以及收敛后的 web ADR。结论：Web 强制仍受 transport principal 绑定问题（H3 假设）约束。
 - ✅ **内核工程脚手架** —— `TenantSessionStore` 契约套件（`dsh-multi-tenant/testing`）、架构门（`pnpm verify`）、包冒烟（`pnpm smoke`）、兼容性政策（`docs/reference/compatibility.md`）。
-- ✅ **架构收敛（M3）** —— 六层架构（`docs/specs/architecture.md`）、Agent `setup` 钩子被确认为准入点，并把「H3-only」确立为**假设**：强制通过 `ctx.agents` 装饰器 + `ApiProxy` facade 是*静态*可解的。**运行时证明被推迟到 M4** —— 静态结论尚未在真实 DSH runtime 上得到演示。
+- ✅ **架构收敛（M3）** —— 六层架构（`docs/specs/architecture.md`）、Agent `setup` 钩子被确认为准入点，并把「H3-only」确立为**假设**，由 M4 的真实 transport 证据最终验证。
 
 ## 下一步（已确定）
 
 - 🚧 **M4 — 真实集成证明。** 在提交上游提案*之前*，用真实 DSH runtime 演示 M3 的结论：
-  1. **准入装饰器** ✅ —— 包装真实的 `AgentService`；断言准入在 `setup` 内、先于 `sessions.enter` 执行，覆盖 create / fork / subagent / resume。已由 `scripts/admission-decorator-probe.mjs`（`docs/specs/admission-composition.md` §5）证明：装饰器能加入每一次 `setup`，且准入在四条路径上都先于可见 —— 无需新的准入 seam。
-  2. **真实 `ApiProxy` facade** ✅ —— 删掉了 spike 的 `ApiSurface`；对真实 `@deepseek-ai/dsh-host-apiproxy` surface 做了穷举分类（ALLOW / GUARD / FILTER / DENY，共 52 个方法），使新增 DSH 方法**编译失败**。流（`events`）/ `respond` / `downloads` 在 ②-C / H4 之前按拒绝处理。
-  3. **真实 transport 原型** —— 对真实 runtime 跑 HTTP / WS / respond / mux / host（仍用 `X-Test-Tenant` / `X-Test-User`），锁死六条租户隔离不变量。
-- 🚧 **M5 — 上游提案 + Web 强制。** 提交 request/connection-scoped principal seam（以及 M4 暴露的任何其他 seam），然后在其上构建强制。
+  1. **准入装饰器** ✅ —— 真实 `AgentService`，覆盖 create / fork / subagent / resume，准入在 `setup` 内、先于 `sessions.enter`。
+  2. **真实 `ApiProxy` facade** ✅ —— spike 的 `ApiSurface` 已删除；真实 `RpcMethodMap` 在编译期穷举分类。v0 安全策略默认拒绝：session point 做 GUARD，仅 `session.list` 做 FILTER，`session.create` 归类为 ADMIT（admission bridge 安装前直接拒绝），search / host-global / deployment-management surface 在缺少 tenant-safe 语义前均 DENY。流 / `respond` / `downloads` 在 ②-C 前继续拒绝。
+  3. **真实 transport 原型** —— 对真实 runtime 跑 HTTP / WS / respond / mux / host（仍用 `X-Test-Tenant` / `X-Test-User`），锁死租户隔离不变量、`rpcId → sessionId` respond correlation 与无遗漏的安装顺序。
+- 🚧 **M5 — 上游提案 + Web 强制。** 只提交 M4 实际证明为必要的 request/connection-scoped principal seam（以及任何其他被真实证据暴露出的 seam），然后在其上构建完整强制。
 
 ## 延后（由决策门控）
 
 - ⏳ **H2 — 资源模型。** Workspace 与 host-global frame 是否由租户拥有。产品决策；在此之前，v0 拒绝非 session 的 host frame。
+- ⏳ **租户作用域搜索。** 当前 `session.search` 是全局排序/限量；在 visibility predicate / scoped candidate set 能保证正确搜索语义前保持拒绝。
 - ⏳ **认证提供方**（JWT / OIDC / API key）。在 H3 之后；`TenantPrincipalResolver` 的落点仍待定。
 - ⏳ **持久存储**（PostgreSQL / Redis / MySQL）。一旦一个独立的组合 / 替换 / 依赖 / 生命周期边界被证明，就创建一个提供方包。
 - ⏳ **`dsh-multi-tenant-web` 的公共契约冻结**（在 H3 解决之前，其名字与 surface 都是临时的）。
@@ -33,8 +34,8 @@
 - **M0 — 工程地基** ✅ monorepo、包规则、规格/ADR 纪律、CI。
 - **M1 — 内核加固** ✅ 契约测试脚手架、架构门、包冒烟、兼容性政策。
 - **M2 — 会话创生 spike** ✅ 确认 `setup` 钩子为准入点；fork / subagent / resume 今天即可解决。
-- **M3 — 架构收敛** ✅ *仅静态*：六层架构、H3-only 作为假设；强制通过 `ctx.agents` 装饰器 + `ApiProxy` facade 静态可解。
-- **M4 — 真实集成证明** 🚧 准入装饰器、真实 `ApiProxy` facade + 穷举分类、真实 HTTP/WS transport 原型。
+- **M3 — 架构收敛** ✅ 六层架构 + H3-only 作为假设。
+- **M4 — 真实集成证明** 🚧 准入装饰器与真实 unary `ApiProxy` 已证明；真实 HTTP/WS transport 待完成。
 - **M5 — 上游提案 + Web 强制。**
 - **M6 — 提供方** 持久存储、认证。
 - **M7 — MCP / audit / 全栈 preset。**

--- a/docs/adr/web-enforcement.md
+++ b/docs/adr/web-enforcement.md
@@ -17,36 +17,57 @@ multi-tenancy across DSH Web's surfaces.
 | Concern | Status |
 | --- | --- |
 | **H1 — session genesis** | **resolved (M2)** — the Agent `setup` hook is the before-visibility async admission point; no core change. |
-| **Admission composability** | **runtime-proven (M4 ②-A)** — a plugin wraps `ctx.agents` and its admission runs inside `setup` before `sessions.enter`; *unfailing* scope installation (before the host's own `create`) is ②-C. |
-| **Enforcement surfaces** (unary guard/filter, mux/host stream filter, respond guard) | **solvable** — the closure-bound `ApiProxy` facade (PR #2's `bind-tenant.ts`) wraps the session-bearing methods and streams. |
-| **Ghost ownership** | **v0-safe tombstone** (M2) — session ids must not be reusable; cleanup semantics deferred. |
+| **Admission composability** | **runtime-proven (M4 ②-A)** — a decorator can join `ctx.agents.create/resume` and its admission runs inside `setup` before `sessions.enter`; *unfailing transport/scope installation* remains part of ②-C. |
+| **Unary enforcement** | **runtime shape implemented (M4 ②-B)** — `bindTenant` wraps the real `ApiProxy` and every `RpcMethodMap` member is exhaustively classified at compile time. The policy is deliberately fail-closed: session points are guarded, only `session.list` is post-filtered, `session.create` is admission-gated, and unmodelled host/global management surfaces are denied. |
+| **Streams / respond** | **pending M4 ②-C** — currently denied. `events` needs principal-bound filtering; `respond` needs runtime proof of `rpcId → sessionId` correlation before authorization. |
+| **Ghost ownership** | **v0 security-safe tombstone** (M2) — session ids must not be reusable; cleanup semantics deferred. |
 
-## The remaining gap — H3 (request-scoped principal)
+## The remaining transport question — H3
 
 The facade takes a `TenantPrincipal`, but the principal is **dropped at the RPC
 boundary** (`ConnectionRpcHandler = (endpoint, payload, signal)`). It exists
 only at the transport boundary (HTTP fetch `new Request(req)`, WS upgrade
 `handleMux(req)`), and DSH then collapses into a shared singleton
 (`HostConnectionService`, one `ApiProxy`, one `WebSocketDownlinks`). There is
-**no per-connection scope** to bind the facade to.
+currently no proven per-request/per-connection binding point for the tenant
+principal.
 
-## Decision
+The current hypothesis is therefore **H3**: the real transport needs a
+request/connection-scoped principal seam. M4 ②-C must prove that this is the
+only missing upstream requirement; the upstream proposal is not filed before
+that proof.
 
-The **minimal upstream seam is H3 only** — a request/connection-scoped
-principal binding point, which makes the `ApiProxy` facade and the `ctx.agents`
-decorator installable **per-connection** rather than process-wide.
+## Security policy for the v0 web surface
 
-Explicitly **not** required:
+`RpcMethodMap` coverage is exhaustive, but exhaustive coverage does not mean
+that every host capability is tenant-safe. Until a resource or privilege model
+exists, v0 follows these rules:
 
-- a core change (H1 resolved via `setup`);
-- a respond-specific seam (the facade's `api.respond` wrap guards it);
-- a global setup-contribution registry (the `ctx.agents` decorator suffices —
-  an upstream middleware is only a cleaner optional alternative).
+- session-keyed point operations → **GUARD**;
+- `session.list` → **FILTER** (post-filtering preserves its current semantics);
+- `session.create` → **ADMIT**, and is denied by the standalone facade until the
+  pre-publication admission bridge is installed;
+- `session.search` → **DENY** for now because DSH returns a globally ranked,
+  capped result set; post-filtering it is not a correct tenant-scoped query;
+- deployment/host management (`settings.*`, `credentials.*`, host/workspace,
+  preset authoring, host-scoped LLM configuration/discovery) → **DENY**;
+- explicitly tenant-neutral read-only discovery may be **ALLOW** (currently
+  `agentPreset.list`).
+
+## Explicitly not required by current evidence
+
+- a kernel change (H1 resolved via `setup`);
+- a new global setup-contribution registry (the admission decorator is
+  runtime-feasible; installation ordering is verified in ②-C).
+
+No claim is made yet that `respond` needs — or does not need — a dedicated
+upstream seam. The current implementation denies it until M4 ②-C proves a safe
+correlation path.
 
 ## Next
 
-②-A (admission decorator) is runtime-proven via
-`scripts/admission-decorator-probe.mjs`. Remaining M4 work: ②-B (real `ApiProxy`
-facade + exhaustive classification) and ②-C (real HTTP/WS transport prototype).
-Then file the H3 upstream proposal (request/connection-scoped principal seam)
-and build the full enforcement on top of it.
+②-A (admission decorator) and ②-B (real `ApiProxy` + exhaustive unary
+classification) are complete. Remaining M4 work is ②-C: real HTTP/WS transport,
+principal lifetime, mux/host filtering, `respond` correlation, and unfailing
+installation ordering. Only then file the upstream proposal and proceed to full
+web enforcement.

--- a/docs/adr/web-enforcement.zh-CN.md
+++ b/docs/adr/web-enforcement.zh-CN.md
@@ -13,24 +13,35 @@
 | 关注点 | 状态 |
 | --- | --- |
 | **H1 — 会话创生** | **已解决（M2）** —— Agent `setup` 钩子是可见之前的异步准入点；无需内核改动。 |
-| **准入组合性** | **运行时已证（M4 ②-A）** —— 插件包装 `ctx.agents`，其准入在 `setup` 内、`sessions.enter` 之前运行；*无条件* scope 安装（先于宿主自身的 `create`）仍属 ②-C。 |
-| **强制 surface**（unary guard/filter、mux/host 流 filter、respond guard） | **可解决** —— 闭包绑定的 `ApiProxy` facade（PR #2 的 `bind-tenant.ts`）包装承载会话的方法与流。 |
-| **幽灵所有权** | **v0 安全墓碑**（M2） —— 会话 id 必须不可复用；清理语义延后。 |
+| **准入组合性** | **运行时已证（M4 ②-A）** —— 装饰器可以加入 `ctx.agents.create/resume`，其准入在 `setup` 内、`sessions.enter` 之前运行；*无条件的 transport/scope 安装*仍属 ②-C。 |
+| **Unary 强制** | **真实形态已实现（M4 ②-B）** —— `bindTenant` 包装真实 `ApiProxy`，`RpcMethodMap` 的每个成员都在编译期穷举分类。策略刻意默认拒绝：session point 做 guard，仅 `session.list` 做 post-filter，`session.create` 走 admission gate，未建模的 host/global 管理面一律 deny。 |
+| **Streams / respond** | **待 M4 ②-C** —— 当前直接拒绝。`events` 需要 principal-bound 过滤；`respond` 需要先运行时证明 `rpcId → sessionId` 关联，再做授权。 |
+| **幽灵所有权** | **v0 在安全上可接受的墓碑**（M2） —— 会话 id 必须不可复用；清理语义延后。 |
 
-## 剩余的缺口 — H3（request-scoped principal）
+## 剩余的 transport 问题 — H3
 
-facade 接收一个 `TenantPrincipal`，但 principal 在 **RPC 边界被丢弃**（`ConnectionRpcHandler = (endpoint, payload, signal)`）。它只存在于 transport 边界（HTTP fetch `new Request(req)`、WS 升级 `handleMux(req)`），随后 DSH 塌缩为一个共享单例（`HostConnectionService`、一个 `ApiProxy`、一个 `WebSocketDownlinks`）。**没有 per-connection 作用域**可供 facade 绑定。
+facade 接收一个 `TenantPrincipal`，但 principal 在 **RPC 边界被丢弃**（`ConnectionRpcHandler = (endpoint, payload, signal)`）。它只存在于 transport 边界（HTTP fetch `new Request(req)`、WS 升级 `handleMux(req)`），随后 DSH 塌缩为一个共享单例（`HostConnectionService`、一个 `ApiProxy`、一个 `WebSocketDownlinks`）。目前还没有被证明可用的 per-request/per-connection principal 绑定点。
 
-## 决策
+因此当前假设仍是 **H3**：真实 transport 需要一个 request/connection-scoped principal seam。M4 ②-C 必须证明这是唯一剩余的上游需求；在这个证明完成之前不提交上游提案。
 
-**最小上游 seam 仅 H3** —— 一个 request/connection-scoped principal 绑定点，它使 `ApiProxy` facade 与 `ctx.agents` 装饰器可以 **per-connection** 而非 process-wide 安装。
+## v0 Web surface 的安全策略
 
-明确**不需要**的：
+`RpcMethodMap` 的覆盖已经穷举，但“穷举”不等于“每个 Host 能力都适合直接暴露给租户”。在资源模型或权限模型尚未建立前，v0 采用以下规则：
+
+- session-keyed point 操作 → **GUARD**；
+- `session.list` → **FILTER**（当前语义允许正确 post-filter）；
+- `session.create` → **ADMIT**，在 pre-publication admission bridge 尚未装好前由独立 facade 直接拒绝；
+- `session.search` → 暂时 **DENY**，因为 DSH 返回的是全局排序、数量受限的结果集，事后过滤并不等价于 tenant-scoped query；
+- deployment/host 管理面（`settings.*`、`credentials.*`、host/workspace、preset authoring、host-scoped LLM 配置/发现）→ **DENY**；
+- 明确判断为 tenant-neutral 的只读发现能力可 **ALLOW**（目前为 `agentPreset.list`）。
+
+## 当前证据明确不需要的东西
 
 - 内核改动（H1 已通过 `setup` 解决）；
-- 一个 respond 专用的 seam（facade 的 `api.respond` 包装已守卫它）；
-- 一个全局 setup 贡献注册表（`ctx.agents` 装饰器已足够 —— 上游中间件只是一个更干净的备选方案）。
+- 新的全局 setup 贡献注册表（准入装饰器已证明运行时可行；安装顺序在 ②-C 验证）。
+
+目前不声称 `respond` 一定需要、或一定不需要专门的上游 seam。当前实现继续拒绝，直到 M4 ②-C 证明一条安全的 correlation 路径。
 
 ## 下一步
 
-②-A（准入装饰器）已由 `scripts/admission-decorator-probe.mjs` 运行时证明。剩余 M4 工作：②-B（真实 `ApiProxy` facade + 穷举分类）与 ②-C（真实 HTTP/WS transport 原型）。然后提交 H3 上游提案（request/connection-scoped principal seam）并在此之上构建完整强制。
+②-A（准入装饰器）和 ②-B（真实 `ApiProxy` + unary 穷举分类）已完成。M4 剩余工作是 ②-C：真实 HTTP/WS transport、principal 生命周期、mux/host 过滤、`respond` correlation，以及无遗漏的安装顺序。完成后再提交上游提案并进入完整 Web 强制。

--- a/docs/specs/architecture.md
+++ b/docs/specs/architecture.md
@@ -14,9 +14,9 @@ anchored to.
 | --- | --- | --- | --- | --- |
 | ① | **Kernel** | `dsh-multi-tenant` | `TenantPrincipal` / `SessionOwner`, claim-once ownership, fail-closed authorization, the `TenantSessionStore` contract. | ✅ test-pinned, prerelease contract |
 | ② | **Ownership provider** | `TenantSessionStore` impls | Persist ownership (memory / PostgreSQL / Redis / MySQL / third-party). Proven by the shared contract suite. | ✅ seam + in-memory default; durable providers deferred |
-| ③ | **Genesis admission** | `ctx.agents` decorator | Join every Agent `setup`; establish / inherit / restore ownership before `sessions.enter`. | 🚧 statically designed, runtime proof is M4 |
-| ④ | **Identity plane** | transport + auth provider | Turn an authenticated HTTP/WS request into a request/connection-scoped `TenantPrincipal`. **H3 lives here.** | ⏳ the one upstream gap |
-| ⑤ | **Enforcement plane** | `dsh-multi-tenant-web` | A tenant-bound `ApiProxy`: point guard, collection projection, respond guard, mux filter, host filter/deny. | 🚧 facade prototype only |
+| ③ | **Genesis admission** | `ctx.agents` decorator | Join every Agent `setup`; establish / inherit / restore ownership before `sessions.enter`. | ✅ runtime-proven for create / fork / subagent / resume; transport installation pending |
+| ④ | **Identity plane** | transport + auth provider | Turn an authenticated HTTP/WS request into a request/connection-scoped `TenantPrincipal`. **H3 lives here.** | ⏳ upstream requirement still to be proven by M4 transport work |
+| ⑤ | **Enforcement plane** | `dsh-multi-tenant-web` | A tenant-bound `ApiProxy`: guarded session points, safe collection projection, admission gating, and fail-closed denial of unmodelled/global surfaces. Streams/respond remain M4 transport work. | 🚧 real unary `ApiProxy` + exhaustive classification done; transport pending |
 | ⑥ | **Distribution / preset** | the official SaaS stack | Compose core + store + web + auth + MCP + audit, each piece replaceable. | ⏳ |
 
 ## Diagram
@@ -30,14 +30,14 @@ flowchart TD
     end
 
     PRINCIPAL -->|"create / fork / subagent / resume"| GENESIS
-    PRINCIPAL -->|"guard / filter"| ENFORCE
+    PRINCIPAL -->|"guard / filter / admit"| ENFORCE
 
     subgraph L3["③ Genesis Admission"]
         GENESIS["AgentSetup hook<br/>establish / inherit / restore"]
     end
 
     subgraph L5["⑤ Enforcement Plane"]
-        ENFORCE["tenant-bound ApiProxy<br/>guard / filter / respond / deny"]
+        ENFORCE["tenant-bound ApiProxy<br/>guard / filter / admit / deny"]
     end
 
     GENESIS --> KERNEL
@@ -77,8 +77,11 @@ flowchart TD
    decorator joins the Agent `setup` hook and establishes (create), inherits
    (fork / subagent), or restores (resume) ownership — all before
    `sessions.enter`, so there is no ownership window.
-3. **⑤ Enforcement** — the tenant-bound `ApiProxy` guards point methods, filters
-   collections and streams, and denies unclassifiable frames — fail-closed.
+3. **⑤ Enforcement** — the tenant-bound `ApiProxy` guards session-keyed methods,
+   post-filters only collections whose semantics remain correct after filtering,
+   and denies unmodelled host/global surfaces. `session.create` is an admission
+   operation, not ordinary allow; streams/respond stay fail-closed until M4's
+   transport proof installs their complete authorization path.
 4. **① Kernel** — `MultiTenantService` authorizes against `TenantSessionStore`
    (claim-once, immutable, tenant boundary unconditional).
 5. **② Provider** — ownership persists to memory / PostgreSQL / Redis / … behind
@@ -99,13 +102,13 @@ Kernel primitives  ◀──  capability contracts  ◀──  providers
 
 ## H3 is a hypothesis, not a conclusion
 
-The static analysis (M2/M3) concludes the upstream proposal shrinks to **H3
-only** — a request/connection-scoped principal seam. That is the current
-*hypothesis*; the `ctx.agents` decorator (③) has not yet been runtime-proven to
-join *every* `setup`. If M4 shows a decorator cannot reliably participate, then
-admission composability (③) becomes a second upstream gap (an `AgentSetup`
-contribution registry or agent-creation middleware). The upstream proposal is
-written only after M4's real-runtime proof.
+M4 has now runtime-proven the `ctx.agents` decorator for all four genesis paths,
+so admission composability is no longer a second upstream hypothesis. The
+remaining hypothesis is **H3**: the real HTTP/WS transport needs a
+request/connection-scoped principal binding point that lets the admission and
+ApiProxy enforcement run under the correct principal without ambient shared
+state. The upstream proposal is written only after M4's real transport proof;
+if that proof exposes another missing seam, the proposal expands accordingly.
 
 ## Layer → doc map
 
@@ -116,4 +119,4 @@ written only after M4's real-runtime proof.
 | ③ Genesis admission | `./session-genesis-map.md`, `./admission-composition.md`, `../adr/session-genesis.md` |
 | ④ Identity plane | `../adr/web-enforcement.md` (H3) |
 | ⑤ Enforcement | `./web-seam-map.md`, `../adr/web-enforcement.md` |
-| ⑥ Preset | `../../ROADMAP.md` (M6/M7) |
+| ⑥ Preset | `../../ROADMAP.md` (M7) |

--- a/docs/specs/architecture.zh-CN.md
+++ b/docs/specs/architecture.zh-CN.md
@@ -10,9 +10,9 @@
 | --- | --- | --- | --- | --- |
 | ① | **内核** | `dsh-multi-tenant` | `TenantPrincipal` / `SessionOwner`、一次性认领所有权、默认拒绝式授权、`TenantSessionStore` 契约。 | ✅ 已由测试锁定，契约预发布 |
 | ② | **所有权提供方** | `TenantSessionStore` 实现 | 持久化所有权（内存 / PostgreSQL / Redis / MySQL / 第三方）。由共享契约套件证明。 | ✅ seam + 内存默认；持久提供方延后 |
-| ③ | **创生准入** | `ctx.agents` 装饰器 | 加入每一次 Agent `setup`；在 `sessions.enter` 之前建立 / 继承 / 恢复所有权。 | 🚧 静态设计完成，运行时证明属 M4 |
-| ④ | **身份平面** | transport + auth 提供方 | 把一次已认证的 HTTP/WS 请求变成 request/connection-scoped `TenantPrincipal`。**H3 在这里。** | ⏳ 唯一的上游缺口 |
-| ⑤ | **强制平面** | `dsh-multi-tenant-web` | 租户绑定的 `ApiProxy`：point guard、collection 投影、respond guard、mux filter、host filter/deny。 | 🚧 仅 facade 原型 |
+| ③ | **创生准入** | `ctx.agents` 装饰器 | 加入每一次 Agent `setup`；在 `sessions.enter` 之前建立 / 继承 / 恢复所有权。 | ✅ create / fork / subagent / resume 已运行时证明；transport 安装仍待完成 |
+| ④ | **身份平面** | transport + auth 提供方 | 把一次已认证的 HTTP/WS 请求变成 request/connection-scoped `TenantPrincipal`。**H3 在这里。** | ⏳ 仍需 M4 transport 证明最终上游需求 |
+| ⑤ | **强制平面** | `dsh-multi-tenant-web` | 租户绑定的 `ApiProxy`：守卫 session point、只对语义安全的 collection 做投影、准入门控，并默认拒绝未建模的 host/global surface。stream/respond 仍属 M4 transport 工作。 | 🚧 真实 unary `ApiProxy` + 穷举分类已完成；transport 待完成 |
 | ⑥ | **分发 / preset** | 官方 SaaS 栈 | 组合 core + store + web + auth + MCP + audit，每一块可替换。 | ⏳ |
 
 ## 图示
@@ -26,14 +26,14 @@ flowchart TD
     end
 
     PRINCIPAL -->|"create / fork / subagent / resume"| GENESIS
-    PRINCIPAL -->|"guard / filter"| ENFORCE
+    PRINCIPAL -->|"guard / filter / admit"| ENFORCE
 
     subgraph L3["③ Genesis Admission"]
         GENESIS["AgentSetup hook<br/>establish / inherit / restore"]
     end
 
     subgraph L5["⑤ Enforcement Plane"]
-        ENFORCE["tenant-bound ApiProxy<br/>guard / filter / respond / deny"]
+        ENFORCE["tenant-bound ApiProxy<br/>guard / filter / admit / deny"]
     end
 
     GENESIS --> KERNEL
@@ -68,7 +68,7 @@ flowchart TD
 
 1. **④ 身份** —— 一次 HTTP 请求或 WS 升级被认证；auth 提供方（JWT / OIDC / API key）产出一个绑定到 request/connection 作用域的 `TenantPrincipal`。内核永远看不到认证机制。
 2. **③ 创生** —— 在 `create` / `fork` / `subagent` / `resume` 上，准入装饰器加入 Agent `setup` 钩子，并建立（create）、继承（fork / subagent）、恢复（resume）所有权 —— 全部在 `sessions.enter` 之前，因此没有所有权窗口。
-3. **⑤ 强制** —— 租户绑定的 `ApiProxy` 守卫 point 方法、过滤 collection 与流、并拒绝不可分类的 frame —— 默认拒绝。
+3. **⑤ 强制** —— 租户绑定的 `ApiProxy` 守卫 session-keyed 方法，只对 post-filter 后仍保持正确语义的 collection 做过滤，并拒绝未建模的 host/global surface。`session.create` 属于准入操作，不是普通 ALLOW；stream/respond 在 M4 transport 证明完成前继续默认拒绝。
 4. **① 内核** —— `MultiTenantService` 对 `TenantSessionStore` 授权（一次性认领、不可变、租户边界无条件）。
 5. **② 提供方** —— 所有权在 `TenantSessionStore` 契约之后持久化到内存 / PostgreSQL / Redis / …。
 
@@ -84,7 +84,7 @@ flowchart TD
 
 ## H3 是假设，不是结论
 
-静态分析（M2/M3）得出上游提案收窄为**仅 H3** —— 一个 request/connection-scoped principal seam。这是当前的*假设*；`ctx.agents` 装饰器（③）尚未被运行时证明能加入*每一次* `setup`。若 M4 表明装饰器无法可靠参与，则准入组合性（③）会成为第二个上游缺口（一个 `AgentSetup` 贡献注册表或 agent 创建中间件）。上游提案要等 M4 的真实 runtime 证明之后才写。
+M4 已经运行时证明 `ctx.agents` 装饰器覆盖四条创生路径，因此准入组合性不再是第二个上游假设。当前剩余假设是 **H3**：真实 HTTP/WS transport 需要一个 request/connection-scoped principal 绑定点，使准入与 `ApiProxy` 强制在正确 principal 下执行，而不依赖共享 ambient 状态。上游提案只在 M4 真实 transport 证明完成后提交；如果该证明暴露新的缺口，则提案随证据扩展。
 
 ## 层 → 文档对照
 
@@ -95,4 +95,4 @@ flowchart TD
 | ③ 创生准入 | `./session-genesis-map.md`、`./admission-composition.md`、`../adr/session-genesis.md` |
 | ④ 身份平面 | `../adr/web-enforcement.md`（H3） |
 | ⑤ 强制 | `./web-seam-map.md`、`../adr/web-enforcement.md` |
-| ⑥ preset | `../../ROADMAP.md`（M6/M7） |
+| ⑥ preset | `../../ROADMAP.md`（M7） |

--- a/docs/specs/web-seam-map.md
+++ b/docs/specs/web-seam-map.md
@@ -3,14 +3,16 @@
 # DSH Web Multi-Tenant Seam Map
 
 > Based on `deepseek-ai/deepseek-harness` @ `47f943859bef60e4160492346772ded9b24f765a`
-> (master, 2026-08-15). Preliminary verdicts are refined by the executable
-> prototype; final verdicts land in `../adr/web-enforcement.md`.
+> (master, 2026-08-15). Preliminary verdicts are refined by executable proof;
+> current policy lives in `../adr/web-enforcement.md`.
 >
-> **Converged since this map was written** (see the ADR): **H1** (create→claim
-> atomicity) is resolved by the Agent `setup` hook — admission runs before
-> `sessions.enter` (runtime-proven M4 ②-A). **H4** (respond) is solvable via the
-> facade's `api.respond` wrap. **H3** (principal propagation) remains the one
-> upstream gap; **H2** (resource model) stays deferred.
+> **Converged since this map was first written**: **H1** (create→claim atomicity)
+> is resolved by the Agent `setup` hook — admission runs before `sessions.enter`
+> (runtime-proven M4 ②-A). **H3** (principal propagation) remains the transport
+> hypothesis to prove in ②-C. **H4** (`respond`) is plugin-solvable in principle
+> but is **not closed yet**: the real `ClientResponse` carries `rpcId + result`,
+> not `sessionId`, so authorization needs `rpcId → sessionId` correlation.
+> **H2** (resource model) stays deferred.
 
 ## 1. Summary
 
@@ -19,53 +21,58 @@ DSH Web exposes **five** authorization-relevant surfaces, organized by
 
 | # | Surface | Shape | Enforcement | Seam |
 |---|---|---|---|---|
-| 1 | Unary RPC (`session.history`, …) | Point / Collection | Guard / Filter | `/api` `rpc.intercept()` |
+| 1 | Unary RPC (`session.history`, …) | Point / Collection / Admission | Guard / Filter / Admit / Deny | real `ApiProxy` facade |
 | 2 | `events.mux` | Stream | Filter | `ApiProxy.events.mux()` |
 | 3 | `events.host` | Stream | Filter / deny | `ApiProxy.events.host()` |
-| 4 | `/api/respond` (approval/question) | Response | Guard | `toFetchHandler` special-case |
-| 5 | `session.create` / `fork` | Create | Atomic claim | `core/session` lifecycle |
+| 4 | `/api/respond` (approval/question) | Response | Guard after correlation | `toFetchHandler` special-case |
+| 5 | `session.create` / fork/subagent/resume | Create | Pre-publication ownership admission | Agent `setup` |
 
 ## 2. Matrix
 
-| Resource | Operation | Shape | Enforcement | Physical seam | Evidence | Preliminary verdict |
+| Resource | Operation | Shape | Enforcement | Physical seam | Evidence | Current verdict |
 |---|---|---|---|---|---|---|
-| Session | `history` `prompt` `rename` `fork` `cancel` `models` `selectModel` `attachment` `updateQueue` | Point | Guard | `/api` unary | handler `(endpoint, payload, signal)`; payload carries `sessionId` | **Guardable**; principal propagation open (→H3) |
-| Session | `list` `search` | Collection | Filter | `/api` unary | `session.list`/`session.search` return everything (no `sessionId`) | **Filterable**; same propagation issue (→H3) |
-| Session | `create` `fork` | Create | Atomic claim | Agent `setup` hook | admission in `setup` runs before `sessions.enter` (no window) | **Atomic via `setup`** (H1 resolved — ADR) |
-| Session | mux frames | Stream | Filter | `events.mux` | all-session aggregated (`ctx.sessions.list()` loop); every frame except `stream/error` is `sessionId`-keyed | **Filterable only via facade/upstream** (→H3) |
-| Approval/Question | `respond` | Response | Guard | `/api/respond` | `clientResponseSchema`, not a `ClientRequest`; not in `rpc.intercept()` | **Not covered by unary intercept** (→H4) |
-| Workspace | host frames | Stream | Filter / deny | `events.host` | `HostFrame` mixes session + workspace + host-global | **Requires resource model** (→H2) |
+| Session | `history` `prompt` `rename` `fork` `cancel` `models` `selectModel` `attachment` `updateQueue` | Point | Guard | real `ApiProxy` facade | payload carries `sessionId` | **Guardable**; principal binding still needs ②-C (→H3) |
+| Session | `list` | Collection | Filter | real `ApiProxy` facade | current list returns the complete visible baseline | **Post-filterable**; implemented in ②-B |
+| Session | `search` | Query-scoped collection | Deny for v0 | real `ApiProxy` facade | globally ranked/capped (20) + `hasMore`; post-filtering can discard tenant-owned lower-ranked matches | **Not correctly post-filterable**; needs scoped query semantics |
+| Session | `create` | Create | Admit | Agent `setup` + transport bridge | setup admission runs before `sessions.enter`; caller principal is still missing at transport | **H1 solved; H3/②-C still required** |
+| Session | fork / subagent | Create | Inherit | Agent `setup` | parent id is available in create options | **Runtime-proven admission path** |
+| Session | resume | Create | Restore | Agent `setup` | `resumeSessionId` available; durable owner is authoritative | **Runtime-proven admission path** |
+| Session | mux frames | Stream | Filter | `events.mux` | all-session aggregated; session-bearing frames are keyed | **Pending ②-C** |
+| Approval/Question | `respond` | Response | Guard after correlation | `/api/respond` | incoming `ClientResponse` has `rpcId`, not `sessionId`; outgoing request/pending registry identifies the session | **Pending ②-C correlation proof** (H4) |
+| Workspace | host frames / workspace methods | Host/global resource | Deny in v0 | facade / host stream | no tenant resource model yet | **DENY until H2** |
+| Deployment management | settings / credentials / preset authoring / host-scoped LLM config | Host-global privileged surface | Deny in v0 | real `ApiProxy` facade | modifies or reveals deployment-level configuration/capabilities | **DENY** |
 
 ## 3. Unary RPC surface (`RpcMethodMap` — closed typed union)
 
-The `/api` unary surface is a **generated, closed union** (compiled into the
-Typert registry; `rpc.intercept('/api', …)` decodes `endpoint` + `payload`).
-This is what makes **compile-time exhaustive coverage** feasible: the plugin can
-classify every member and fail to build when DSH adds a new one.
+The `/api` unary surface is a **generated, closed map**. `dsh-multi-tenant-web`
+now imports the real `RpcMethodMap` and defines:
+
+```ts
+Record<keyof RpcMethodMap, Category>
+```
+
+so a new DSH method or a misspelled classification key fails `tsc` instead of
+silently falling through. The runtime backstop still treats unknown string
+methods as `deny`.
 
 Namespaces / methods (52 total):
 
-| Namespace | Methods | sessionId-bearing |
+| Namespace | Methods | Tenant-security treatment |
 |---|---|---|
-| `session.*` | `list` `search` `create` `history` `models` `selectModel` `rename` `fork` `prompt` `attachment` `updateQueue` `cancel` | all except `list`/`search`/`create` |
-| `subagent.*` | `list` `history` `prompt` `interrupt` | all (`parentSessionId`) |
-| `host.*` | `describe` `pickDirectory` `listDirectory` `createDirectory` `openPath` | none (host-global) |
-| `workspace.*` | `list` `create` `rename` `delete` `insertBefore` `insertSessionBefore` `archiveSession` | `archiveSession`/`insertSessionBefore` reference sessions (workspace-scoped) |
-| `goal.*` | `create` `edit` `pause` `resume` `complete` `clear` | all (`sessionId`) |
-| `skill.*` | `list` | `sessionId` |
-| `agentPreset.*` | `list` `select` `read` `copy` `openDocument` `remove` | `select` (`sessionId`) |
-| `settings.*` | `describe` `openDocument` `update` `replace` `mutate` | none |
-| `credentials.*` | `describe` `set` `unset` | none |
-| `llm.*` | `providers` `models` `discoverModels` | none |
+| `session.*` | `list` `search` `create` `history` `models` `selectModel` `rename` `fork` `prompt` `attachment` `updateQueue` `cancel` | list=FILTER; search=DENY pending scoped query; create=ADMIT; remaining session-keyed methods=GUARD |
+| `subagent.*` | `list` `history` `prompt` `interrupt` | GUARD on `parentSessionId` |
+| `host.*` | `describe` `pickDirectory` `listDirectory` `createDirectory` `openPath` | DENY (host-global) |
+| `workspace.*` | `list` `create` `rename` `delete` `insertBefore` `insertSessionBefore` `archiveSession` | DENY until H2 |
+| `goal.*` | `create` `edit` `pause` `resume` `complete` `clear` | GUARD on `sessionId` |
+| `skill.*` | `list` | GUARD on `sessionId` |
+| `agentPreset.*` | `list` `select` `read` `copy` `openDocument` `remove` | list=ALLOW picker discovery; select=GUARD; authoring/inspection=DENY |
+| `settings.*` | `describe` `openDocument` `update` `replace` `mutate` | DENY (deployment configuration) |
+| `credentials.*` | `describe` `set` `unset` | DENY (deployment credentials) |
+| `llm.*` | `providers` `models` `discoverModels` | DENY for v0 (host-scoped configuration/catalog); guarded `session.models` remains available |
 
-**Enforcement implication**: session-keyed methods are POINT guards
-(`assertSessionAccess(principal, payload.sessionId)` — or `payload.parentSessionId`
-for `subagent.*`); `session.list`/`search` are COLLECTION filters; `host.*` /
-`workspace.*` are host-global DENY; the rest are global-config ALLOW. This is now
-the executable `CLASSIFICATION` table in `dsh-multi-tenant-web` — a new DSH
-method fails `tsc` rather than silently passing as unclassified. The
-**principal** is the open question (→H3), not the `sessionId` (which `payload`
-already carries).
+The important distinction is now explicit: **no session id** does not imply
+**ALLOW**. Host/global privilege surfaces are denied until they have an explicit
+resource/role model.
 
 ## 4. Stream surfaces
 
@@ -82,62 +89,60 @@ type MuxFrame =
   | { type: 'session/queue'; sessionId; … }
   | { type: 'session/jobs'; sessionId; … }
   | { type: 'session/projection'; sessionId; … }
-  | { type: 'stream/error'; error }        // ← no sessionId
-```
-
-Every frame except `stream/error` is `sessionId`-keyed → filterable by
-`principal can access sessionId`. The aggregation point is the whole-stream
-filter problem (→H3).
-
-### 4.2 `events.host` — `HostFrame` (mixed resource)
-
-```ts
-type HostFrame =
-  | { type: 'host/session-added'; sessionId; … }
-  | { type: 'host/session-removed'; sessionId }
-  | { type: 'host/session-status'; sessionId; … }
-  | { type: 'host/agent-error'; sessionId; … }
-  | { type: 'host/workspace-changed'; workspace }            // ← workspace
-  | { type: 'host/workspace-removed'; workspaceId }          // ← workspace
-  | { type: 'host/workspace-order-changed'; workspaceIds }   // ← workspace
-  | { type: 'host/archived-sessions-changed'; archivedSessionIds }  // ← list
-  | { type: 'host/remote-event'; event; args }               // ← host-global
   | { type: 'stream/error'; error }
 ```
 
-`events.host` is **not** a pure session stream — it carries Workspace and
-host-global frames. This is what forces the resource-ownership question (→H2):
-is Workspace tenant-owned? If yes, `SessionOwner` is insufficient. If no,
-which host frames must be denied in multi-tenant mode?
+Session-bearing frames can be filtered by ownership once a principal is bound to
+the connection. Unclassifiable/control/error frames need an explicit redact or
+terminate policy; they must not be blindly attributed to a tenant.
+
+### 4.2 `events.host` — `HostFrame` (mixed resource)
+
+`events.host` mixes Session, Workspace, and host-global frames. v0 therefore
+allows only explicitly session-keyed frames that pass ownership and denies the
+rest until H2 defines Workspace/host resource ownership.
 
 ## 5. `/api/respond` (bidirectional)
 
-Approval/question is server-initiated: `approval/requested` → browser answers →
-`POST /api/respond` with a `ClientResponse` (`clientResponseSchema`), **not** a
-`ClientRequest`. The unary `rpc.intercept()` path decodes `ClientRequest` only;
-`toFetchHandler` special-cases `/api/respond`. The response payload carries
-`sessionId`, so ownership **is** checkable — but there is no shared seam with the
-unary path (→H4). Resolved by the facade's `api.respond` wrap (ADR).
+Approval/question is server-initiated: the host emits a `ServerRequest` carrying
+its `rpcId` and session-bearing payload; the browser replies with a
+`ClientResponse` over `POST /api/respond`. The **incoming response itself does
+not carry `sessionId`** — it carries only `rpcId` and `result`.
 
-## 6. Seams and gaps (→ Hard Conclusions)
+Therefore the tenant guard must keep or query a pending correlation:
 
-| Gap | Evidence | Feeds |
+```text
+outgoing server request
+rpcId -> sessionId
+        ↓
+incoming ClientResponse(rpcId)
+        ↓
+resolve sessionId
+        ↓
+assertSessionAccess(principal, sessionId)
+        ↓
+api.respond(...)
+```
+
+This is currently fail-closed in `bindTenant` and remains M4 ②-C work. No
+respond-specific upstream seam is assumed until the real transport proof says
+one is necessary.
+
+## 6. Seams and gaps
+
+| Gap | Evidence | Status |
 |---|---|---|
-| Unary handler has no principal/Request | `ConnectionRpcHandler = (endpoint, payload, signal)` | H3 |
-| Mux/host streams are global | `WebSocketDownlinks` holds one `ApiProxy`; `events.mux` aggregates `ctx.sessions.list()` | H3 |
-| `/api/respond` bypasses unary intercept | `clientResponseSchema` special-case in `toFetchHandler` | ~~H4~~ resolved (facade `api.respond` wrap) |
-| ~~create→claim race~~ | `session.create(id?: SessionId)`; core has no `release`/`reassign` | ~~H1~~ resolved (`setup` hook, M4 ②-A) |
-| host stream exposes Workspace + host-global | `HostFrame` union includes `workspace-*`, `remote-event` | H2 |
+| Request/connection has no proven principal binding point | unary handler drops Request; WS/HTTP collapse into shared services | H3 hypothesis — prove in ②-C |
+| Mux/host streams are global | shared `ApiProxy` / aggregated streams | ②-C |
+| `/api/respond` identifies the pending interaction by `rpcId`, not `sessionId` | real `ClientResponse` shape | H4 correlation proof pending ②-C |
+| ~~create→claim race~~ | Agent setup runs admission before `sessions.enter` | ~~H1~~ resolved (M4 ②-A) |
+| host/workspace/config surfaces have no tenant resource model | host-global contracts | DENY; H2 / privilege model deferred |
+| `session.search` is globally capped/ranked | max 20 + `hasMore` | scoped query seam/design pending |
 
 ## 7. Ecosystem notes
 
-- **Stale `latest` dist-tags.** `@deepseek-ai/dsh-{host-apiproxy,session,client-connection,tools}`
-  publish `latest` → `0.0.1-rc.1` while the newest published version is
-  `0.1.0-rc.6`. Consumers must pin an explicit prerelease version
-  (`…@0.1.0-rc.6`), never `latest`. This is a footgun for third-party plugins
-  and matters for how `dsh-multi-tenant-web` declares DSH deps.
-- **`ApiProxy` shape.** The real surface is a large namespace object
-  (`sessions` / `subagents` / `host` / `workspace` / `skills` / `agentPresets` /
-  `events` / `goals` / `settings` / `credentials` / `llm` / `respond`), with
-  methods wrapped in `RpcRequest`/`RpcResponse`. The prototype's `ApiSurface`
-  is a spike-local simplification of the session-bearing subset.
+- **Stale `latest` dist-tags.** Consumers pin explicit prerelease versions rather
+  than relying on `latest` while the DSH prerelease tags remain inconsistent.
+- **Real `ApiProxy`.** The web package now compiles against the real
+  `@deepseek-ai/dsh-host-apiproxy/api` contract; the old spike-local `ApiSurface`
+  has been removed.

--- a/docs/specs/web-seam-map.zh-CN.md
+++ b/docs/specs/web-seam-map.zh-CN.md
@@ -3,107 +3,107 @@
 # DSH Web 多租户 Seam 图
 
 > 基于 `deepseek-ai/deepseek-harness` @ `47f943859bef60e4160492346772ded9b24f765a`
-> （master，2026-08-15）。初步判定由可执行原型细化；最终判定落在 `../adr/web-enforcement.md`。
+> （master，2026-08-15）。初步判定由可执行证据不断细化；当前策略以 `../adr/web-enforcement.md` 为准。
 >
-> **本图成文后已收敛**（见 ADR）：**H1**（create→claim 原子性）由 Agent `setup` 钩子解决 —— 准入在 `sessions.enter` 之前运行（M4 ②-A 运行时证明）。**H4**（respond）可经 facade 的 `api.respond` 包装解决。**H3**（principal 传播）仍是唯一上游缺口；**H2**（资源模型）仍延后。
+> **本图最初成文后已收敛**：**H1**（create→claim 原子性）由 Agent `setup` 钩子解决 —— 准入在 `sessions.enter` 之前运行（M4 ②-A 运行时证明）。**H3**（principal 传播）仍是 ②-C 要验证的 transport 假设。**H4**（`respond`）原则上可由插件解决，但**尚未闭环**：真实 `ClientResponse` 只有 `rpcId + result`，没有 `sessionId`，因此授权需要 `rpcId → sessionId` 关联。**H2**（资源模型）仍延后。
 
 ## 1. 概述
 
-DSH Web 暴露**五个**与授权相关的 surface，按 **Resource × Access Shape → Enforcement**（而非按 transport）组织：
+DSH Web 暴露**五类**与授权相关的 surface，按 **Resource × Access Shape → Enforcement**（而非按 transport）组织：
 
 | # | Surface | Shape | Enforcement | Seam |
 |---|---|---|---|---|
-| 1 | Unary RPC（`session.history`，…） | Point / Collection | Guard / Filter | `/api` `rpc.intercept()` |
+| 1 | Unary RPC（`session.history`，…） | Point / Collection / Admission | Guard / Filter / Admit / Deny | 真实 `ApiProxy` facade |
 | 2 | `events.mux` | Stream | Filter | `ApiProxy.events.mux()` |
 | 3 | `events.host` | Stream | Filter / deny | `ApiProxy.events.host()` |
-| 4 | `/api/respond`（approval/question） | Response | Guard | `toFetchHandler` 特例 |
-| 5 | `session.create` / `fork` | Create | Atomic claim | `core/session` 生命周期 |
+| 4 | `/api/respond`（approval/question） | Response | correlation 后 Guard | `toFetchHandler` 特例 |
+| 5 | `session.create` / fork/subagent/resume | Create | 发布前所有权准入 | Agent `setup` |
 
 ## 2. 矩阵
 
-| Resource | Operation | Shape | Enforcement | Physical seam | Evidence | 初步判定 |
+| Resource | Operation | Shape | Enforcement | Physical seam | Evidence | 当前判定 |
 |---|---|---|---|---|---|---|
-| Session | `history` `prompt` `rename` `fork` `cancel` `models` `selectModel` `attachment` `updateQueue` | Point | Guard | `/api` unary | handler `(endpoint, payload, signal)`；payload 携带 `sessionId` | **可守卫**；principal 传播待定（→H3） |
-| Session | `list` `search` | Collection | Filter | `/api` unary | `session.list`/`session.search` 返回全部（无 `sessionId`） | **可过滤**；同一传播问题（→H3） |
-| Session | `create` `fork` | Create | Atomic claim | Agent `setup` 钩子 | 准入在 `setup` 内、`sessions.enter` 之前运行（无窗口） | **经 `setup` 原子**（H1 已解决 — ADR） |
-| Session | mux frames | Stream | Filter | `events.mux` | 全 session 聚合（`ctx.sessions.list()` 循环）；除 `stream/error` 外的每个 frame 都以 `sessionId` 为键 | **仅能经 facade/上游过滤**（→H3） |
-| Approval/Question | `respond` | Response | Guard | `/api/respond` | `clientResponseSchema`，非 `ClientRequest`；不在 `rpc.intercept()` 内 | **未被 unary intercept 覆盖**（→H4） |
-| Workspace | host frames | Stream | Filter / deny | `events.host` | `HostFrame` 混合 session + workspace + host-global | **需要资源模型**（→H2） |
+| Session | `history` `prompt` `rename` `fork` `cancel` `models` `selectModel` `attachment` `updateQueue` | Point | Guard | 真实 `ApiProxy` facade | payload 携带 `sessionId` | **可守卫**；principal 绑定仍需 ②-C（→H3） |
+| Session | `list` | Collection | Filter | 真实 `ApiProxy` facade | 当前 list 返回完整 baseline | **可正确 post-filter**；②-B 已实现 |
+| Session | `search` | Query-scoped collection | v0 Deny | 真实 `ApiProxy` facade | 全局排序、最多 20 条 + `hasMore`；事后过滤会丢失本租户排名更靠后的结果 | **不能正确 post-filter**；需要 scoped query 语义 |
+| Session | `create` | Create | Admit | Agent `setup` + transport bridge | setup 准入在 `sessions.enter` 之前运行；transport 仍缺 caller principal | **H1 已解；仍需 H3/②-C** |
+| Session | fork / subagent | Create | Inherit | Agent `setup` | create options 中可拿到 parent id | **准入路径已运行时证明** |
+| Session | resume | Create | Restore | Agent `setup` | `resumeSessionId` 可得；durable owner 为权威 | **准入路径已运行时证明** |
+| Session | mux frames | Stream | Filter | `events.mux` | 全 session 聚合，session frame 有键 | **待 ②-C** |
+| Approval/Question | `respond` | Response | correlation 后 Guard | `/api/respond` | incoming `ClientResponse` 只有 `rpcId`，没有 `sessionId`；外发 request / pending registry 能定位 session | **待 ②-C correlation 证明**（H4） |
+| Workspace | host frames / workspace methods | Host/global resource | v0 Deny | facade / host stream | 尚无 tenant resource model | **H2 前 DENY** |
+| Deployment management | settings / credentials / preset authoring / host-scoped LLM config | Host-global privileged surface | v0 Deny | 真实 `ApiProxy` facade | 会修改或暴露 deployment 级配置/能力 | **DENY** |
 
-## 3. Unary RPC surface（`RpcMethodMap` — 封闭 typed union）
+## 3. Unary RPC surface（`RpcMethodMap` — 封闭 typed map）
 
-`/api` unary surface 是一个**生成的、封闭 union**（编译进 Typert 注册表；`rpc.intercept('/api', …)` 解码 `endpoint` + `payload`）。这正使**编译期穷举覆盖**变得可行：插件可以分类每一个成员，并在 DSH 新增方法时构建失败。
+`/api` unary surface 是一个生成的封闭 map。`dsh-multi-tenant-web` 现在直接导入真实 `RpcMethodMap` 并定义：
+
+```ts
+Record<keyof RpcMethodMap, Category>
+```
+
+因此 DSH 新增方法或分类 key 拼错都会让 `tsc` 失败，而不是静默放过。运行时对未知字符串方法仍默认 `deny`。
 
 命名空间 / 方法（共 52 个）：
 
-| 命名空间 | 方法 | 承载 sessionId |
+| 命名空间 | 方法 | 多租户安全处理 |
 |---|---|---|
-| `session.*` | `list` `search` `create` `history` `models` `selectModel` `rename` `fork` `prompt` `attachment` `updateQueue` `cancel` | 除 `list`/`search`/`create` 外全部 |
-| `subagent.*` | `list` `history` `prompt` `interrupt` | 全部（`parentSessionId`） |
-| `host.*` | `describe` `pickDirectory` `listDirectory` `createDirectory` `openPath` | 无（host-global） |
-| `workspace.*` | `list` `create` `rename` `delete` `insertBefore` `insertSessionBefore` `archiveSession` | `archiveSession`/`insertSessionBefore` 引用 session（workspace 作用域） |
-| `goal.*` | `create` `edit` `pause` `resume` `complete` `clear` | 全部（`sessionId`） |
-| `skill.*` | `list` | `sessionId` |
-| `agentPreset.*` | `list` `select` `read` `copy` `openDocument` `remove` | `select`（`sessionId`） |
-| `settings.*` | `describe` `openDocument` `update` `replace` `mutate` | 无 |
-| `credentials.*` | `describe` `set` `unset` | 无 |
-| `llm.*` | `providers` `models` `discoverModels` | 无 |
+| `session.*` | `list` `search` `create` `history` `models` `selectModel` `rename` `fork` `prompt` `attachment` `updateQueue` `cancel` | list=FILTER；search=DENY（待 scoped query）；create=ADMIT；其他 session-keyed 方法=GUARD |
+| `subagent.*` | `list` `history` `prompt` `interrupt` | 在 `parentSessionId` 上 GUARD |
+| `host.*` | `describe` `pickDirectory` `listDirectory` `createDirectory` `openPath` | DENY（host-global） |
+| `workspace.*` | `list` `create` `rename` `delete` `insertBefore` `insertSessionBefore` `archiveSession` | H2 前 DENY |
+| `goal.*` | `create` `edit` `pause` `resume` `complete` `clear` | 在 `sessionId` 上 GUARD |
+| `skill.*` | `list` | 在 `sessionId` 上 GUARD |
+| `agentPreset.*` | `list` `select` `read` `copy` `openDocument` `remove` | list=ALLOW（picker）；select=GUARD；authoring/inspection=DENY |
+| `settings.*` | `describe` `openDocument` `update` `replace` `mutate` | DENY（deployment 配置） |
+| `credentials.*` | `describe` `set` `unset` | DENY（deployment 凭据） |
+| `llm.*` | `providers` `models` `discoverModels` | v0 DENY（host-scoped 配置/目录）；仍可使用受 GUARD 的 `session.models` |
 
-**强制含义**：session 为键的方法是 POINT guard（`assertSessionAccess(principal, payload.sessionId)` —— `subagent.*` 则为 `payload.parentSessionId`）；`session.list`/`search` 是 COLLECTION filter；`host.*` / `workspace.*` 是 host-global DENY；其余是全局配置 ALLOW。这已落为 `dsh-multi-tenant-web` 中可执行的 `CLASSIFICATION` 表 —— 新增 DSH 方法会令 `tsc` 失败，而非静默地作为未分类通过。悬而未决的是 **principal**（→H3），而非 `sessionId`（`payload` 已携带）。
+这里的关键区别是：**没有 sessionId 不等于 ALLOW**。Host/global 权限面在建立明确资源/角色模型之前一律拒绝。
 
 ## 4. 流 surface
 
 ### 4.1 `events.mux` — `MuxFrame`（全 session 聚合）
 
-```ts
-type MuxFrame =
-  | { type: 'session/event'; sessionId; … }
-  | { type: 'session/subscribed'; sessionId; … }
-  | { type: 'approval/requested'; sessionId; approvalId; … }
-  | { type: 'approval/resolved'; sessionId; … }
-  | { type: 'question/requested'; sessionId; … }
-  | { type: 'question/resolved'; sessionId; … }
-  | { type: 'session/queue'; sessionId; … }
-  | { type: 'session/jobs'; sessionId; … }
-  | { type: 'session/projection'; sessionId; … }
-  | { type: 'stream/error'; error }        // ← 无 sessionId
-```
-
-除 `stream/error` 外的每个 frame 都以 `sessionId` 为键 → 可由「principal 能否访问 sessionId」过滤。聚合点是整个流的过滤问题（→H3）。
+session-bearing frame 在 connection 已绑定 principal 后可以按所有权过滤。无法归属 tenant 的 control/error frame 需要明确 redact 或 terminate 规则，不能直接归给任意租户。
 
 ### 4.2 `events.host` — `HostFrame`（混合资源）
 
-```ts
-type HostFrame =
-  | { type: 'host/session-added'; sessionId; … }
-  | { type: 'host/session-removed'; sessionId }
-  | { type: 'host/session-status'; sessionId; … }
-  | { type: 'host/agent-error'; sessionId; … }
-  | { type: 'host/workspace-changed'; workspace }            // ← workspace
-  | { type: 'host/workspace-removed'; workspaceId }          // ← workspace
-  | { type: 'host/workspace-order-changed'; workspaceIds }   // ← workspace
-  | { type: 'host/archived-sessions-changed'; archivedSessionIds }  // ← list
-  | { type: 'host/remote-event'; event; args }               // ← host-global
-  | { type: 'stream/error'; error }
-```
-
-`events.host` **不是**纯粹的 session 流 —— 它携带 Workspace 与 host-global frame。这正迫使资源所有权问题浮出（→H2）：Workspace 是否由租户拥有？若是，`SessionOwner` 不够。若否，多租户模式下必须拒绝哪些 host frame？
+`events.host` 混合 Session、Workspace 与 host-global frame。v0 因此只允许明确 session-keyed 且通过所有权检查的 frame，其余在 H2 定义 Workspace/host 资源所有权之前一律拒绝。
 
 ## 5. `/api/respond`（双向）
 
-Approval/question 是服务端发起的：`approval/requested` → 浏览器应答 → 携带 `ClientResponse`（`clientResponseSchema`）的 `POST /api/respond`，**而非** `ClientRequest`。unary `rpc.intercept()` 路径只解码 `ClientRequest`；`toFetchHandler` 特判 `/api/respond`。响应 payload 携带 `sessionId`，因此所有权**是**可检查的 —— 但与 unary 路径之间没有共享 seam（→H4）。经 facade 的 `api.respond` 包装解决（ADR）。
+Approval/question 是服务端发起的：Host 发出一个带 `rpcId` 和 session-bearing payload 的 `ServerRequest`；浏览器再通过 `POST /api/respond` 回一个 `ClientResponse`。**incoming response 自己不带 `sessionId`** —— 只有 `rpcId` 和 `result`。
 
-## 6. Seam 与缺口（→ 硬结论）
+因此 tenant guard 必须维护或查询 pending correlation：
 
-| 缺口 | Evidence | 导向 |
+```text
+outgoing server request
+rpcId -> sessionId
+        ↓
+incoming ClientResponse(rpcId)
+        ↓
+resolve sessionId
+        ↓
+assertSessionAccess(principal, sessionId)
+        ↓
+api.respond(...)
+```
+
+当前 `bindTenant` 对它默认拒绝，仍属于 M4 ②-C。除非真实 transport 证明必须，否则不预设需要 respond 专用上游 seam。
+
+## 6. Seam 与缺口
+
+| 缺口 | Evidence | 状态 |
 |---|---|---|
-| Unary handler 无 principal/Request | `ConnectionRpcHandler = (endpoint, payload, signal)` | H3 |
-| Mux/host 流是全局的 | `WebSocketDownlinks` 持有一个 `ApiProxy`；`events.mux` 聚合 `ctx.sessions.list()` | H3 |
-| `/api/respond` 绕过 unary intercept | `toFetchHandler` 中的 `clientResponseSchema` 特例 | ~~H4~~ 已解决（facade `api.respond` 包装） |
-| ~~create→claim 竞态~~ | `session.create(id?: SessionId)`；core 无 `release`/`reassign` | ~~H1~~ 已解决（`setup` 钩子，M4 ②-A） |
-| host 流暴露 Workspace + host-global | `HostFrame` union 含 `workspace-*`、`remote-event` | H2 |
+| Request/connection 尚无被证明的 principal 绑定点 | unary handler 丢失 Request；HTTP/WS 后进入共享服务 | H3 假设 —— ②-C 验证 |
+| Mux/host 流是全局的 | shared `ApiProxy` / aggregated streams | ②-C |
+| `/api/respond` 仅凭 `rpcId` 标识 pending interaction | 真实 `ClientResponse` 结构 | H4 correlation 待 ②-C 证明 |
+| ~~create→claim 竞态~~ | Agent setup 在 `sessions.enter` 前执行准入 | ~~H1~~ 已解决（M4 ②-A） |
+| host/workspace/config surface 无 tenant resource model | host-global contracts | DENY；H2 / 权限模型延后 |
+| `session.search` 全局限量/排序 | max 20 + `hasMore` | scoped query seam/design 待定 |
 
 ## 7. 生态备注
 
-- **过期的 `latest` dist-tag。** `@deepseek-ai/dsh-{host-apiproxy,session,client-connection,tools}` 发布 `latest` → `0.0.1-rc.1`，而最新发布版本是 `0.1.0-rc.6`。消费者必须 pin 显式 prerelease 版本（`…@0.1.0-rc.6`），绝不用 `latest`。这对第三方插件是个陷阱，也关系到 `dsh-multi-tenant-web` 如何声明 DSH 依赖。
-- **`ApiProxy` 形态。** 真实 surface 是一个大型命名空间对象（`sessions` / `subagents` / `host` / `workspace` / `skills` / `agentPresets` / `events` / `goals` / `settings` / `credentials` / `llm` / `respond`），其方法被包裹在 `RpcRequest`/`RpcResponse` 中。原型的 `ApiSurface` 是对承载 session 子集的 spike 局部简化。
+- **过期的 `latest` dist-tag。** DSH prerelease tag 仍不稳定时，消费者 pin 显式 prerelease 版本，而不是依赖 `latest`。
+- **真实 `ApiProxy`。** Web 包现在已经直接编译到真实 `@deepseek-ai/dsh-host-apiproxy/api` 契约；旧的 spike-local `ApiSurface` 已删除。

--- a/packages/multi-tenant-web/README.md
+++ b/packages/multi-tenant-web/README.md
@@ -10,10 +10,15 @@ DSH Web multi-tenant integration: principal binding, RPC/mux/WS authorization.
 
 ## Status
 
-M4 in progress: the admission decorator (②-A) and the real `ApiProxy` facade
-with exhaustive classification (②-B) are done. `bindTenant` wraps the real
-`@deepseek-ai/dsh-host-apiproxy` `ApiProxy`; `CLASSIFICATION` assigns every one
-of the 52 unary RPC methods an `allow` / `guard` / `filter` / `deny` verdict (a
-new DSH method fails `tsc`). Streams (`events`) and `respond` are denied until
-②-C / H4. The one remaining upstream gap is a request/connection-scoped
-principal (H3). See [`docs/adr/web-enforcement.md`](../../docs/adr/web-enforcement.md).
+M4 is in progress. The admission decorator (②-A) and the real `ApiProxy` facade
+with exhaustive unary classification (②-B) are done. `CLASSIFICATION` covers
+all 52 current unary RPC methods and a new DSH method fails `tsc` until it is
+classified.
+
+The v0 policy is deliberately fail-closed: session-keyed point methods are
+`guard`, only `session.list` is currently safe to `filter`, `session.create` is
+`admit` (denied until the transport installs the pre-publication admission
+bridge), and unmodelled host/deployment management plus `session.search` are
+`deny`. Streams (`events`), `respond`, and `downloads` remain denied until ②-C
+proves their real transport authorization path. H3 remains the principal-
+binding hypothesis to validate, not a filed upstream conclusion yet.

--- a/packages/multi-tenant-web/README.zh-CN.md
+++ b/packages/multi-tenant-web/README.zh-CN.md
@@ -8,4 +8,6 @@ DSH Web 多租户集成：主体绑定、RPC/mux/WS 授权。
 
 ## 状态
 
-M4 进行中：准入装饰器（②-A）与真实 `ApiProxy` facade + 穷举分类（②-B）已完成。`bindTenant` 包装真实的 `@deepseek-ai/dsh-host-apiproxy` `ApiProxy`；`CLASSIFICATION` 为全部 52 个 unary RPC 方法赋 `allow` / `guard` / `filter` / `deny` 判定（新增 DSH 方法会令 `tsc` 失败）。流（`events`）与 `respond` 在 ②-C / H4 之前按拒绝处理。唯一剩余的上游缺口是 request/connection-scoped principal（H3）。见 [`docs/adr/web-enforcement.md`](../../docs/adr/web-enforcement.md)。
+M4 进行中。准入装饰器（②-A）与真实 `ApiProxy` facade + unary 穷举分类（②-B）已完成。`CLASSIFICATION` 覆盖当前全部 52 个 unary RPC 方法；DSH 新增方法时，未分类前会直接令 `tsc` 失败。
+
+v0 策略刻意默认拒绝：session-keyed point 方法为 `guard`，目前只有 `session.list` 适合 `filter`，`session.create` 为 `admit`（transport 尚未安装发布前准入 bridge 时直接拒绝），未建模的 host/deployment 管理面以及 `session.search` 都为 `deny`。流（`events`）、`respond` 与 `downloads` 在 ②-C 证明真实 transport 授权路径之前继续拒绝。H3 仍是待验证的 principal 绑定假设，而不是已经提交的上游结论。

--- a/packages/multi-tenant-web/src/bind-tenant.ts
+++ b/packages/multi-tenant-web/src/bind-tenant.ts
@@ -5,12 +5,13 @@
  * and enforces the tenant boundary per method, driven by the exhaustive
  * `CLASSIFICATION` table in `./classification.ts`:
  *
- *   - `allow`  — pass through unchanged.
+ *   - `allow`  — explicitly tenant-neutral read-only discovery; pass through.
  *   - `guard`  — assert `assertSessionAccess` on the payload's session id before
  *     delegating (throws a uniform `SessionAccessDeniedError` on denial).
- *   - `filter` — project `session.list` / `session.search` results to the
- *     sessions the principal may access.
- *   - `deny`   — fail closed (host-global / workspace surfaces; unclassified).
+ *   - `filter` — project post-filterable collections to visible sessions.
+ *   - `admit`  — requires the pre-publication Agent `setup` admission bridge;
+ *     denied by the standalone facade until M4 ②-C installs that bridge.
+ *   - `deny`   — fail closed (host/global/unmodelled surfaces).
  *
  * The principal is **closed over**, never written to any shared/ambient context,
  * so concurrent tenants cannot cross-talk. The proxy is the runtime dispatcher;
@@ -55,9 +56,7 @@ function methodName(namespace: string, method: string): string {
   return `${NAMESPACE_PREFIX[namespace] ?? namespace}.${method}`
 }
 
-/**
- * Return `api` narrowed to the sessions `principal` may access.
- */
+/** Return `api` narrowed to the sessions `principal` may access. */
 export function bindTenant(
   api: ApiProxy,
   principal: TenantPrincipal,
@@ -68,6 +67,7 @@ export function bindTenant(
     switch (classify(name)) {
       case 'allow':
         return fn
+      case 'admit':
       case 'deny':
         return deny
       case 'guard':

--- a/packages/multi-tenant-web/src/classification.ts
+++ b/packages/multi-tenant-web/src/classification.ts
@@ -8,22 +8,22 @@
  * silently pass through as unclassified.
  *
  * Categories:
- *   - `allow`  — no session identity; pass through unchanged (global config:
- *               settings, credentials, llm, agent-preset management, and
- *               `session.create`, whose ownership is established downstream in
- *               the Agent `setup` admission hook).
+ *   - `allow`  — explicitly tenant-neutral read-only discovery that is safe to
+ *               expose unchanged.
  *   - `guard`  — a point method whose payload carries a session id; the facade
  *               asserts `assertSessionAccess` before delegating.
- *   - `filter` — a collection method (`session.list` / `session.search`) whose
- *               result is projected to the sessions the principal may access.
- *   - `deny`   — host-global / workspace surfaces that cannot be tenant-isolated
- *               until the resource model (H2) is decided; fail closed.
+ *   - `filter` — a collection that is semantically safe to post-filter by
+ *               session ownership (`session.list` today).
+ *   - `admit`  — creates a new tenant-owned resource and therefore requires the
+ *               pre-publication Agent `setup` admission path. The standalone
+ *               ApiProxy facade denies it until that bridge is installed.
+ *   - `deny`   — host/global or otherwise unmodelled surfaces; fail closed.
  *
  * @module dsh-multi-tenant-web/classification
  */
 import type { RpcMethodMap } from '@deepseek-ai/dsh-host-apiproxy/api'
 
-export type Category = 'allow' | 'guard' | 'filter' | 'deny'
+export type Category = 'allow' | 'guard' | 'filter' | 'admit' | 'deny'
 
 /**
  * Method name → category. Annotation (not `satisfies`) so both a *missing* key
@@ -32,8 +32,13 @@ export type Category = 'allow' | 'guard' | 'filter' | 'deny'
 export const CLASSIFICATION: Record<keyof RpcMethodMap, Category> = {
   // session.*
   'session.list': 'filter',
-  'session.search': 'filter',
-  'session.create': 'allow',
+  // Search is capped/ranked globally (20 results + hasMore). Post-filtering can
+  // hide a tenant's lower-ranked matches, so it is not a correct tenant-scoped
+  // query until DSH exposes a visibility predicate / scoped candidate set.
+  'session.search': 'deny',
+  // Creation is not ordinary ALLOW: ownership must be established in Agent
+  // setup before publication. The transport/admission bridge lands in M4 ②-C.
+  'session.create': 'admit',
   'session.history': 'guard',
   'session.models': 'guard',
   'session.selectModel': 'guard',
@@ -64,13 +69,14 @@ export const CLASSIFICATION: Record<keyof RpcMethodMap, Category> = {
   'workspace.archiveSession': 'deny',
   // skill.* — session-contextual listing.
   'skill.list': 'guard',
-  // agentPreset.* — management is global; `select` targets one session.
+  // agentPreset.list is picker discovery; select targets one guarded session.
+  // Authoring/inspection calls are deployment-management surfaces → deny.
   'agentPreset.list': 'allow',
   'agentPreset.select': 'guard',
-  'agentPreset.read': 'allow',
-  'agentPreset.copy': 'allow',
-  'agentPreset.openDocument': 'allow',
-  'agentPreset.remove': 'allow',
+  'agentPreset.read': 'deny',
+  'agentPreset.copy': 'deny',
+  'agentPreset.openDocument': 'deny',
+  'agentPreset.remove': 'deny',
   // goal.* — session-scoped (each goal carries its sessionId).
   'goal.create': 'guard',
   'goal.edit': 'guard',
@@ -78,20 +84,22 @@ export const CLASSIFICATION: Record<keyof RpcMethodMap, Category> = {
   'goal.resume': 'guard',
   'goal.complete': 'guard',
   'goal.clear': 'guard',
-  // settings.* — deployment/global config, not session data.
-  'settings.describe': 'allow',
-  'settings.openDocument': 'allow',
-  'settings.update': 'allow',
-  'settings.replace': 'allow',
-  'settings.mutate': 'allow',
-  // credentials.* — global credential management.
-  'credentials.describe': 'allow',
-  'credentials.set': 'allow',
-  'credentials.unset': 'allow',
-  // llm.* — global provider/model catalog.
-  'llm.providers': 'allow',
-  'llm.models': 'allow',
-  'llm.discoverModels': 'allow',
+  // settings.* — deployment/global configuration. DSH documents these as
+  // loopback/configuration-plane surfaces, including write-only secrets.
+  'settings.describe': 'deny',
+  'settings.openDocument': 'deny',
+  'settings.update': 'deny',
+  'settings.replace': 'deny',
+  'settings.mutate': 'deny',
+  // credentials.* — deployment credential management, never tenant-session data.
+  'credentials.describe': 'deny',
+  'credentials.set': 'deny',
+  'credentials.unset': 'deny',
+  // llm.* — host-scoped provider/configuration catalog. Session-scoped model
+  // discovery remains available through guarded `session.models`.
+  'llm.providers': 'deny',
+  'llm.models': 'deny',
+  'llm.discoverModels': 'deny',
 }
 
 /**

--- a/packages/multi-tenant-web/tests/bind-tenant.test.ts
+++ b/packages/multi-tenant-web/tests/bind-tenant.test.ts
@@ -27,6 +27,7 @@ function makeStubApi(): ApiProxy {
     sessions: {
       list: async (req: any) => ok(req.rpcId, { items: [{ sessionId: 's1' }, { sessionId: 's2' }] }),
       search: async (req: any) => ok(req.rpcId, { items: [{ sessionId: 's1' }, { sessionId: 's2' }], hasMore: false }),
+      create: async (req: any) => ok(req.rpcId, { sessionId: 'new' }),
       history: async (req: any) => ok(req.rpcId, { historyOf: req.payload.sessionId }),
     },
     subagents: {
@@ -35,31 +36,46 @@ function makeStubApi(): ApiProxy {
     host: {
       describe: async (req: any) => ok(req.rpcId, {}),
     },
+    settings: {
+      describe: async (req: any) => ok(req.rpcId, {}),
+    },
+    credentials: {
+      set: async (req: any) => ok(req.rpcId, {}),
+    },
     llm: {
       models: async (req: any) => ok(req.rpcId, {}),
+    },
+    agentPresets: {
+      list: async (req: any) => ok(req.rpcId, { presets: [] }),
+      read: async (req: any) => ok(req.rpcId, {}),
     },
     respond: async () => ({ accepted: true }),
   } as unknown as ApiProxy
 }
 
 describe('CLASSIFICATION (exhaustive — compile-time guaranteed by Record<keyof RpcMethodMap, …>)', () => {
-  it('maps session-keyed methods to guard, collections to filter', () => {
+  it('guards session-keyed methods and only post-filters safe collections', () => {
     expect(CLASSIFICATION['session.history']).toBe('guard')
     expect(CLASSIFICATION['session.list']).toBe('filter')
-    expect(CLASSIFICATION['session.search']).toBe('filter')
+    expect(CLASSIFICATION['session.search']).toBe('deny')
     expect(CLASSIFICATION['goal.create']).toBe('guard')
     expect(CLASSIFICATION['skill.list']).toBe('guard')
     expect(CLASSIFICATION['agentPreset.select']).toBe('guard')
     expect(CLASSIFICATION['subagent.list']).toBe('guard')
   })
 
-  it('maps create/global-config to allow, host/workspace to deny', () => {
-    expect(CLASSIFICATION['session.create']).toBe('allow')
-    expect(CLASSIFICATION['llm.models']).toBe('allow')
-    expect(CLASSIFICATION['settings.describe']).toBe('allow')
-    expect(CLASSIFICATION['credentials.set']).toBe('allow')
+  it('treats session.create as admission, not ordinary allow', () => {
+    expect(CLASSIFICATION['session.create']).toBe('admit')
+  })
+
+  it('denies deployment-management surfaces by default', () => {
     expect(CLASSIFICATION['host.describe']).toBe('deny')
     expect(CLASSIFICATION['workspace.list']).toBe('deny')
+    expect(CLASSIFICATION['settings.describe']).toBe('deny')
+    expect(CLASSIFICATION['credentials.set']).toBe('deny')
+    expect(CLASSIFICATION['llm.models']).toBe('deny')
+    expect(CLASSIFICATION['agentPreset.read']).toBe('deny')
+    expect(CLASSIFICATION['agentPreset.list']).toBe('allow')
   })
 })
 
@@ -78,16 +94,31 @@ describe('bindTenant facade (real ApiProxy)', () => {
     expect(res.result.value.items.map((item: any) => item.sessionId)).toEqual(['s1'])
   })
 
-  it('denies host-global methods', async () => {
+  it('denies search until tenant-scoped query semantics exist', async () => {
     const multiTenant = await makeMultiTenant()
     const facade = bindTenant(makeStubApi(), alice, multiTenant)
-    await expect((facade.host as any).describe({ rpcId: 'r', payload: {} })).rejects.toThrow(SessionAccessDeniedError)
+    await expect((facade.sessions as any).search({ rpcId: 'r', payload: { query: 'x' } })).rejects.toThrow(SessionAccessDeniedError)
   })
 
-  it('allows global-config methods through unchanged', async () => {
+  it('denies session.create until the admission bridge is installed', async () => {
     const multiTenant = await makeMultiTenant()
     const facade = bindTenant(makeStubApi(), alice, multiTenant)
-    await expect((facade.llm as any).models({ rpcId: 'r', payload: {} })).resolves.toBeDefined()
+    await expect((facade.sessions as any).create({ rpcId: 'r', payload: {} })).rejects.toThrow(SessionAccessDeniedError)
+  })
+
+  it('denies deployment-management methods', async () => {
+    const multiTenant = await makeMultiTenant()
+    const facade = bindTenant(makeStubApi(), alice, multiTenant)
+    await expect((facade.settings as any).describe({ rpcId: 'r', payload: {} })).rejects.toThrow(SessionAccessDeniedError)
+    await expect((facade.credentials as any).set({ rpcId: 'r', payload: { ref: 'x', value: 'secret' } })).rejects.toThrow(SessionAccessDeniedError)
+    await expect((facade.llm as any).models({ rpcId: 'r', payload: {} })).rejects.toThrow(SessionAccessDeniedError)
+    await expect((facade.agentPresets as any).read({ rpcId: 'r', payload: { agentPreset: 'p' } })).rejects.toThrow(SessionAccessDeniedError)
+  })
+
+  it('allows explicitly tenant-neutral picker discovery', async () => {
+    const multiTenant = await makeMultiTenant()
+    const facade = bindTenant(makeStubApi(), alice, multiTenant)
+    await expect((facade.agentPresets as any).list({ rpcId: 'r', payload: {} })).resolves.toBeDefined()
   })
 
   it('guards subagent methods on the parent session', async () => {


### PR DESCRIPTION
## Summary

Tighten the obvious M4 unary-RPC policy issues before moving on to the real HTTP/WS transport prototype. This keeps the current architecture intact and makes the v0 web surface explicitly fail-closed where tenant semantics are not yet proven.

## What changed

- Add an explicit `admit` classification for `session.create`; the standalone `ApiProxy` facade denies it until the pre-publication admission bridge is installed by the transport layer.
- Stop treating `session.search` as an ordinary post-filterable collection. It is globally ranked/capped (20 + `hasMore`), so v0 denies it until a tenant-scoped query/visibility seam preserves correct search semantics.
- Deny deployment/host management surfaces by default: `settings.*`, `credentials.*`, preset authoring/inspection, and host-scoped `llm.*` configuration/catalog calls. Keep only the explicitly tenant-neutral `agentPreset.list` picker discovery as `allow`; `agentPreset.select` remains session-guarded.
- Keep host/workspace, streams, `respond`, and downloads fail-closed.
- Correct the `respond` documentation: real `ClientResponse` carries `rpcId + result`, not `sessionId`; H4 therefore needs `rpcId -> sessionId` correlation proof in M4 ②-C and is not marked resolved yet.
- Align the six-layer architecture, Seam Map, ADR, roadmap, and EN/zh-CN package docs with the hardened policy.
- Expand web tests to pin the new security classifications and facade denials.

## Why

PR #15 correctly made classification exhaustive, but exhaustiveness only guarantees every method has an answer — it does not guarantee the answer is tenant-safe. Several deployment-global capabilities were classified `allow`, and `session.create`/`session.search` had semantics that were too weak for the v0 multi-tenant boundary.

## Scope

No Kernel changes. No H3 implementation. No HTTP/WS transport work. No new auth/store/provider packages.

## Validation

The branch is intentionally opened as a draft so the repository CI can run the existing `verify`, typecheck, test, build, and package-smoke gates against these changes.