### PR TITLE
docs: codify boundary-first policy and RC7 target

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,6 +18,47 @@ Current spec artifacts: `docs/specs/web-seam-map.md` (web surfaces) and
 `docs/adr/web-enforcement.md` (hard conclusions + upstream seam
 proposal).
 
+## Boundary-first decision rule
+
+Before adding implementation, classify the surface being discussed:
+
+1. **Controlled by this repository → enforce it.** If we own the reliable
+   enforcement point, make the rule fail-closed and prove the invariant with
+   executable tests.
+2. **Owned by the ecosystem → standardize it.** If the guarantee depends on a
+   DSH or third-party seam, define the smallest reusable contract / seam,
+   publish conformance expectations, and collaborate upstream. A local spike is
+   evidence; it is not permission to permanently fork or reimplement the
+   upstream subsystem.
+3. **Not reliably enforceable → bound it.** State the threat-model / support
+   boundary and keep the promise narrow. Do not add broad architectural
+   machinery merely to claim coverage over a surface we still cannot prove.
+
+Complexity is not evidence. A PR whose main effect is to absorb an upstream or
+uncontrolled responsibility into this repository should be rejected or
+deferred unless it demonstrates a stable, independently owned boundary.
+
+## Prerelease-following discipline
+
+DeepSeek Harness is moving quickly, so this project optimizes for **small,
+explicit compatibility deltas** rather than long-lived local forks. The current
+target baseline is **DSH `0.1.0-rc.7`**.
+
+- Pin explicit prerelease versions; never make compatibility depend on an
+  unqualified `latest` tag.
+- Record the exact DSH version / commit used by a probe or architectural
+  conclusion.
+- Historical evidence is immutable evidence: an RC6 proof stays labelled RC6
+  until the affected seam is revalidated for RC7. Do not rewrite the label just
+  because source looks similar.
+- On a DSH bump, identify which seams changed and rerun only the affected
+  probes / conformance checks. Do not redesign unchanged layers.
+- Keep compatibility upgrades separate from unrelated feature expansion when
+  practical, so regressions and upstream changes remain easy to review and
+  revert.
+
+See `docs/reference/compatibility.md` for the current target and evidence policy.
+
 ## Package conventions
 
 - One package = one **independently composable / replaceable capability**, or
@@ -67,6 +108,9 @@ Two test kinds prove different things:
 ## Definition of done
 
 - Spec / ADR updated wherever behavior is decided.
+- The boundary classification is explicit when a change depends on an upstream
+  or otherwise uncontrolled surface.
+- Compatibility evidence names the DSH version it was actually validated on.
 - Contract and unit tests green (`pnpm test`).
 - `pnpm typecheck`, `pnpm build`, `pnpm verify`, and `pnpm smoke` green.
 - No transport/vendor dependency leaked into the kernel.

--- a/CONTRIBUTING.zh-CN.md
+++ b/CONTRIBUTING.zh-CN.md
@@ -12,6 +12,28 @@
 
 当前的规格产物：`docs/specs/web-seam-map.md`（web surface）与 `docs/adr/web-enforcement.md`（硬结论 + 上游 seam 提案）。
 
+## 边界优先的决策规则
+
+增加实现之前，先判断讨论中的 surface 属于哪一类：
+
+1. **本仓库控制得住 → 严格强制。** 如果我们拥有可靠的 enforcement point，就默认拒绝，并用可执行测试证明安全不变量。
+2. **属于生态 → 制定标准。** 如果保证依赖 DSH 或第三方 seam，就定义最小、可复用的 contract / seam，发布一致性要求并优先向上游协作。本地 spike 是证据，不等于可以长期 fork 或重写上游子系统。
+3. **无法可靠强制 → 明确边界。** 直接说明 threat model / support boundary，把承诺限定在真正能证明的范围内。不要为了声称“已经覆盖”一个仍无法证明的 surface，而引入大范围工程复杂度。
+
+复杂度不是证据。一个 PR 如果主要效果是把上游或本仓库控制不了的责任强行吸收到本项目里，除非它证明了一个稳定、独立归属的边界，否则应该拒绝或延后。
+
+## 快速跟进 prerelease 的纪律
+
+DeepSeek Harness 仍在快速迭代，因此本项目优化的是**小而明确的兼容性增量**，而不是长期维护本地 fork。当前目标基线是 **DSH `0.1.0-rc.7`**。
+
+- 显式 pin prerelease 版本；兼容性绝不依赖未限定的 `latest` tag。
+- 每个 probe 或架构结论都记录实际验证所对应的 DSH 精确版本 / commit。
+- 历史证据就是历史证据：一个 RC6 proof 在受影响 seam 为 RC7 重新验证之前，继续标记为 RC6。不能因为源码看起来类似就直接改标签。
+- DSH 升级时，先识别哪些 seam 真正发生变化，只重跑受影响的 probe / conformance check；未变化的层不要重新设计。
+- 在实际可行时，把兼容性升级与无关功能扩张拆开，让回归与上游变化更容易 review 和 revert。
+
+当前目标与证据政策见 `docs/reference/compatibility.md`。
+
 ## 包约定
 
 - 一个包 = 一个**可独立组合 / 可替换的能力**，或一个**不可再分的安全边界**。绝不是代码量阈值，也绝不是一个安全不变量的碎片。
@@ -38,6 +60,8 @@
 ## 完成定义
 
 - 凡决定行为之处，规格 / ADR 均已更新。
+- 当一个变更依赖上游或其他本仓库控制不了的 surface 时，必须明确写出它属于哪一类边界。
+- 兼容性证据必须标出它实际验证所对应的 DSH 版本。
 - 契约与单元测试通过（`pnpm test`）。
 - `pnpm typecheck`、`pnpm build`、`pnpm verify`、`pnpm smoke` 通过。
 - 无 transport/vendor 依赖泄漏进内核。

--- a/README.md
+++ b/README.md
@@ -7,24 +7,44 @@ Composable multi-tenant / SaaS plugin suite for
 
 > **Phase: engineering foundation.** The kernel baseline is established and
 > test-pinned; its public contract remains prerelease. The suite grows around it
-> one plugin at a time. See [ROADMAP.md](./ROADMAP.md).
+> one plugin at a time. The current DSH target is **`0.1.0-rc.7`**; exact
+> evidence and prerelease pinning rules live in
+> [`docs/reference/compatibility.md`](./docs/reference/compatibility.md). See
+> [ROADMAP.md](./ROADMAP.md) for sequencing.
 
 ## What this is
 
 A **plugin family**, not a single plugin. A kernel — `dsh-multi-tenant` — owns
 the tenant/session contract (identity, ownership, fail-closed authorization).
-This repository ships the official default implementations (storage, web
+This repository ships official default implementations (storage, web
 enforcement, …) as independently publishable [Cordis](https://github.com/cordiverse/cordis)
 plugins, each following DSH's service/bundle logic and each replaceable by a
 third-party implementation that passes the same contract tests.
 
-Maintaining a complete default stack matters because a single party can then
-hold the **end-to-end tenant-isolation invariant** — tenant A can never touch
-tenant B across auth → RPC → session → MCP → downstream — something no single
-plugin's unit test can prove.
+Maintaining a coherent default stack matters because it lets this repository
+own and prove the tenant-isolation invariants on the surfaces it actually
+controls. That promise stops at explicit boundaries: ecosystem-owned seams are
+handled through contracts, conformance tests, and minimal upstream proposals;
+surfaces this project cannot reliably enforce are documented as boundaries
+instead of being hidden behind brittle local complexity.
 
 ## Guiding principles
 
+- **Control → enforce** — where this repository owns the enforcement point, the
+  rule is strict and fail-closed, and the invariant is locked by executable
+  tests.
+- **Ecosystem → standardize** — where a guarantee depends on DSH or another
+  replaceable ecosystem component, define the smallest useful seam/contract,
+  publish conformance expectations, and collaborate upstream. Do not fork or
+  reimplement a whole subsystem merely to make the local project appear more
+  complete.
+- **Outside control → bound** — where no reliable enforcement seam exists,
+  state the threat-model / support boundary plainly. Prefer an honest limitation
+  over architectural complexity that cannot actually prove the guarantee.
+- **Fast-follow prereleases** — pin explicit DSH prereleases, record the exact
+  evidence version, and revalidate only the seams affected by an upstream
+  change. Historical RC6 evidence stays labelled RC6; new work targets RC7
+  until the compatibility baseline moves again.
 - **Typical capability layering** — *Contract* (a native DSH/Cordis seam:
   Service, event, or protocol) → *Provider* (plugin) → *Composition*
   (`cordis.patch.yml` bundle), *where applicable*. Pure integration /
@@ -36,7 +56,7 @@ plugin's unit test can prove.
 - **Split by replaceable capability, not size** — and a single security
   invariant is not split across packages.
 - **Default ≠ only** — the suite ships defaults; third parties may swap any
-  layer, if it passes the same contract test.
+  layer if it passes the same contract test.
 
 See [CONTRIBUTING.md](./CONTRIBUTING.md) for how development is done here.
 Full documentation lives in [`docs/`](./docs/README.md).

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -4,22 +4,26 @@
 
 面向 [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness)（DSH）的可组合多租户 / SaaS 插件套件。
 
-> **阶段：工程地基。** 内核基线已建立并由测试锁定；其公共契约仍处于预发布状态。套件围绕内核一次一个插件地生长。参见 [ROADMAP.md](./ROADMAP.md)。
+> **阶段：工程地基。** 内核基线已建立并由测试锁定；其公共契约仍处于预发布状态。套件围绕内核一次一个插件地生长。当前 DSH 目标基线是 **`0.1.0-rc.7`**；精确的证据版本与 prerelease pinning 规则见 [`docs/reference/compatibility.md`](./docs/reference/compatibility.md)。路线顺序参见 [ROADMAP.md](./ROADMAP.md)。
 
 ## 这是什么
 
 一个**插件家族**，而非单个插件。内核 —— `dsh-multi-tenant` —— 拥有租户/会话契约（身份、所有权、默认拒绝式授权）。本仓库以可独立发布的 [Cordis](https://github.com/cordiverse/cordis) 插件形式发布官方默认实现（存储、Web 强制、……），每个插件都遵循 DSH 的 service/bundle 逻辑，且每个都可以被通过同一套契约测试的第三方实现替换。
 
-维护一套完整的默认技术栈之所以重要，是因为只有这样才能让单一方持有**端到端的租户隔离不变量** —— 租户 A 永远无法跨 auth → RPC → session → MCP → 下游触达租户 B —— 而这是任何单个插件的单元测试都无法证明的。
+维护一套连贯的默认技术栈之所以重要，是因为这样本仓库才能对**自己真正控制的 surface** 持有并证明租户隔离不变量。这个承诺止于明确边界：依赖 DSH 或其他可替换生态组件的地方，通过契约、一致性测试和最小化的上游提案协作；本项目无法可靠强制的 surface，则明确写成边界，而不是用脆弱的本地复杂度把它包装成“看起来已经解决”。
 
 ## 指导原则
 
+- **控制得住 → 严格强制** —— 本仓库拥有 enforcement point 的地方，规则必须 fail-closed，并用可执行测试锁住安全不变量。
+- **需要生态协作 → 制定标准** —— 一个保证依赖 DSH 或其他可替换生态组件时，定义最小而通用的 seam / contract、发布一致性要求，并优先向上游协作。不要为了让本项目看起来更完整，就 fork 或重写整个上游子系统。
+- **控制不住 → 明确边界** —— 没有可靠 enforcement seam 的地方，直接说明 threat model / support boundary。宁可明确承认限制，也不要引入实际上无法证明保证的工程复杂度。
+- **快速跟进 prerelease** —— 显式 pin DSH prerelease，记录证据对应的精确版本，只重新验证上游变更影响到的 seam。历史 RC6 证据继续标记为 RC6；新的工作以 RC7 为目标，直到兼容性基线再次推进。
 - **典型的能力分层** —— *契约*（一个原生 DSH/Cordis seam：Service、事件或协议）→ *提供方*（插件）→ *组合*（`cordis.patch.yml` bundle），*在适用时*。纯集成 / 安全边界插件直接对原生 seam 组合。
 - **单向依赖** —— 内核只拥有跨套件的最小租户原语，并且不依赖任何 transport 或 vendor 特定的东西（无 JWT、无 PostgreSQL、无 HTTP、无 MCP、无 Redis）；能力包拥有自己的契约，且可以依赖内核的原语。
 - **按可替换的能力拆分，而非按大小** —— 且单个安全不变量不会被拆分到多个包。
 - **默认 ≠ 唯一** —— 套件发布默认实现；只要通过同一套契约测试，第三方可以替换任何一层。
 
-关于本仓库的开发方式，参见 [CONTRIBUTING.md](./CONTRIBUTING.md)。
+关于本仓库的开发方式，参见 [CONTRIBUTING.md](./CONTRIBUTING.md)。完整文档见 [`docs/`](./docs/README.md)。
 
 ## 包
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,6 +4,25 @@
 
 Statuses: ✅ done · 🚧 next (settled) · ⏳ deferred (decision-gated).
 
+## Roadmap discipline
+
+This roadmap follows the same boundary rule as the implementation:
+
+- **Control → enforce.** Milestones may promise strict behavior only where this
+  repository owns a reliable enforcement point and can lock it with tests.
+- **Ecosystem → standardize.** If progress depends on a DSH / third-party seam,
+  the deliverable is a minimal contract, conformance expectation, or upstream
+  proposal. The roadmap does not silently turn an ecosystem dependency into a
+  permanent local fork.
+- **Outside control → bound.** If a guarantee cannot currently be enforced, it
+  is documented as a support / threat-model boundary or deferred. We do not add
+  large subsystems merely to make the checklist look more complete.
+- **Fast-follow the current DSH prerelease.** The current target is
+  **`0.1.0-rc.7`**. Historical RC6 evidence remains valid as RC6 evidence; only
+  seams affected by the version move are revalidated before a dependent
+  milestone is considered proven on RC7. See
+  `docs/reference/compatibility.md`.
+
 ## Done
 
 - ✅ **Kernel core** — `TenantPrincipal` / `SessionOwner`, claim-once ownership,
@@ -25,7 +44,9 @@ Statuses: ✅ done · 🚧 next (settled) · ⏳ deferred (decision-gated).
 ## Next (settled)
 
 - 🚧 **M4 — Real integration proof.** Demonstrate the M3 claims against the real
-  DSH runtime *before* filing the upstream proposal:
+  DSH runtime *before* filing the upstream proposal. Existing RC6 proofs are
+  historical evidence; affected seams are selectively revalidated against the
+  current RC7 target rather than redesigning unchanged layers:
   1. **Admission decorator** ✅ — real `AgentService`, create / fork / subagent /
      resume, admission inside `setup` before `sessions.enter`.
   2. **Real `ApiProxy` facade** ✅ — the spike `ApiSurface` is gone; the real
@@ -39,9 +60,11 @@ Statuses: ✅ done · 🚧 next (settled) · ⏳ deferred (decision-gated).
      real runtime (still `X-Test-Tenant` / `X-Test-User`), locking the tenant-
      isolation invariants, `rpcId → sessionId` respond correlation, and
      unfailing installation ordering.
-- 🚧 **M5 — Upstream proposal + web enforcement.** File the request/connection-
-  scoped principal seam (plus any other seam M4 actually proves necessary),
-  then build the full enforcement on top of it.
+- 🚧 **M5 — Upstream proposal + web enforcement.** File only the
+  request/connection-scoped principal seam (plus any other seam M4 actually
+  proves necessary), then build the full enforcement on top of it. A missing
+  upstream seam is an ecosystem collaboration point, not a reason to absorb the
+  whole transport into this repository.
 
 ## Deferred (decision-gated)
 
@@ -74,9 +97,10 @@ Statuses: ✅ done · 🚧 next (settled) · ⏳ deferred (decision-gated).
 - **M5 — Upstream proposal + web enforcement.**
 - **M6 — Providers** durable stores, auth.
 - **M7 — MCP / audit / full-stack preset.**
-- **M8 — End-to-end tenant-isolation suite** — the executable "crown" that proves
-  Tenant A can never touch Tenant B across auth → HTTP/WS → ApiProxy → session →
-  agent → MCP → storage.
+- **M8 — End-to-end tenant-isolation suite** — the executable "crown" for the
+  surfaces included in the supported stack. It proves the covered isolation
+  chain and lists any unsupported / ecosystem-owned surfaces as explicit
+  boundaries rather than claiming guarantees the suite cannot exercise.
 
 Each milestone is gated by its predecessor's decision; deferred items above are
 pulled forward only when their gate (a decision or an upstream seam) closes.

--- a/ROADMAP.zh-CN.md
+++ b/ROADMAP.zh-CN.md
@@ -4,6 +4,15 @@
 
 状态：✅ 已完成 · 🚧 下一步（已确定） · ⏳ 延后（由决策门控）。
 
+## 路线图纪律
+
+本路线图与实现遵循同一套边界规则：
+
+- **控制得住 → 严格强制。** 只有当本仓库拥有可靠 enforcement point，并且可以用测试锁住不变量时，里程碑才承诺严格行为。
+- **需要生态协作 → 制定标准。** 如果推进依赖 DSH / 第三方 seam，交付物是最小 contract、一致性要求或上游提案。路线图不会把一个生态依赖悄悄变成长期本地 fork。
+- **控制不住 → 明确边界。** 当前无法强制的保证，写成 support / threat-model boundary 或延后。不要为了让 checklist 看起来更完整，就增加大型子系统。
+- **快速跟进当前 DSH prerelease。** 当前目标是 **`0.1.0-rc.7`**。历史 RC6 证据继续作为 RC6 证据保留；版本推进时，只重新验证真正受影响的 seam，依赖这些结论的里程碑在 RC7 上重新形成证据之后再视为已证明。参见 `docs/reference/compatibility.md`。
+
 ## 已完成
 
 - ✅ **内核核心** —— `TenantPrincipal` / `SessionOwner`、一次性认领所有权、默认拒绝式授权、`TenantSessionStore` service seam（内存提供方）。`packages/multi-tenant`。
@@ -14,11 +23,11 @@
 
 ## 下一步（已确定）
 
-- 🚧 **M4 — 真实集成证明。** 在提交上游提案*之前*，用真实 DSH runtime 演示 M3 的结论：
+- 🚧 **M4 — 真实集成证明。** 在提交上游提案*之前*，用真实 DSH runtime 演示 M3 的结论。已有 RC6 proof 继续作为历史证据保留；对当前 RC7 目标只做受影响 seam 的定向复验，而不是重新设计没有变化的层：
   1. **准入装饰器** ✅ —— 真实 `AgentService`，覆盖 create / fork / subagent / resume，准入在 `setup` 内、先于 `sessions.enter`。
   2. **真实 `ApiProxy` facade** ✅ —— spike 的 `ApiSurface` 已删除；真实 `RpcMethodMap` 在编译期穷举分类。v0 安全策略默认拒绝：session point 做 GUARD，仅 `session.list` 做 FILTER，`session.create` 归类为 ADMIT（admission bridge 安装前直接拒绝），search / host-global / deployment-management surface 在缺少 tenant-safe 语义前均 DENY。流 / `respond` / `downloads` 在 ②-C 前继续拒绝。
   3. **真实 transport 原型** —— 对真实 runtime 跑 HTTP / WS / respond / mux / host（仍用 `X-Test-Tenant` / `X-Test-User`），锁死租户隔离不变量、`rpcId → sessionId` respond correlation 与无遗漏的安装顺序。
-- 🚧 **M5 — 上游提案 + Web 强制。** 只提交 M4 实际证明为必要的 request/connection-scoped principal seam（以及任何其他被真实证据暴露出的 seam），然后在其上构建完整强制。
+- 🚧 **M5 — 上游提案 + Web 强制。** 只提交 M4 实际证明为必要的 request/connection-scoped principal seam（以及任何其他被真实证据暴露出的 seam），然后在其上构建完整强制。缺少上游 seam 是生态协作点，不是把整套 transport 吸收到本仓库里的理由。
 
 ## 延后（由决策门控）
 
@@ -39,6 +48,6 @@
 - **M5 — 上游提案 + Web 强制。**
 - **M6 — 提供方** 持久存储、认证。
 - **M7 — MCP / audit / 全栈 preset。**
-- **M8 — 端到端租户隔离套件** —— 可执行的「皇冠」：证明租户 A 跨 auth → HTTP/WS → ApiProxy → session → agent → MCP → storage 绝不触及租户 B。
+- **M8 — 端到端租户隔离套件** —— 对**支持栈中实际覆盖的 surface**执行的「皇冠」测试。它证明被覆盖的隔离链；任何未支持 / 属于生态的 surface 都必须明确列成边界，而不是声称测试无法执行的保证。
 
 每个里程碑由其前驱的决策门控；上表延后项仅当其门（一个决策或一个上游 seam）闭合时才会被提前。

--- a/docs/reference/compatibility.md
+++ b/docs/reference/compatibility.md
@@ -4,16 +4,43 @@
 
 ## Runtime
 
-- **Node** `>= 22.19` (matches DeepSeek Harness engines).
+- **Node** `>= 22.19` (matches the current DeepSeek Harness engine floor).
 - **Cordis** `@deepseek-ai/cordis` `>= 4.0.1 < 5` (peer).
+
+## Current DSH target
+
+The project currently targets **DeepSeek Harness `0.1.0-rc.7`**. New
+architecture decisions and new compatibility work are evaluated against that
+baseline.
+
+"Target" is not the same as "every historical proof has already been rerun".
+Evidence always keeps the version it was actually produced on. For example, an
+RC6 runtime probe remains RC6 evidence until the affected seam is revalidated
+for RC7. A dependent milestone is considered proven on the current target only
+when its affected evidence has been refreshed or an explicit compatibility
+review records why the upstream seam is unchanged.
+
+This distinction lets the project follow fast-moving DSH prereleases without
+rewriting history or forcing a full architectural revalidation on every release.
 
 ## DSH prerelease pinning
 
-DeepSeek Harness sub-packages publish a stale `latest` dist-tag (`0.0.1-rc.1`)
-while the newest published version is `0.1.0-rc.6`. **Never depend on
-`latest`** — pin an explicit prerelease version (e.g. `…@0.1.0-rc.6`), and
-record the DSH commit SHA a package's types were verified against (see
-`../specs/web-seam-map.md`).
+**Never depend on an unqualified `latest` tag for DSH prereleases.** Pin an
+explicit prerelease version and record the DSH commit SHA / release used by any
+package types, runtime probe, or architectural conclusion.
+
+When DSH moves to a new prerelease:
+
+1. identify which DSH-facing seams changed;
+2. rerun only the probes / conformance checks that cover those seams;
+3. update affected package pins and evidence labels explicitly; and
+4. leave unrelated layers alone.
+
+A version bump is a compatibility exercise, not a reason to absorb upstream
+responsibilities into this repository. If the new version exposes a needed
+seam, use it. If a seam is ecosystem-owned but still missing, define the
+smallest reusable standard / upstream proposal. If no reliable enforcement
+point exists, document the boundary rather than inventing a brittle local fork.
 
 ## Toolchain
 

--- a/docs/reference/compatibility.zh-CN.md
+++ b/docs/reference/compatibility.zh-CN.md
@@ -4,12 +4,29 @@
 
 ## 运行时
 
-- **Node** `>= 22.19`（与 DeepSeek Harness engines 一致）。
+- **Node** `>= 22.19`（与当前 DeepSeek Harness 的 engine 下限一致）。
 - **Cordis** `@deepseek-ai/cordis` `>= 4.0.1 < 5`（peer）。
 
-## DSH 预发布 pinning
+## 当前 DSH 目标
 
-DeepSeek Harness 子包发布了一个过期的 `latest` dist-tag（`0.0.1-rc.1`），而最新发布版本是 `0.1.0-rc.6`。**绝不要依赖 `latest`** —— pin 一个显式 prerelease 版本（例如 `…@0.1.0-rc.6`），并记录某个包的类型所针对验证的 DSH commit SHA（见 `../specs/web-seam-map.md`）。
+项目当前以 **DeepSeek Harness `0.1.0-rc.7`** 为目标基线。新的架构决策与新的兼容性工作，都针对这个基线进行评估。
+
+“目标基线”不等于“所有历史 proof 都已经重新跑过”。证据始终保留它实际产生时的版本。例如，一个 RC6 runtime probe 在受影响 seam 为 RC7 重新验证之前，继续是 RC6 证据。只有当依赖它的受影响证据已经刷新，或者一次明确的兼容性 review 记录了上游 seam 为什么没有变化时，对应里程碑才算在当前目标版本上被证明。
+
+这种区分让项目可以快速跟进 DSH prerelease，而不需要篡改历史，也不需要每个版本都把整个架构重新验证一遍。
+
+## DSH prerelease pinning
+
+**DSH prerelease 绝不依赖未限定的 `latest` tag。** 显式 pin prerelease 版本，并为任何 package type、runtime probe 或架构结论记录实际对应的 DSH commit SHA / release。
+
+当 DSH 推进到新的 prerelease 时：
+
+1. 先识别哪些面向 DSH 的 seam 真正发生变化；
+2. 只重跑覆盖这些 seam 的 probe / conformance check；
+3. 显式更新受影响的 package pin 与证据标签；
+4. 与此次变化无关的层保持不动。
+
+版本升级是兼容性工作，不是把上游责任吸收到本仓库里的理由。如果新版本已经暴露所需 seam，就直接使用；如果 seam 属于生态但仍缺失，就定义最小、可复用的标准 / 上游提案；如果根本没有可靠 enforcement point，就明确写出边界，而不是制造脆弱的本地 fork。
 
 ## 工具链
 


### PR DESCRIPTION
## Summary

Codify the project rule that keeps this suite strict where it has authority, composable where it needs ecosystem cooperation, and explicit where it cannot provide a guarantee:

- **Control → enforce**: fail closed and lock the invariant with executable tests.
- **Ecosystem → standardize**: define the smallest reusable seam / contract, publish conformance expectations, and collaborate upstream instead of absorbing the upstream subsystem.
- **Outside control → bound**: state the threat-model / support boundary instead of adding complexity that still cannot prove the guarantee.

The same rule is now present in the root README, contribution policy, roadmap discipline, and compatibility policy, with matching EN / zh-CN text.

## RC7 baseline

The project now declares **DeepSeek Harness `0.1.0-rc.7`** as the current target baseline.

This PR deliberately distinguishes **target baseline** from **evidence baseline**:

- historical RC6 probes / conclusions remain labelled RC6 until the affected seam is revalidated;
- new architecture and compatibility work targets RC7;
- a DSH prerelease bump should revalidate only affected seams, not trigger a whole-project redesign.

This prevents both failure modes: silently pretending old evidence was produced on RC7, and overreacting to every upstream prerelease by rebuilding unchanged layers.

## Roadmap impact

- The roadmap now promises strict guarantees only on surfaces the supported stack can actually exercise.
- Missing DSH seams are explicitly ecosystem collaboration points, not an automatic reason to fork or own the entire transport/runtime.
- The M8 "crown" language is narrowed to the supported/covered isolation chain, with unsupported or ecosystem-owned surfaces required to remain explicit boundaries.

## Deliberately not in this PR

This is a governance / compatibility-baseline change, not the RC7 dependency migration itself.

It does **not** change the existing `@deepseek-ai/dsh-host-apiproxy@0.1.0-rc.6` package pin or rewrite historical probe evidence. Under the new policy, that migration should be a separate, explicit compatibility change that updates the pin/lockfile and reruns only the affected probes before M4/M5 depend on the RC7 result.

No JWT, durable store, transport implementation, MCP, sandbox, or other feature work is added here.

## Validation

- One commit, 8 documentation files.
- EN / zh-CN policy text updated together.
- No runtime/package dependency graph changed, so the existing lockfile remains untouched.
