### PR TITLE
docs: converge roadmap around first kernel prerelease

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,31 +2,26 @@
 
 # dsh-multi-tenant
 
-Composable multi-tenant / SaaS plugin suite for
+Composable multi-tenant plugin primitives for
 [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) (DSH).
 
-> **Phase: engineering foundation.** The kernel baseline is established and
-> test-pinned; its public contract remains prerelease. The suite grows around it
-> one plugin at a time. The current DSH target is **`0.1.0-rc.7`**; exact
-> evidence and prerelease pinning rules live in
-> [`docs/reference/compatibility.md`](./docs/reference/compatibility.md). See
-> [ROADMAP.md](./ROADMAP.md) for sequencing.
+> **Phase: first kernel prerelease.** The kernel baseline is established and
+> test-pinned; its public contract remains prerelease. The current DSH target is
+> **`0.1.0-rc.7`**. The release-oriented plan is in
+> [ROADMAP.md](./ROADMAP.md), and exact evidence/version rules are in
+> [`docs/reference/compatibility.md`](./docs/reference/compatibility.md).
 
 ## What this is
 
-A **plugin family**, not a single plugin. A kernel — `dsh-multi-tenant` — owns
-the tenant/session contract (identity, ownership, fail-closed authorization).
-This repository ships official default implementations (storage, web
-enforcement, …) as independently publishable [Cordis](https://github.com/cordiverse/cordis)
-plugins, each following DSH's service/bundle logic and each replaceable by a
-third-party implementation that passes the same contract tests.
+A **plugin family with a small kernel**, not a promise to implement an entire
+SaaS platform. `dsh-multi-tenant` owns the tenant/session primitives this
+repository can enforce directly: identity shape, immutable session ownership,
+fail-closed authorization, and the `TenantSessionStore` provider contract.
 
-Maintaining a coherent default stack matters because it lets this repository
-own and prove the tenant-isolation invariants on the surfaces it actually
-controls. That promise stops at explicit boundaries: ecosystem-owned seams are
-handled through contracts, conformance tests, and minimal upstream proposals;
-surfaces this project cannot reliably enforce are documented as boundaries
-instead of being hidden behind brittle local complexity.
+Other capabilities are added only when their boundary is real and useful. A DSH
+or third-party seam is handled through a minimal contract/conformance proposal;
+a surface we cannot reliably enforce is documented as a boundary instead of
+being absorbed into a local fork.
 
 ## Guiding principles
 
@@ -35,38 +30,39 @@ instead of being hidden behind brittle local complexity.
   tests.
 - **Ecosystem → standardize** — where a guarantee depends on DSH or another
   replaceable ecosystem component, define the smallest useful seam/contract,
-  publish conformance expectations, and collaborate upstream. Do not fork or
-  reimplement a whole subsystem merely to make the local project appear more
-  complete.
+  publish conformance expectations, and collaborate upstream.
 - **Outside control → bound** — where no reliable enforcement seam exists,
-  state the threat-model / support boundary plainly. Prefer an honest limitation
-  over architectural complexity that cannot actually prove the guarantee.
+  state the threat-model / support boundary plainly. Complexity is not evidence.
 - **Fast-follow prereleases** — pin explicit DSH prereleases, record the exact
-  evidence version, and revalidate only the seams affected by an upstream
-  change. Historical RC6 evidence stays labelled RC6; new work targets RC7
-  until the compatibility baseline moves again.
-- **Typical capability layering** — *Contract* (a native DSH/Cordis seam:
-  Service, event, or protocol) → *Provider* (plugin) → *Composition*
-  (`cordis.patch.yml` bundle), *where applicable*. Pure integration /
-  security-boundary plugins compose directly against native seams.
-- **One-way dependency** — the kernel owns only the minimal cross-suite tenant
-  primitives and depends on nothing transport- or vendor-specific (no JWT, no
-  PostgreSQL, no HTTP, no MCP, no Redis); capability packages own their own
-  contracts and may depend on the kernel's primitives.
-- **Split by replaceable capability, not size** — and a single security
-  invariant is not split across packages.
-- **Default ≠ only** — the suite ships defaults; third parties may swap any
-  layer if it passes the same contract test.
+  evidence version, and revalidate only seams affected by an upstream change.
+- **One-way dependency** — the kernel has no transport/vendor dependency (no
+  JWT, PostgreSQL, HTTP, MCP, Redis); providers and integrations stay outside.
+- **Default ≠ only** — a provider is replaceable when it passes the same shared
+  contract suite; roadmap symmetry is never a reason to implement every backend.
 
-See [CONTRIBUTING.md](./CONTRIBUTING.md) for how development is done here.
-Full documentation lives in [`docs/`](./docs/README.md).
+## Release scope
+
+The first public 0.1 prerelease is the **kernel package**. Production Web
+multi-user enforcement is a separate ecosystem-gated track:
+
+- `dsh-multi-tenant` — release candidate: ownership, authorization, store seam,
+  testing utilities.
+- `dsh-multi-tenant-web` — experimental fail-closed enforcement spike; its
+  production contract waits for a DSH request/connection principal-scope seam.
+
+The 0.1 line does **not** claim shell/filesystem/process/container/network
+isolation, billing/UI/organization management, host-global resource tenancy, or
+cross-user team ACLs. See the boundary matrix in [ROADMAP.md](./ROADMAP.md).
 
 ## Packages
 
 | Package | npm | Role |
 | --- | --- | --- |
-| [`packages/multi-tenant`](./packages/multi-tenant) | `dsh-multi-tenant` | Kernel: `ctx.multiTenant` + `ctx.tenantSessionStore`, claim-once ownership, fail-closed authorization. |
-| [`packages/multi-tenant-web`](./packages/multi-tenant-web) | `dsh-multi-tenant-web` | Web enforcement: principal binding, RPC/mux/WS guard (early spike). |
+| [`packages/multi-tenant`](./packages/multi-tenant) | `dsh-multi-tenant` | Kernel: `ctx.multiTenant` + `ctx.tenantSessionStore`, claim-once ownership, fail-closed authorization, provider contract/testing. |
+| [`packages/multi-tenant-web`](./packages/multi-tenant-web) | `dsh-multi-tenant-web` | Experimental tenant-bound `ApiProxy` enforcement research; production principal binding is DSH-transport-gated. |
+
+See [CONTRIBUTING.md](./CONTRIBUTING.md) for development policy and
+[`docs/specs/architecture.md`](./docs/specs/architecture.md) for layer ownership.
 
 ## Development
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -2,35 +2,42 @@
 
 # dsh-multi-tenant
 
-面向 [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness)（DSH）的可组合多租户 / SaaS 插件套件。
+面向 [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness)（DSH）的可组合多租户插件原语。
 
-> **阶段：工程地基。** 内核基线已建立并由测试锁定；其公共契约仍处于预发布状态。套件围绕内核一次一个插件地生长。当前 DSH 目标基线是 **`0.1.0-rc.7`**；精确的证据版本与 prerelease pinning 规则见 [`docs/reference/compatibility.md`](./docs/reference/compatibility.md)。路线顺序参见 [ROADMAP.md](./ROADMAP.md)。
+> **阶段：第一次 kernel prerelease。** 内核基线已经建立并由测试锁定；公共契约仍处于 prerelease。当前 DSH 目标是 **`0.1.0-rc.7`**。面向发布的路线见 [ROADMAP.md](./ROADMAP.md)，精确 evidence/version 规则见 [`docs/reference/compatibility.md`](./docs/reference/compatibility.md)。
 
 ## 这是什么
 
-一个**插件家族**，而非单个插件。内核 —— `dsh-multi-tenant` —— 拥有租户/会话契约（身份、所有权、默认拒绝式授权）。本仓库以可独立发布的 [Cordis](https://github.com/cordiverse/cordis) 插件形式发布官方默认实现（存储、Web 强制、……），每个插件都遵循 DSH 的 service/bundle 逻辑，且每个都可以被通过同一套契约测试的第三方实现替换。
+这是一个**带小型 kernel 的插件家族**，不是“把整套 SaaS 平台都实现掉”的承诺。`dsh-multi-tenant` 只拥有本仓库能够直接强制的 tenant/session 原语：identity shape、不可变 session ownership、fail-closed authorization，以及 `TenantSessionStore` provider contract。
 
-维护一套连贯的默认技术栈之所以重要，是因为这样本仓库才能对**自己真正控制的 surface** 持有并证明租户隔离不变量。这个承诺止于明确边界：依赖 DSH 或其他可替换生态组件的地方，通过契约、一致性测试和最小化的上游提案协作；本项目无法可靠强制的 surface，则明确写成边界，而不是用脆弱的本地复杂度把它包装成“看起来已经解决”。
+其他能力只有在边界真实、并且确实有价值时才进入项目。依赖 DSH 或第三方 seam 的事情，用最小 contract/conformance proposal 进行生态协作；当前无法可靠强制的 surface，则直接作为边界说明，而不是吸收到本地 fork 里。
 
 ## 指导原则
 
-- **控制得住 → 严格强制** —— 本仓库拥有 enforcement point 的地方，规则必须 fail-closed，并用可执行测试锁住安全不变量。
-- **需要生态协作 → 制定标准** —— 一个保证依赖 DSH 或其他可替换生态组件时，定义最小而通用的 seam / contract、发布一致性要求，并优先向上游协作。不要为了让本项目看起来更完整，就 fork 或重写整个上游子系统。
-- **控制不住 → 明确边界** —— 没有可靠 enforcement seam 的地方，直接说明 threat model / support boundary。宁可明确承认限制，也不要引入实际上无法证明保证的工程复杂度。
-- **快速跟进 prerelease** —— 显式 pin DSH prerelease，记录证据对应的精确版本，只重新验证上游变更影响到的 seam。历史 RC6 证据继续标记为 RC6；新的工作以 RC7 为目标，直到兼容性基线再次推进。
-- **典型的能力分层** —— *契约*（一个原生 DSH/Cordis seam：Service、事件或协议）→ *提供方*（插件）→ *组合*（`cordis.patch.yml` bundle），*在适用时*。纯集成 / 安全边界插件直接对原生 seam 组合。
-- **单向依赖** —— 内核只拥有跨套件的最小租户原语，并且不依赖任何 transport 或 vendor 特定的东西（无 JWT、无 PostgreSQL、无 HTTP、无 MCP、无 Redis）；能力包拥有自己的契约，且可以依赖内核的原语。
-- **按可替换的能力拆分，而非按大小** —— 且单个安全不变量不会被拆分到多个包。
-- **默认 ≠ 唯一** —— 套件发布默认实现；只要通过同一套契约测试，第三方可以替换任何一层。
+- **控制得住 → 严格强制** —— 本仓库拥有 enforcement point 的地方，规则必须 fail-closed，并用可执行测试锁住不变量。
+- **需要生态协作 → 制定标准** —— 一个保证依赖 DSH 或其他可替换生态组件时，定义最小而有用的 seam/contract、发布一致性要求，并优先向上游协作。
+- **控制不住 → 明确边界** —— 没有可靠 enforcement seam 的地方，直接说明 threat-model / support boundary。复杂度不是证据。
+- **快速跟进 prerelease** —— 显式 pin DSH prerelease，记录 evidence 对应精确版本，只重新验证上游变化真正影响到的 seam。
+- **单向依赖** —— kernel 没有 transport/vendor 依赖（无 JWT、PostgreSQL、HTTP、MCP、Redis）；provider 与 integration 保持在外层。
+- **默认 ≠ 唯一** —— provider 通过相同共享 contract suite 即可替换；不能为了 roadmap 对称而把每一种 backend 都自己实现。
 
-关于本仓库的开发方式，参见 [CONTRIBUTING.md](./CONTRIBUTING.md)。完整文档见 [`docs/`](./docs/README.md)。
+## 发布范围
+
+第一次公开的 0.1 prerelease 是 **kernel package**。Production Web 多用户 enforcement 属于另一条受生态 seam 门控的路线：
+
+- `dsh-multi-tenant` —— release candidate：ownership、authorization、store seam、testing utilities。
+- `dsh-multi-tenant-web` —— experimental、fail-closed 的 enforcement spike；production principal binding 等待 DSH request/connection principal-scope seam。
+
+0.1 版本线**不**声称提供 shell/filesystem/process/container/network isolation、billing/UI/组织管理、host-global resource tenancy 或跨用户 team ACL。完整边界矩阵见 [ROADMAP.md](./ROADMAP.md)。
 
 ## 包
 
 | 包 | npm | 角色 |
 | --- | --- | --- |
-| [`packages/multi-tenant`](./packages/multi-tenant) | `dsh-multi-tenant` | 内核：`ctx.multiTenant` + `ctx.tenantSessionStore`，一次性认领所有权，默认拒绝式授权。 |
-| [`packages/multi-tenant-web`](./packages/multi-tenant-web) | `dsh-multi-tenant-web` | Web 强制：主体绑定，RPC/mux/WS 守卫（早期 spike）。 |
+| [`packages/multi-tenant`](./packages/multi-tenant) | `dsh-multi-tenant` | Kernel：`ctx.multiTenant` + `ctx.tenantSessionStore`，claim-once ownership、fail-closed authorization、provider contract/testing。 |
+| [`packages/multi-tenant-web`](./packages/multi-tenant-web) | `dsh-multi-tenant-web` | 实验性的 tenant-bound `ApiProxy` enforcement 研究；production principal binding 受 DSH transport seam 门控。 |
+
+开发规范见 [CONTRIBUTING.md](./CONTRIBUTING.md)，layer 归属见 [`docs/specs/architecture.md`](./docs/specs/architecture.md)。
 
 ## 开发
 
@@ -41,7 +48,7 @@ pnpm test
 pnpm build
 ```
 
-根脚本通过 `pnpm -r` 委托给每个工作区包。
+根脚本通过 `pnpm -r` 委托给每个 workspace package。
 
 ## 许可证
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,106 +1,184 @@
 [简体中文](./ROADMAP.zh-CN.md) | English
 
-# Roadmap
+# Roadmap — converge for the first release
 
-Statuses: ✅ done · 🚧 next (settled) · ⏳ deferred (decision-gated).
+Statuses: ✅ done · 🚧 release-blocking · 🤝 ecosystem · 🧭 later / demand-gated · ⛔ explicit boundary.
 
-## Roadmap discipline
+## Release target
 
-This roadmap follows the same boundary rule as the implementation:
+The next goal is **not** a complete multi-tenant SaaS distribution. It is a small,
+useful, honest first release of the kernel line:
 
-- **Control → enforce.** Milestones may promise strict behavior only where this
-  repository owns a reliable enforcement point and can lock it with tests.
-- **Ecosystem → standardize.** If progress depends on a DSH / third-party seam,
-  the deliverable is a minimal contract, conformance expectation, or upstream
-  proposal. The roadmap does not silently turn an ecosystem dependency into a
-  permanent local fork.
-- **Outside control → bound.** If a guarantee cannot currently be enforced, it
-  is documented as a support / threat-model boundary or deferred. We do not add
-  large subsystems merely to make the checklist look more complete.
-- **Fast-follow the current DSH prerelease.** The current target is
-  **`0.1.0-rc.7`**. Historical RC6 evidence remains valid as RC6 evidence; only
-  seams affected by the version move are revalidated before a dependent
-  milestone is considered proven on RC7. See
-  `docs/reference/compatibility.md`.
+- **`dsh-multi-tenant`** — first public **0.1 prerelease** (proposed
+  `0.1.0-rc.1`), targeting **DeepSeek Harness `0.1.0-rc.7`**.
+- **`dsh-multi-tenant-web`** — remains an **experimental enforcement spike**.
+  Its production contract is not a blocker for the kernel release because the
+  missing request/connection principal scope belongs to the DSH transport
+  ecosystem.
+
+The release promise is deliberately narrow: session ownership and
+fail-closed authorization on surfaces this repository controls. Anything else
+is either an ecosystem contract or an explicit boundary.
+
+## Boundary matrix
+
+| Surface | Classification | What this project does | Blocks first kernel release? |
+| --- | --- | --- | --- |
+| Tenant principal / session ownership / access decisions | **Control → enforce** | Own the contract and fail closed. | **Yes** — already implemented and test-pinned. |
+| `TenantSessionStore` seam + contract suite | **Control → enforce** | Own the seam; ship the in-memory reference; third parties prove providers with the shared suite. | **Yes** — already done. |
+| Agent genesis admission (`setup`) | **Control → enforce** | Keep the decorator/probe; revalidate only the affected RC7 seam. | **Yes** — compatibility evidence only. |
+| Unary `ApiProxy` classification | **Control → enforce** | Exhaustively classify the real `RpcMethodMap`; unknown/new methods fail closed. | **Yes** — compatibility evidence only. |
+| HTTP/WS request/connection principal scope | **Ecosystem → standardize** | Specify the smallest generic DSH seam and upstream it. Do not fork/rebuild the Web transport. | **No** for kernel; **yes** for production web enforcement. |
+| mux / host streams and `respond` | **Control after ecosystem seam** | Keep denied in the spike; implement/test only after a principal-scoped transport seam exists. | No for kernel. |
+| Auth providers (JWT/OIDC/API key) | **Later provider** | Add a replaceable reference provider only after there is a real transport principal scope. | No. |
+| Durable ownership stores | **Later provider** | Add one or more providers when there is real demand; the provider seam already exists. | No. |
+| `session.search` tenant visibility | **Ecosystem / later** | Deny for now; pursue a scoped visibility/search contract only if needed. | No. |
+| Workspace / host-global management | **Outside v0.1 scope** | Deny where exposed through the web spike; do not invent tenant semantics for DSH-global resources. | No. |
+| Tenant-aware MCP context propagation | **Ecosystem / later** | Define a conformance contract when the DSH/MCP seam is concrete and there is demand. | No. |
+| Shell / filesystem / process / container / network isolation | **Explicit boundary** | Not provided by this plugin family. Strong execution isolation belongs to the deployment/runtime layer. | No. |
+| Billing, UI, organization/user administration | **Explicit boundary** | Not a goal of this repository. | No. |
+| Team sharing / ACLs / ownership reassignment | **Explicit v0.1 boundary** | v0.1 keeps immutable tenant+user ownership. A separate same-tenant access policy may be designed later. | No. |
 
 ## Done
 
-- ✅ **Kernel core** — `TenantPrincipal` / `SessionOwner`, claim-once ownership,
-  fail-closed authorization, `TenantSessionStore` service seam (in-memory
-  provider). `packages/multi-tenant`.
-- ✅ **Monorepo** — pnpm workspace with `packages/`, shared `tsconfig.base.json`,
-  delegated root scripts, CI.
-- ✅ **Web seam spike (M2)** — Seam Map, executable facade prototype (6 security
-  invariants), and the converged web ADR. Concluded that web enforcement is
-  blocked on a transport principal-binding problem (H3 hypothesis).
-- ✅ **Kernel engineering harness** — `TenantSessionStore` contract suite
-  (`dsh-multi-tenant/testing`), architecture gate (`pnpm verify`), package
-  smoke (`pnpm smoke`), compatibility policy (`docs/reference/compatibility.md`).
-- ✅ **Architecture convergence (M3)** — six-layer architecture
-  (`docs/specs/architecture.md`), the Agent `setup` hook confirmed as the
-  admission point, and "H3-only" established as a **hypothesis** to verify with
-  real transport evidence in M4.
+- ✅ **M0 — Engineering foundation** — monorepo, package rules, spec/ADR discipline, CI.
+- ✅ **M1 — Kernel hardening** — claim-once ownership, fail-closed access,
+  `TenantSessionStore`, shared contract tests, package smoke, architecture gates.
+- ✅ **M2 — Session genesis proof** — Agent `setup` is the before-visibility
+  admission point; create / fork / subagent / resume are covered by the RC6
+  runtime proof.
+- ✅ **M3 — Web enforcement spike** — real `ApiProxy` facade, exhaustive unary
+  classification, fail-closed policy, and the H3 transport gap identified.
+- ✅ **Boundary policy** — control → enforce; ecosystem → standardize; outside
+  control → bound. RC7 is the current target baseline.
 
-## Next (settled)
+## Release track — the next few iterations
 
-- 🚧 **M4 — Real integration proof.** Demonstrate the M3 claims against the real
-  DSH runtime *before* filing the upstream proposal. Existing RC6 proofs are
-  historical evidence; affected seams are selectively revalidated against the
-  current RC7 target rather than redesigning unchanged layers:
-  1. **Admission decorator** ✅ — real `AgentService`, create / fork / subagent /
-     resume, admission inside `setup` before `sessions.enter`.
-  2. **Real `ApiProxy` facade** ✅ — the spike `ApiSurface` is gone; the real
-     `RpcMethodMap` is exhaustively classified at compile time. The v0 security
-     policy is fail-closed: GUARD session points, FILTER only `session.list`,
-     ADMIT `session.create` (denied until the admission bridge is installed),
-     and DENY search / host-global / deployment-management surfaces that do not
-     yet have tenant-safe semantics. Streams / `respond` / `downloads` remain
-     denied pending ②-C.
-  3. **Real transport prototype** — HTTP / WS / respond / mux / host against the
-     real runtime (still `X-Test-Tenant` / `X-Test-User`), locking the tenant-
-     isolation invariants, `rpcId → sessionId` respond correlation, and
-     unfailing installation ordering.
-- 🚧 **M5 — Upstream proposal + web enforcement.** File only the
-  request/connection-scoped principal seam (plus any other seam M4 actually
-  proves necessary), then build the full enforcement on top of it. A missing
-  upstream seam is an ecosystem collaboration point, not a reason to absorb the
-  whole transport into this repository.
+Only these steps block the first `dsh-multi-tenant` release.
 
-## Deferred (decision-gated)
+### 🚧 R1 — RC7 compatibility refresh
 
-- ⏳ **H2 — resource model.** Whether Workspace and host-global frames are
-  tenant-owned. Product decision; until then, v0 denies non-session host frames.
-- ⏳ **Tenant-scoped search.** `session.search` is globally ranked/capped today;
-  it stays denied until a visibility predicate / scoped candidate set preserves
-  correct search semantics.
-- ⏳ **Auth providers** (JWT / OIDC / API key). Post-H3; `TenantPrincipalResolver`
-  placement still undecided.
-- ⏳ **Durable stores** (PostgreSQL / Redis / MySQL). Create a provider package
-  once an independent composition / replacement / dependency / lifecycle
-  boundary is demonstrated.
-- ⏳ **Public-contract freeze** for `dsh-multi-tenant-web` (name and surface are
-  provisional until H3 resolves).
-- ⏳ Tenant-aware MCP, audit/usage, billing/UI.
+A focused compatibility PR, not a feature PR:
 
-## Milestones
+1. bump the DSH dev/test pins that participate in the proofs from RC6 to
+   **`0.1.0-rc.7`** and refresh the lockfile;
+2. rerun the admission/runtime probe and the real `RpcMethodMap` type/test
+   coverage against RC7;
+3. record the exact RC7 evidence commit/version in the compatibility docs;
+4. if an affected seam changed, adapt the smallest owned layer only. Do **not**
+   redesign unchanged layers and do not build a replacement Web carrier merely
+   to close H3 locally.
 
-- **M0 — Engineering foundation** ✅ monorepo, package rules, spec/ADR
-  discipline, CI.
-- **M1 — Kernel hardening** ✅ contract-test harness, architecture gate, package
-  smoke, compatibility policy.
-- **M2 — Session genesis spike** ✅ `setup` hook confirmed as the admission
-  point; fork / subagent / resume solvable today.
-- **M3 — Architecture convergence** ✅ six-layer architecture and H3-only as a
-  hypothesis.
-- **M4 — Real integration proof** 🚧 admission decorator and real unary
-  `ApiProxy` are proven; real HTTP/WS transport remains.
-- **M5 — Upstream proposal + web enforcement.**
-- **M6 — Providers** durable stores, auth.
-- **M7 — MCP / audit / full-stack preset.**
-- **M8 — End-to-end tenant-isolation suite** — the executable "crown" for the
-  surfaces included in the supported stack. It proves the covered isolation
-  chain and lists any unsupported / ecosystem-owned surfaces as explicit
-  boundaries rather than claiming guarantees the suite cannot exercise.
+### 🚧 R2 — Kernel release hardening
 
-Each milestone is gated by its predecessor's decision; deferred items above are
-pulled forward only when their gate (a decision or an upstream seam) closes.
+1. keep package metadata aligned with the actual kernel scope — identity,
+   ownership, authorization, store seam/testing; no claims of built-in MCP,
+   audit, auth, or production Web isolation;
+2. publish clear **supported guarantees** and **explicit boundaries** in the
+   README/package docs;
+3. run the existing release gates: `pnpm verify`, `pnpm typecheck`, `pnpm test`,
+   `pnpm build`, and `pnpm smoke`;
+4. choose the first 0.1 prerelease version (recommended `0.1.0-rc.1`) and verify
+   the packed consumer experience.
+
+### 🚧 R3 — Publish the kernel prerelease
+
+- publish/tag the `dsh-multi-tenant` 0.1 prerelease;
+- release notes name the RC7 evidence baseline and the security boundary;
+- `dsh-multi-tenant-web` is **not** presented as a production multi-user Web
+  solution. It may remain repository-only or be published only with an explicit
+  experimental/prerelease label.
+
+After R3, the project has a real version users and ecosystem authors can build
+against without waiting for every SaaS concern to be solved.
+
+## Ecosystem track — important, but non-blocking for the kernel
+
+### 🤝 E1 — DSH principal-scope seam
+
+RC7 still exposes `ConnectionRpcHandler` as decoded
+`(endpoint, payload, signal)` and the Web carrier documents that it has no
+authentication layer. The required deliverable from this repository is therefore
+**a small generic upstream seam**, not a local transport fork.
+
+The proposal should remain tenant-agnostic and enable a caller to derive a
+request/connection-scoped API/security context from the real HTTP request / WS
+upgrade. Conformance expectations should cover:
+
+- HTTP request scope and WebSocket connection lifetime;
+- concurrent principals with no ambient/global cross-talk;
+- the ability to install a principal-bound `ApiProxy` before `session.create`
+  admission and before event delivery;
+- safe correlation for server-request responses (`respond`) if real runtime
+  evidence shows it is needed.
+
+This proposal does **not** block the kernel release.
+
+### 🤝 E2 — Production Web enforcement, after the seam exists
+
+Once DSH exposes an adequate principal-scope seam:
+
+1. turn `dsh-multi-tenant-web` from a spike into an installable enforcement
+   plugin;
+2. wire admission, unary guards/filtering, stream filtering, and `respond` under
+   the same principal scope;
+3. add a minimal two-tenant adversarial E2E suite for the supported Web
+   surfaces;
+4. only then freeze the Web package's public contract and consider a Web
+   prerelease.
+
+### 🤝 E3 — Additional ecosystem contracts, only on demand
+
+These are independent follow-ups, not a serial M6/M7/M8 chain:
+
+- tenant-scoped search visibility;
+- tenant-aware MCP principal/context propagation;
+- any DSH-global resource model that the ecosystem actually decides to make
+  tenant-owned.
+
+Each starts with a seam/contract and conformance expectation, not a large local
+implementation.
+
+## Later owned providers — optional, independent packages
+
+🧭 These can be built after the kernel release without changing the kernel:
+
+- a durable `TenantSessionStore` provider (PostgreSQL / Redis / MySQL — choose
+  based on contributor/user demand, not roadmap symmetry);
+- a reference auth provider after E1 lands;
+- lifecycle/admin cleanup for tombstoned ownership if a real use case requires
+  it.
+
+None is required to prove the kernel contract.
+
+## Explicit boundaries / non-goals
+
+⛔ The 0.1 line does **not** claim to provide strong process/container isolation.
+A tenant-authorized Agent may still have whatever shell/filesystem/network
+capabilities the surrounding DSH deployment grants it. Deployments requiring
+strong execution isolation must enforce that outside this plugin family.
+
+⛔ This repository does not become a billing system, organization/user directory,
+UI product, or general RBAC framework.
+
+⛔ It does not reimplement the DSH Web transport, session search engine, MCP
+runtime, or host resource model simply to make every checklist row local.
+
+⛔ v0.1 ownership is immutable `(tenantId, userId)` ownership. Cross-user sharing,
+reassignment, admin inspection, and team ACLs require a separate same-tenant
+policy plane and are not silently added to the kernel.
+
+## What blocks what
+
+```text
+RC7 compatibility ──> kernel release hardening ──> dsh-multi-tenant 0.1 prerelease
+
+DSH principal-scope seam ──> production dsh-multi-tenant-web ──> Web E2E / Web release
+
+search / MCP / durable providers / auth provider / audit / UI
+        └──────────── independent, demand-gated follow-ups ────────────┘
+```
+
+The roadmap is intentionally short. A new item belongs here only when it blocks
+an owned release guarantee; ecosystem work lives on the ecosystem track, and
+unsupported concerns remain explicit boundaries.

--- a/ROADMAP.zh-CN.md
+++ b/ROADMAP.zh-CN.md
@@ -1,53 +1,143 @@
 [English](./ROADMAP.md) | 简体中文
 
-# 路线图
+# 路线图 —— 为第一次发布收敛
 
-状态：✅ 已完成 · 🚧 下一步（已确定） · ⏳ 延后（由决策门控）。
+状态：✅ 已完成 · 🚧 发布阻塞项 · 🤝 生态协作 · 🧭 后续 / 按需求触发 · ⛔ 明确边界。
 
-## 路线图纪律
+## 发布目标
 
-本路线图与实现遵循同一套边界规则：
+下一阶段的目标**不是**做出一整套完整的多租户 SaaS 分发版，而是先发布一个小而有用、边界诚实的内核版本：
 
-- **控制得住 → 严格强制。** 只有当本仓库拥有可靠 enforcement point，并且可以用测试锁住不变量时，里程碑才承诺严格行为。
-- **需要生态协作 → 制定标准。** 如果推进依赖 DSH / 第三方 seam，交付物是最小 contract、一致性要求或上游提案。路线图不会把一个生态依赖悄悄变成长期本地 fork。
-- **控制不住 → 明确边界。** 当前无法强制的保证，写成 support / threat-model boundary 或延后。不要为了让 checklist 看起来更完整，就增加大型子系统。
-- **快速跟进当前 DSH prerelease。** 当前目标是 **`0.1.0-rc.7`**。历史 RC6 证据继续作为 RC6 证据保留；版本推进时，只重新验证真正受影响的 seam，依赖这些结论的里程碑在 RC7 上重新形成证据之后再视为已证明。参见 `docs/reference/compatibility.md`。
+- **`dsh-multi-tenant`** —— 第一个公开的 **0.1 预发布版本**（建议
+  `0.1.0-rc.1`），目标基线为 **DeepSeek Harness `0.1.0-rc.7`**。
+- **`dsh-multi-tenant-web`** —— 继续保持**实验性的 enforcement spike**。
+  它的 production contract 不阻塞内核发布，因为缺失的 request/connection
+  principal scope 属于 DSH transport 生态能力。
+
+第一次发布的承诺刻意收窄：只承诺本仓库真正控制得住的 session 所有权与 fail-closed 授权。其他事情要么进入生态契约，要么明确列为边界。
+
+## 边界矩阵
+
+| Surface | 分类 | 本项目负责什么 | 阻塞第一次内核发布？ |
+| --- | --- | --- | --- |
+| Tenant principal / session ownership / access decision | **控制得住 → 严格强制** | 本仓库拥有契约并默认拒绝。 | **是** —— 已实现且由测试锁定。 |
+| `TenantSessionStore` seam + contract suite | **控制得住 → 严格强制** | 本仓库拥有 seam；提供内存参考实现；第三方用共享套件证明 provider。 | **是** —— 已完成。 |
+| Agent 创生准入（`setup`） | **控制得住 → 严格强制** | 保留 decorator/probe；只重新验证 RC7 受影响 seam。 | **是** —— 只差兼容性证据更新。 |
+| unary `ApiProxy` 分类 | **控制得住 → 严格强制** | 对真实 `RpcMethodMap` 穷举分类；未知 / 新增方法默认拒绝。 | **是** —— 只差兼容性证据更新。 |
+| HTTP/WS request/connection principal scope | **需要生态协作 → 制定标准** | 定义最小、通用的 DSH seam 并向上游协作。不要 fork / 重写 Web transport。 | 内核**不阻塞**；production Web **阻塞**。 |
+| mux / host stream 与 `respond` | **生态 seam 落地后由我们强制** | spike 中继续拒绝；有 principal-scoped transport seam 后再实现和测试。 | 内核不阻塞。 |
+| Auth provider（JWT/OIDC/API key） | **后续 provider** | 真实 transport principal scope 存在后，再做可替换参考 provider。 | 否。 |
+| 持久 ownership store | **后续 provider** | 有真实需求时增加 provider；provider seam 已存在。 | 否。 |
+| `session.search` 租户可见性 | **生态 / 后续** | 当前拒绝；真正需要时再推动 scoped visibility/search contract。 | 否。 |
+| Workspace / host-global management | **v0.1 范围外** | Web spike 中暴露到的地方继续拒绝；不替 DSH-global 资源凭空发明 tenant 语义。 | 否。 |
+| tenant-aware MCP context propagation | **生态 / 后续** | DSH/MCP seam 稳定且有需求时，再定义一致性契约。 | 否。 |
+| Shell / filesystem / process / container / network isolation | **明确边界** | 本插件家族不提供；强执行隔离属于 deployment/runtime 层。 | 否。 |
+| Billing、UI、组织/用户管理 | **明确边界** | 不是本仓库目标。 | 否。 |
+| 团队共享 / ACL / ownership reassignment | **v0.1 明确边界** | v0.1 保持 tenant+user 不可变所有权；未来如有需求另设计同租户 policy plane。 | 否。 |
 
 ## 已完成
 
-- ✅ **内核核心** —— `TenantPrincipal` / `SessionOwner`、一次性认领所有权、默认拒绝式授权、`TenantSessionStore` service seam（内存提供方）。`packages/multi-tenant`。
-- ✅ **Monorepo** —— pnpm 工作区含 `packages/`、共享 `tsconfig.base.json`、委托式根脚本、CI。
-- ✅ **Web seam spike（M2）** —— Seam Map、可执行 facade 原型（6 条安全不变量）、以及收敛后的 web ADR。结论：Web 强制仍受 transport principal 绑定问题（H3 假设）约束。
-- ✅ **内核工程脚手架** —— `TenantSessionStore` 契约套件（`dsh-multi-tenant/testing`）、架构门（`pnpm verify`）、包冒烟（`pnpm smoke`）、兼容性政策（`docs/reference/compatibility.md`）。
-- ✅ **架构收敛（M3）** —— 六层架构（`docs/specs/architecture.md`）、Agent `setup` 钩子被确认为准入点，并把「H3-only」确立为**假设**，由 M4 的真实 transport 证据最终验证。
+- ✅ **M0 — 工程地基** —— monorepo、包规则、spec/ADR 纪律、CI。
+- ✅ **M1 — 内核加固** —— claim-once ownership、fail-closed access、
+  `TenantSessionStore`、共享契约测试、package smoke、架构门。
+- ✅ **M2 — Session genesis proof** —— Agent `setup` 是 visibility 前的准入点；
+  create / fork / subagent / resume 已有 RC6 runtime proof。
+- ✅ **M3 — Web enforcement spike** —— 真实 `ApiProxy` facade、unary 穷举分类、
+  fail-closed policy，以及 H3 transport 缺口已经识别。
+- ✅ **边界治理原则** —— 控制得住就强制；需要生态协作就制定标准；控制不住就明确边界。当前目标基线为 RC7。
 
-## 下一步（已确定）
+## 发布主线 —— 接下来几轮迭代
 
-- 🚧 **M4 — 真实集成证明。** 在提交上游提案*之前*，用真实 DSH runtime 演示 M3 的结论。已有 RC6 proof 继续作为历史证据保留；对当前 RC7 目标只做受影响 seam 的定向复验，而不是重新设计没有变化的层：
-  1. **准入装饰器** ✅ —— 真实 `AgentService`，覆盖 create / fork / subagent / resume，准入在 `setup` 内、先于 `sessions.enter`。
-  2. **真实 `ApiProxy` facade** ✅ —— spike 的 `ApiSurface` 已删除；真实 `RpcMethodMap` 在编译期穷举分类。v0 安全策略默认拒绝：session point 做 GUARD，仅 `session.list` 做 FILTER，`session.create` 归类为 ADMIT（admission bridge 安装前直接拒绝），search / host-global / deployment-management surface 在缺少 tenant-safe 语义前均 DENY。流 / `respond` / `downloads` 在 ②-C 前继续拒绝。
-  3. **真实 transport 原型** —— 对真实 runtime 跑 HTTP / WS / respond / mux / host（仍用 `X-Test-Tenant` / `X-Test-User`），锁死租户隔离不变量、`rpcId → sessionId` respond correlation 与无遗漏的安装顺序。
-- 🚧 **M5 — 上游提案 + Web 强制。** 只提交 M4 实际证明为必要的 request/connection-scoped principal seam（以及任何其他被真实证据暴露出的 seam），然后在其上构建完整强制。缺少上游 seam 是生态协作点，不是把整套 transport 吸收到本仓库里的理由。
+只有下面这些事情阻塞第一次 `dsh-multi-tenant` 发布。
 
-## 延后（由决策门控）
+### 🚧 R1 — RC7 兼容性刷新
 
-- ⏳ **H2 — 资源模型。** Workspace 与 host-global frame 是否由租户拥有。产品决策；在此之前，v0 拒绝非 session 的 host frame。
-- ⏳ **租户作用域搜索。** 当前 `session.search` 是全局排序/限量；在 visibility predicate / scoped candidate set 能保证正确搜索语义前保持拒绝。
-- ⏳ **认证提供方**（JWT / OIDC / API key）。在 H3 之后；`TenantPrincipalResolver` 的落点仍待定。
-- ⏳ **持久存储**（PostgreSQL / Redis / MySQL）。一旦一个独立的组合 / 替换 / 依赖 / 生命周期边界被证明，就创建一个提供方包。
-- ⏳ **`dsh-multi-tenant-web` 的公共契约冻结**（在 H3 解决之前，其名字与 surface 都是临时的）。
-- ⏳ 租户感知的 MCP、审计/用量、计费/UI。
+这是一个聚焦的 compatibility PR，不是 feature PR：
 
-## 里程碑
+1. 把参与 proof 的 DSH dev/test pin 从 RC6 升到 **`0.1.0-rc.7`**，刷新 lockfile；
+2. 对 RC7 重跑 admission/runtime probe，以及真实 `RpcMethodMap` 的 type/test coverage；
+3. 在 compatibility docs 中记录精确的 RC7 evidence commit/version；
+4. 如果受影响 seam 真有变化，只适配最小的 owned layer。**不要**重新设计未变化的层，也不要为了本地关闭 H3 而造一套替代 Web carrier。
 
-- **M0 — 工程地基** ✅ monorepo、包规则、规格/ADR 纪律、CI。
-- **M1 — 内核加固** ✅ 契约测试脚手架、架构门、包冒烟、兼容性政策。
-- **M2 — 会话创生 spike** ✅ 确认 `setup` 钩子为准入点；fork / subagent / resume 今天即可解决。
-- **M3 — 架构收敛** ✅ 六层架构 + H3-only 作为假设。
-- **M4 — 真实集成证明** 🚧 准入装饰器与真实 unary `ApiProxy` 已证明；真实 HTTP/WS transport 待完成。
-- **M5 — 上游提案 + Web 强制。**
-- **M6 — 提供方** 持久存储、认证。
-- **M7 — MCP / audit / 全栈 preset。**
-- **M8 — 端到端租户隔离套件** —— 对**支持栈中实际覆盖的 surface**执行的「皇冠」测试。它证明被覆盖的隔离链；任何未支持 / 属于生态的 surface 都必须明确列成边界，而不是声称测试无法执行的保证。
+### 🚧 R2 — 内核发布加固
 
-每个里程碑由其前驱的决策门控；上表延后项仅当其门（一个决策或一个上游 seam）闭合时才会被提前。
+1. package metadata 必须和真实内核范围一致 —— identity、ownership、authorization、store seam/testing；不能声称内置 MCP、audit、auth 或 production Web isolation；
+2. 在 README / package docs 中明确发布 **supported guarantees** 与 **explicit boundaries**；
+3. 跑现有发布门：`pnpm verify`、`pnpm typecheck`、`pnpm test`、`pnpm build`、`pnpm smoke`；
+4. 确定第一次 0.1 prerelease 版本（建议 `0.1.0-rc.1`），验证 packed consumer experience。
+
+### 🚧 R3 — 发布内核 prerelease
+
+- publish/tag `dsh-multi-tenant` 的 0.1 prerelease；
+- release notes 明确 RC7 evidence baseline 与 security boundary；
+- `dsh-multi-tenant-web` **不能**被描述成 production 多用户 Web 方案。它可以继续仅存在于仓库中，或者只有在明确 experimental/prerelease 标签下才发布。
+
+R3 完成以后，项目就已经有一个真实版本，用户和生态作者可以围绕它开发，而不必等所有 SaaS 问题一起解决。
+
+## 生态主线 —— 重要，但不阻塞内核发布
+
+### 🤝 E1 — DSH principal-scope seam
+
+RC7 当前公开的 `ConnectionRpcHandler` 仍然只有解码后的
+`(endpoint, payload, signal)`，官方 Web carrier 文档也明确说明当前没有 authentication layer。因此本项目应该交付的是**一个小而通用的上游 seam**，不是本地 transport fork。
+
+上游 proposal 应保持 tenant-agnostic，让调用方可以基于真实 HTTP request / WS upgrade 建立 request/connection-scoped API/security context。一致性要求至少覆盖：
+
+- HTTP request scope 与 WebSocket connection lifetime；
+- 并发 principal 之间没有 ambient/global cross-talk；
+- 能在 `session.create` admission 以及 event delivery 之前安装 principal-bound `ApiProxy`；
+- 如果真实 runtime evidence 证明需要，则包含 server-request response（`respond`）安全 correlation。
+
+这个 proposal **不阻塞**内核发布。
+
+### 🤝 E2 — seam 存在以后再做 production Web enforcement
+
+DSH 提供足够的 principal-scope seam 后：
+
+1. 把 `dsh-multi-tenant-web` 从 spike 变成可安装的 enforcement plugin；
+2. 在同一 principal scope 下接通 admission、unary guard/filter、stream filtering 与 `respond`；
+3. 对支持的 Web surface 增加最小 two-tenant adversarial E2E suite；
+4. 到这一步才冻结 Web package public contract，并考虑 Web prerelease。
+
+### 🤝 E3 — 其他生态 contract，只在有需求时启动
+
+这些是独立 follow-up，不再形成串行的 M6/M7/M8 大链条：
+
+- tenant-scoped search visibility；
+- tenant-aware MCP principal/context propagation；
+- 生态真正决定要 tenant-owned 的其他 DSH-global resource model。
+
+每一项都先从 seam/contract + conformance expectation 开始，而不是先做大规模本地实现。
+
+## 后续 owned provider —— 可选、独立包
+
+🧭 这些可以在内核发布之后独立推进，不需要改内核：
+
+- 一个 durable `TenantSessionStore` provider（PostgreSQL / Redis / MySQL —— 根据 contributor/user 真实需求选择，而不是为了 roadmap 对称而全做）；
+- E1 落地后的 reference auth provider；
+- 如果出现真实 use case，再做 tombstoned ownership 的 lifecycle/admin cleanup。
+
+它们都不是证明内核契约所必需的。
+
+## 明确边界 / 非目标
+
+⛔ 0.1 版本线**不**声称提供强 process/container isolation。一个已通过租户授权的 Agent 仍拥有其所在 DSH deployment 授予的 shell/filesystem/network 能力。需要强执行隔离的部署必须在本插件家族之外强制。
+
+⛔ 本仓库不会演变成 billing system、组织/用户目录、UI 产品或通用 RBAC framework。
+
+⛔ 不会为了让 checklist 每一行都变成本地能力，就重新实现 DSH Web transport、session search engine、MCP runtime 或 host resource model。
+
+⛔ v0.1 ownership 是不可变的 `(tenantId, userId)` ownership。跨用户共享、reassignment、admin inspection、team ACL 必须属于独立的 same-tenant policy plane，不能悄悄塞进 kernel。
+
+## 什么阻塞什么
+
+```text
+RC7 compatibility ──> kernel release hardening ──> dsh-multi-tenant 0.1 prerelease
+
+DSH principal-scope seam ──> production dsh-multi-tenant-web ──> Web E2E / Web release
+
+search / MCP / durable providers / auth provider / audit / UI
+        └──────────── 独立、按需求触发的 follow-up ─────────────┘
+```
+
+这份 Roadmap 刻意保持短小。只有真正阻塞**本仓库拥有的 release guarantee** 的事项才进入发布主线；生态事项放在生态主线；不支持的事情继续作为明确边界。

--- a/docs/adr/web-enforcement.md
+++ b/docs/adr/web-enforcement.md
@@ -1,73 +1,92 @@
 [简体中文](./web-enforcement.zh-CN.md) | English
 
-# ADR — DSH Web Multi-Tenant Enforcement (converged)
+# ADR — DSH Web Multi-Tenant Enforcement (release-converged)
 
-> Status: **proposed**. Converges M2 (session genesis), M3.0 (admission
-> composition), and the web Seam Map (`../specs/web-seam-map.md`). Supersedes the
-> earlier web ADR (which predated M2/M3.0).
+> Status: **proposed**. Converges the session-genesis, admission-composition,
+> real-`ApiProxy`, and RC7 transport evidence. This ADR now follows the project
+> boundary rule: owned enforcement is implemented here; missing DSH transport
+> scope is an ecosystem seam, not a reason to fork the carrier.
 
 ## Context
 
-The core (`dsh-multi-tenant`) owns session ownership + fail-closed
-authorization. The question is the **minimal upstream seam** needed to enforce
-multi-tenancy across DSH Web's surfaces.
+The core (`dsh-multi-tenant`) owns session ownership and fail-closed
+authorization. The Web question is narrower: what is the smallest DSH seam
+needed to carry an authenticated request/connection identity into that owned
+enforcement without shared ambient state?
 
 ## Converged findings
 
 | Concern | Status |
 | --- | --- |
-| **H1 — session genesis** | **resolved (M2)** — the Agent `setup` hook is the before-visibility async admission point; no core change. |
-| **Admission composability** | **runtime-proven (M4 ②-A)** — a decorator can join `ctx.agents.create/resume` and its admission runs inside `setup` before `sessions.enter`; *unfailing transport/scope installation* remains part of ②-C. |
-| **Unary enforcement** | **runtime shape implemented (M4 ②-B)** — `bindTenant` wraps the real `ApiProxy` and every `RpcMethodMap` member is exhaustively classified at compile time. The policy is deliberately fail-closed: session points are guarded, only `session.list` is post-filtered, `session.create` is admission-gated, and unmodelled host/global management surfaces are denied. |
-| **Streams / respond** | **pending M4 ②-C** — currently denied. `events` needs principal-bound filtering; `respond` needs runtime proof of `rpcId → sessionId` correlation before authorization. |
-| **Ghost ownership** | **v0 security-safe tombstone** (M2) — session ids must not be reusable; cleanup semantics deferred. |
+| **H1 — session genesis** | **Resolved.** Agent `setup` is the before-visibility async admission point; no kernel change is required. |
+| **Admission composability** | **Runtime-proven on RC6; RC7 refresh is release compatibility work.** A decorator joins `ctx.agents.create/resume` and runs admission before `sessions.enter`. |
+| **Unary enforcement** | **Implemented as the real shape.** `bindTenant` wraps the real `ApiProxy`; every `RpcMethodMap` member is exhaustively classified and the policy fails closed. |
+| **H3 — request/connection principal scope** | **RC7 ecosystem gap.** Public `ConnectionRpcHandler` receives only decoded `(endpoint, payload, signal)`, while the DSH Web carrier owns the real HTTP/WS boundary and documents that it has no authentication layer. |
+| **Streams / respond** | **Deferred behind H3.** They remain denied in the spike. Implement them only when a real principal-scoped transport path exists. |
+| **Ghost ownership** | **v0 security-safe tombstone.** Session ids must not be reused; cleanup semantics are independent later work. |
 
-## The remaining transport question — H3
+## H3 under RC7 — ecosystem deliverable
 
-The facade takes a `TenantPrincipal`, but the principal is **dropped at the RPC
-boundary** (`ConnectionRpcHandler = (endpoint, payload, signal)`). It exists
-only at the transport boundary (HTTP fetch `new Request(req)`, WS upgrade
-`handleMux(req)`), and DSH then collapses into a shared singleton
-(`HostConnectionService`, one `ApiProxy`, one `WebSocketDownlinks`). There is
-currently no proven per-request/per-connection binding point for the tenant
-principal.
+The facade needs a `TenantPrincipal`, but RC7's public Connection RPC seam no
+longer has the transport request when the decoded handler runs. The real HTTP
+request / WS upgrade is held inside the DSH Web carrier, and the shipped carrier
+explicitly describes its host fence as reachability policy rather than
+authentication.
 
-The current hypothesis is therefore **H3**: the real transport needs a
-request/connection-scoped principal seam. M4 ②-C must prove that this is the
-only missing upstream requirement; the upstream proposal is not filed before
-that proof.
+That evidence is sufficient to classify H3 as **ecosystem-owned**. The project
+should not build and maintain a production replacement for DSH's Web transport
+just to make the local checklist complete.
 
-## Security policy for the v0 web surface
+The deliverable is a **minimal tenant-agnostic upstream seam** that lets a
+consumer derive or install request/connection-scoped API/security context from
+the actual HTTP request / WS upgrade. The proposal should preserve DSH's carrier
+ownership and be useful beyond this plugin.
 
-`RpcMethodMap` coverage is exhaustive, but exhaustive coverage does not mean
-that every host capability is tenant-safe. Until a resource or privilege model
-exists, v0 follows these rules:
+A small local probe may still be used to sharpen an API proposal, but a full
+HTTP/WS transport clone is no longer a prerequisite for the kernel release or
+for filing the upstream proposal.
+
+## v0 Web spike security policy
+
+`RpcMethodMap` coverage is exhaustive, but exhaustive coverage does not make
+host-global capabilities tenant-safe. Until real resource semantics and H3
+exist, the spike stays fail-closed:
 
 - session-keyed point operations → **GUARD**;
-- `session.list` → **FILTER** (post-filtering preserves its current semantics);
-- `session.create` → **ADMIT**, and is denied by the standalone facade until the
-  pre-publication admission bridge is installed;
-- `session.search` → **DENY** for now because DSH returns a globally ranked,
-  capped result set; post-filtering it is not a correct tenant-scoped query;
+- `session.list` → **FILTER** only while post-filtering preserves semantics;
+- `session.create` → **ADMIT**, denied until principal-scoped admission can be
+  installed before publication;
+- `session.search` → **DENY** for now; tenant-scoped ranking/visibility belongs
+  to a later search contract;
 - deployment/host management (`settings.*`, `credentials.*`, host/workspace,
   preset authoring, host-scoped LLM configuration/discovery) → **DENY**;
-- explicitly tenant-neutral read-only discovery may be **ALLOW** (currently
-  `agentPreset.list`).
+- explicitly tenant-neutral read-only discovery may be **ALLOW**.
+- streams, `respond`, and downloads stay **DENY** until their supported security
+  semantics are implemented.
 
-## Explicitly not required by current evidence
+## Explicitly not required
 
-- a kernel change (H1 resolved via `setup`);
-- a new global setup-contribution registry (the admission decorator is
-  runtime-feasible; installation ordering is verified in ②-C).
+Current evidence does **not** require:
 
-No claim is made yet that `respond` needs — or does not need — a dedicated
-upstream seam. The current implementation denies it until M4 ②-C proves a safe
-correlation path.
+- a kernel change;
+- a global setup-contribution registry;
+- a permanent fork or reimplementation of DSH Web transport;
+- JWT/OIDC/API-key logic inside the kernel;
+- making host-global DSH resources tenant-owned as part of v0.1.
+
+`respond` may require correlation state once a principal-scoped connection path
+exists. That is an enforcement detail to prove then, not a reason to expand the
+upstream proposal preemptively.
 
 ## Next
 
-②-A (admission decorator) and ②-B (real `ApiProxy` + exhaustive unary
-classification) are complete. Remaining M4 work is ②-C: real HTTP/WS transport,
-principal lifetime, mux/host filtering, `respond` correlation, and unfailing
-installation ordering. Only then file the upstream proposal and proceed to full
-web enforcement.
+1. **Release track:** refresh the affected admission/ApiProxy evidence on RC7;
+   this is enough for the kernel compatibility baseline.
+2. **Ecosystem track:** file the small request/connection-scope upstream
+   proposal, with concurrency and HTTP/WS lifetime conformance expectations.
+3. **After an adequate seam exists:** turn `dsh-multi-tenant-web` into a
+   production plugin and prove mux/host/respond plus unary/admission in a
+   two-tenant E2E suite.
+
+Production Web enforcement no longer blocks the first `dsh-multi-tenant`
+kernel prerelease.

--- a/docs/adr/web-enforcement.zh-CN.md
+++ b/docs/adr/web-enforcement.zh-CN.md
@@ -1,47 +1,62 @@
 [English](./web-enforcement.md) | 简体中文
 
-# ADR — DSH Web 多租户强制（收敛版）
+# ADR — DSH Web 多租户强制（发布收敛版）
 
-> 状态：**proposed（提案）**。收敛 M2（会话创生）、M3.0（准入组合）与 web Seam Map（`../specs/web-seam-map.md`）。取代早期（早于 M2/M3.0 的）web ADR。
+> 状态：**proposed（提案）**。收敛 session genesis、admission composition、真实 `ApiProxy` 以及 RC7 transport 证据。本文档现在明确遵循项目边界原则：本仓库控制得住的 enforcement 自己实现；DSH transport 缺少的 scope 作为生态 seam 处理，而不是 fork carrier。
 
 ## 背景
 
-内核（`dsh-multi-tenant`）拥有会话所有权 + 默认拒绝式授权。问题在于：跨 DSH Web 各 surface 强制多租户所需的最小上游 seam 是什么。
+内核（`dsh-multi-tenant`）拥有 session ownership 和 fail-closed authorization。Web 问题更窄：需要 DSH 提供什么最小 seam，才能把一个已认证的 request/connection identity 带入本仓库拥有的 enforcement，同时不依赖共享 ambient state。
 
-## 收敛后的发现
+## 收敛后的结论
 
 | 关注点 | 状态 |
 | --- | --- |
-| **H1 — 会话创生** | **已解决（M2）** —— Agent `setup` 钩子是可见之前的异步准入点；无需内核改动。 |
-| **准入组合性** | **运行时已证（M4 ②-A）** —— 装饰器可以加入 `ctx.agents.create/resume`，其准入在 `setup` 内、`sessions.enter` 之前运行；*无条件的 transport/scope 安装*仍属 ②-C。 |
-| **Unary 强制** | **真实形态已实现（M4 ②-B）** —— `bindTenant` 包装真实 `ApiProxy`，`RpcMethodMap` 的每个成员都在编译期穷举分类。策略刻意默认拒绝：session point 做 guard，仅 `session.list` 做 post-filter，`session.create` 走 admission gate，未建模的 host/global 管理面一律 deny。 |
-| **Streams / respond** | **待 M4 ②-C** —— 当前直接拒绝。`events` 需要 principal-bound 过滤；`respond` 需要先运行时证明 `rpcId → sessionId` 关联，再做授权。 |
-| **幽灵所有权** | **v0 在安全上可接受的墓碑**（M2） —— 会话 id 必须不可复用；清理语义延后。 |
+| **H1 — session genesis** | **已解决。** Agent `setup` 是 visibility 前的异步准入点；不需要 kernel 改动。 |
+| **Admission composability** | **RC6 runtime 已证明；RC7 refresh 属于发布兼容性工作。** decorator 可以加入 `ctx.agents.create/resume`，且 admission 在 `sessions.enter` 前执行。 |
+| **Unary enforcement** | **真实形态已实现。** `bindTenant` 包装真实 `ApiProxy`；`RpcMethodMap` 每个成员都被穷举分类，策略默认拒绝。 |
+| **H3 — request/connection principal scope** | **RC7 生态缺口。** 公开的 `ConnectionRpcHandler` 只有解码后的 `(endpoint, payload, signal)`；真实 HTTP/WS boundary 由 DSH Web carrier 持有，而且官方文档明确说明目前没有 authentication layer。 |
+| **Streams / respond** | **在 H3 之后处理。** spike 中继续拒绝。只有真实 principal-scoped transport path 存在后才实现。 |
+| **Ghost ownership** | **v0 在安全上可接受的 tombstone。** Session id 不可复用；cleanup semantics 是独立后续工作。 |
 
-## 剩余的 transport 问题 — H3
+## RC7 下的 H3 —— 生态交付物
 
-facade 接收一个 `TenantPrincipal`，但 principal 在 **RPC 边界被丢弃**（`ConnectionRpcHandler = (endpoint, payload, signal)`）。它只存在于 transport 边界（HTTP fetch `new Request(req)`、WS 升级 `handleMux(req)`），随后 DSH 塌缩为一个共享单例（`HostConnectionService`、一个 `ApiProxy`、一个 `WebSocketDownlinks`）。目前还没有被证明可用的 per-request/per-connection principal 绑定点。
+facade 需要一个 `TenantPrincipal`，但 RC7 的公开 Connection RPC seam 在 decoded handler 执行时已经拿不到 transport request。真实 HTTP request / WS upgrade 保留在 DSH Web carrier 内部；官方 carrier 也明确把现有 host fence 定义为 reachability policy，而不是 authentication。
 
-因此当前假设仍是 **H3**：真实 transport 需要一个 request/connection-scoped principal seam。M4 ②-C 必须证明这是唯一剩余的上游需求；在这个证明完成之前不提交上游提案。
+这些证据已经足够把 H3 归类为**生态拥有**。本项目不应该为了让本地 checklist 看起来完整，就长期构建并维护一套 DSH Web transport 替代实现。
 
-## v0 Web surface 的安全策略
+真正应该交付的是一个**最小、tenant-agnostic 的 upstream seam**：让 consumer 可以基于真实 HTTP request / WS upgrade 建立或安装 request/connection-scoped API/security context。proposal 应保留 DSH 对 carrier 的所有权，并尽量让这个 seam 对其他插件也有价值。
 
-`RpcMethodMap` 的覆盖已经穷举，但“穷举”不等于“每个 Host 能力都适合直接暴露给租户”。在资源模型或权限模型尚未建立前，v0 采用以下规则：
+为了打磨 API proposal，可以继续写一个很小的 local probe；但完整 HTTP/WS transport clone 不再是 kernel release 的前置条件，也不再是提交 upstream proposal 的前置条件。
+
+## v0 Web spike 的安全策略
+
+`RpcMethodMap` 已经穷举，但穷举并不等于 host-global capability 就具备 tenant-safe 语义。真实 resource semantics 和 H3 存在之前，spike 继续 fail-closed：
 
 - session-keyed point 操作 → **GUARD**；
-- `session.list` → **FILTER**（当前语义允许正确 post-filter）；
-- `session.create` → **ADMIT**，在 pre-publication admission bridge 尚未装好前由独立 facade 直接拒绝；
-- `session.search` → 暂时 **DENY**，因为 DSH 返回的是全局排序、数量受限的结果集，事后过滤并不等价于 tenant-scoped query；
+- `session.list` → 只有在 post-filter 保持语义正确时才 **FILTER**；
+- `session.create` → **ADMIT**，在 principal-scoped admission 能够 publication 前安装之前继续拒绝；
+- `session.search` → 当前 **DENY**；tenant-scoped ranking/visibility 属于后续 search contract；
 - deployment/host 管理面（`settings.*`、`credentials.*`、host/workspace、preset authoring、host-scoped LLM 配置/发现）→ **DENY**；
-- 明确判断为 tenant-neutral 的只读发现能力可 **ALLOW**（目前为 `agentPreset.list`）。
+- 明确 tenant-neutral 的只读 discovery 可以 **ALLOW**；
+- streams、`respond`、downloads 在支持的安全语义真正实现前继续 **DENY**。
 
-## 当前证据明确不需要的东西
+## 明确不需要的东西
 
-- 内核改动（H1 已通过 `setup` 解决）；
-- 新的全局 setup 贡献注册表（准入装饰器已证明运行时可行；安装顺序在 ②-C 验证）。
+当前证据**不**要求：
 
-目前不声称 `respond` 一定需要、或一定不需要专门的上游 seam。当前实现继续拒绝，直到 M4 ②-C 证明一条安全的 correlation 路径。
+- kernel 改动；
+- 新的全局 setup contribution registry；
+- 永久 fork 或重写 DSH Web transport；
+- 把 JWT/OIDC/API-key 逻辑塞进 kernel；
+- 在 v0.1 中把 DSH host-global resource 强行变成 tenant-owned。
+
+principal-scoped connection path 存在以后，`respond` 可能需要 correlation state。那是届时要验证的 enforcement detail，不是现在提前扩大 upstream proposal 的理由。
 
 ## 下一步
 
-②-A（准入装饰器）和 ②-B（真实 `ApiProxy` + unary 穷举分类）已完成。M4 剩余工作是 ②-C：真实 HTTP/WS transport、principal 生命周期、mux/host 过滤、`respond` correlation，以及无遗漏的安装顺序。完成后再提交上游提案并进入完整 Web 强制。
+1. **发布主线：** 对 RC7 刷新受影响的 admission/ApiProxy evidence；这已经足够形成 kernel compatibility baseline。
+2. **生态主线：** 提交小型 request/connection-scope upstream proposal，并附带并发隔离与 HTTP/WS lifetime 的 conformance expectation。
+3. **足够 seam 存在以后：** 再把 `dsh-multi-tenant-web` 变成 production plugin，并通过 two-tenant E2E 一起证明 unary/admission/mux/host/respond。
+
+Production Web enforcement 不再阻塞第一次 `dsh-multi-tenant` kernel prerelease。

--- a/docs/specs/architecture.md
+++ b/docs/specs/architecture.md
@@ -1,39 +1,43 @@
 [简体中文](./architecture.zh-CN.md) | English
 
-# Architecture — six layers
+# Architecture — six layers, explicit ownership
 
-The project is **one composable plugin family**, organized into six layers. The
-kernel owns only the cross-suite tenant primitives; every layer above it is a
-replaceable capability, and every layer below the kernel is a swappable
-provider. This document is the global map the individual ADRs and Seam Maps are
-anchored to.
+The project is **one composable plugin family**, organized into six conceptual
+layers. The layers describe where a multi-tenant guarantee must connect; they do
+**not** mean this repository must implement every layer. The boundary rule is
+part of the architecture:
+
+- owned enforcement points are implemented and tested here;
+- ecosystem-owned seams are specified and upstreamed;
+- capabilities outside the supported threat model stay explicit boundaries.
 
 ## The six layers
 
-| # | Layer | Artifact | Responsibility | Status |
+| # | Layer | Artifact | Responsibility | Ownership / status |
 | --- | --- | --- | --- | --- |
-| ① | **Kernel** | `dsh-multi-tenant` | `TenantPrincipal` / `SessionOwner`, claim-once ownership, fail-closed authorization, the `TenantSessionStore` contract. | ✅ test-pinned, prerelease contract |
-| ② | **Ownership provider** | `TenantSessionStore` impls | Persist ownership (memory / PostgreSQL / Redis / MySQL / third-party). Proven by the shared contract suite. | ✅ seam + in-memory default; durable providers deferred |
-| ③ | **Genesis admission** | `ctx.agents` decorator | Join every Agent `setup`; establish / inherit / restore ownership before `sessions.enter`. | ✅ runtime-proven for create / fork / subagent / resume; transport installation pending |
-| ④ | **Identity plane** | transport + auth provider | Turn an authenticated HTTP/WS request into a request/connection-scoped `TenantPrincipal`. **H3 lives here.** | ⏳ upstream requirement still to be proven by M4 transport work |
-| ⑤ | **Enforcement plane** | `dsh-multi-tenant-web` | A tenant-bound `ApiProxy`: guarded session points, safe collection projection, admission gating, and fail-closed denial of unmodelled/global surfaces. Streams/respond remain M4 transport work. | 🚧 real unary `ApiProxy` + exhaustive classification done; transport pending |
-| ⑥ | **Distribution / preset** | the official SaaS stack | Compose core + store + web + auth + MCP + audit, each piece replaceable. | ⏳ |
+| ① | **Kernel** | `dsh-multi-tenant` | `TenantPrincipal` / `SessionOwner`, claim-once ownership, fail-closed authorization, the `TenantSessionStore` contract. | **Owned here.** ✅ test-pinned, prerelease contract. |
+| ② | **Ownership provider** | `TenantSessionStore` impls | Persist ownership. Providers prove conformance with the shared contract suite. | **Contract owned here; providers replaceable.** ✅ in-memory reference; durable providers demand-gated. |
+| ③ | **Genesis admission** | `ctx.agents` decorator | Join Agent `setup`; establish / inherit / restore ownership before `sessions.enter`. | **Owned here where DSH exposes the hook.** ✅ RC6 runtime proof; RC7 evidence refresh is release work. |
+| ④ | **Identity bridge** | DSH transport scope + auth resolver/provider | Carry authenticated request/connection identity to a scoped `TenantPrincipal`. | **Split ownership.** 🤝 transport scope is a DSH ecosystem seam; auth providers are optional integrations after that seam exists. |
+| ⑤ | **Enforcement plane** | `dsh-multi-tenant-web` | Principal-bound `ApiProxy`: guard/filter/admit/deny; later streams/respond under the same scope. | **Owned here after Layer ④ exists.** 🚧 unary spike exists; production Web contract is ecosystem-gated. |
+| ⑥ | **Distribution / integration** | optional bundles / recipes | Compose whichever kernel, provider, auth, Web, MCP, audit, or deployment components a product needs. | **Not a mandatory full-stack deliverable.** 🧭 recipes may be added when useful. |
 
 ## Diagram
 
 ```mermaid
 flowchart TD
-    subgraph L4["④ Identity Plane"]
+    subgraph L4["④ Identity Bridge"]
         direction TB
-        HTTP["HTTP / WebSocket"] --> AUTH["Auth Provider<br/>(JWT / OIDC / API key)"]
-        AUTH --> PRINCIPAL["Request / connection-scoped<br/>TenantPrincipal"]
+        HTTP["HTTP / WebSocket"] --> SCOPE["DSH request / connection scope<br/>(ecosystem seam)"]
+        SCOPE --> AUTH["replaceable auth resolver/provider"]
+        AUTH --> PRINCIPAL["scoped TenantPrincipal"]
     end
 
     PRINCIPAL -->|"create / fork / subagent / resume"| GENESIS
     PRINCIPAL -->|"guard / filter / admit"| ENFORCE
 
     subgraph L3["③ Genesis Admission"]
-        GENESIS["AgentSetup hook<br/>establish / inherit / restore"]
+        GENESIS["Agent setup decorator<br/>establish / inherit / restore"]
     end
 
     subgraph L5["⑤ Enforcement Plane"]
@@ -51,72 +55,88 @@ flowchart TD
 
     subgraph L2["② Ownership Provider"]
         STORE["TenantSessionStore contract"]
-        STORE --> MEM["Memory"]
-        STORE --> PG["PostgreSQL"]
-        STORE --> REDIS["Redis"]
-        STORE --> THIRD["third-party"]
+        STORE --> MEM["Memory reference"]
+        STORE --> DURABLE["optional durable providers"]
+        STORE --> THIRD["third-party providers"]
     end
 
-    subgraph L6["⑥ Distribution / Preset"]
-        PRESET["official SaaS stack<br/>core + store + web + auth + MCP + audit"]
+    subgraph L6["⑥ Distribution / Integration"]
+        RECIPE["optional bundles / deployment recipes"]
     end
 
-    PRESET -.-> L1
-    PRESET -.-> L2
-    PRESET -.-> L3
-    PRESET -.-> L4
-    PRESET -.-> L5
+    RECIPE -.-> L1
+    RECIPE -.-> L2
+    RECIPE -.-> L3
+    RECIPE -.-> L4
+    RECIPE -.-> L5
 ```
 
 ## Request flow
 
-1. **④ Identity** — an HTTP request or WS upgrade is authenticated; the auth
-   provider (JWT / OIDC / API key) yields a `TenantPrincipal` bound to the
-   request/connection scope. The kernel never sees the auth mechanism.
+1. **④ Identity bridge** — a deployment authenticates an HTTP request or WS
+   upgrade and resolves a `TenantPrincipal`. For production Web isolation this
+   requires a DSH request/connection scope that can carry or install the scoped
+   API/security context. The kernel never sees JWT/OIDC/API-key mechanics.
 2. **③ Genesis** — on `create` / `fork` / `subagent` / `resume`, the admission
-   decorator joins the Agent `setup` hook and establishes (create), inherits
-   (fork / subagent), or restores (resume) ownership — all before
-   `sessions.enter`, so there is no ownership window.
-3. **⑤ Enforcement** — the tenant-bound `ApiProxy` guards session-keyed methods,
-   post-filters only collections whose semantics remain correct after filtering,
-   and denies unmodelled host/global surfaces. `session.create` is an admission
-   operation, not ordinary allow; streams/respond stay fail-closed until M4's
-   transport proof installs their complete authorization path.
-4. **① Kernel** — `MultiTenantService` authorizes against `TenantSessionStore`
-   (claim-once, immutable, tenant boundary unconditional).
-5. **② Provider** — ownership persists to memory / PostgreSQL / Redis / … behind
-   the `TenantSessionStore` contract.
+   decorator joins Agent `setup` and establishes, inherits, or restores ownership
+   before `sessions.enter`.
+3. **⑤ Enforcement** — a tenant-bound `ApiProxy` guards session-keyed methods,
+   filters only collections whose semantics remain correct, and denies
+   unmodelled/global surfaces. Streams/respond remain denied in the spike until
+   Layer ④ provides a real principal scope.
+4. **① Kernel** — `MultiTenantService` authorizes against the
+   `TenantSessionStore` contract. Tenant and user ownership is immutable in the
+   0.1 line.
+5. **② Provider** — ownership is stored by the selected provider. Provider
+   choice does not change the kernel contract.
 
 ## Dependency direction (one-way)
 
+```text
+Kernel primitives  ◀──  capability contracts  ◀──  providers / integrations
 ```
-Kernel primitives  ◀──  capability contracts  ◀──  providers
-```
 
-- The **kernel** has **zero** transport/vendor dependencies — it never knows
-  JWT / PostgreSQL / HTTP / MCP / Redis. Enforced by `scripts/verify-packages.mjs`.
-- **Capability** packages (③ genesis admission, ⑤ enforcement) own their own
-  contracts and may depend on the kernel's primitives.
-- **Providers** (②) depend on the contract they implement; sibling capabilities
-  do not reach through each other's implementations.
+- The **kernel** has zero transport/vendor dependencies — it never knows JWT,
+  PostgreSQL, HTTP, MCP, Redis, or a particular deployment runtime.
+- Capability packages own only the contracts they can enforce.
+- Provider and integration packages depend on the contract they implement; a
+  sibling capability does not reach through another sibling's implementation.
+- A missing upstream seam is not solved by importing or copying the entire
+  upstream subsystem into the kernel.
 
-## H3 is a hypothesis, not a conclusion
+## H3 under DSH RC7 — ecosystem seam, not kernel blocker
 
-M4 has now runtime-proven the `ctx.agents` decorator for all four genesis paths,
-so admission composability is no longer a second upstream hypothesis. The
-remaining hypothesis is **H3**: the real HTTP/WS transport needs a
-request/connection-scoped principal binding point that lets the admission and
-ApiProxy enforcement run under the correct principal without ambient shared
-state. The upstream proposal is written only after M4's real transport proof;
-if that proof exposes another missing seam, the proposal expands accordingly.
+RC7's public `ConnectionRpcHandler` receives decoded
+`(endpoint, payload, signal)`, while the DSH Web carrier owns the real HTTP/WS
+boundary and documents that it currently has no authentication layer. That is
+enough evidence to classify request/connection principal scope as an
+**ecosystem-owned seam**.
 
-## Layer → doc map
+The project therefore does not need a production-like local Web transport fork
+to release the kernel. The deliverable is a minimal, tenant-agnostic upstream
+proposal that lets a deployment derive/install a request/connection-scoped API
+or security context from the real HTTP request / WS upgrade. When such a seam
+exists, Layer ⑤ can turn its current fail-closed spike into production Web
+enforcement.
 
-| Layer | Docs |
+## Explicit architecture boundary: execution isolation
+
+This architecture protects the application/session control surfaces it covers.
+It does **not** claim process, filesystem, shell, container, credential,
+network/egress, or host isolation for an Agent that the surrounding DSH
+deployment has already allowed to run. Strong execution isolation belongs to
+the deployment/runtime layer and is intentionally outside this plugin family's
+0.1 guarantee.
+
+## Layer → roadmap ownership
+
+| Layer | Roadmap treatment |
 | --- | --- |
-| ① Kernel | `../README.md` core package, `./session-genesis-map.md` |
-| ② Provider | `dsh-multi-tenant/testing` contract suite |
-| ③ Genesis admission | `./session-genesis-map.md`, `./admission-composition.md`, `../adr/session-genesis.md` |
-| ④ Identity plane | `../adr/web-enforcement.md` (H3) |
-| ⑤ Enforcement | `./web-seam-map.md`, `../adr/web-enforcement.md` |
-| ⑥ Preset | `../../ROADMAP.md` (M7) |
+| ① Kernel | first-release blocker; owned and enforced here |
+| ② Provider | contract is release blocker; durable providers are independent follow-ups |
+| ③ Genesis admission | RC7 compatibility evidence is release blocker |
+| ④ Identity bridge | ecosystem track; does not block kernel release |
+| ⑤ Web enforcement | production work waits for Layer ④; not a kernel blocker |
+| ⑥ Distribution / integration | optional recipes, never a required "complete SaaS stack" milestone |
+
+See `../../ROADMAP.md` for the release and ecosystem tracks.

--- a/docs/specs/architecture.zh-CN.md
+++ b/docs/specs/architecture.zh-CN.md
@@ -1,35 +1,40 @@
 [English](./architecture.md) | 简体中文
 
-# 架构 —— 六层
+# 架构 —— 六层，但明确归属
 
-本项目是**一个可组合的插件家族**，组织为六层。内核只拥有跨套件的租户原语；其上每一层都是可替换的能力，其下每一层都是可替换的提供方。本文档是各 ADR 与 Seam Map 所锚定的全局图。
+本项目是**一个可组合的插件家族**，概念上组织为六层。这些层说明多租户保证需要在哪些位置连接，并**不**意味着本仓库必须把每一层都自己实现。边界原则本身就是架构的一部分：
+
+- 本仓库拥有的 enforcement point，由本仓库实现并测试；
+- 属于生态的 seam，由本仓库定义标准并向上游协作；
+- 超出支持 threat model 的能力，继续作为明确边界。
 
 ## 六层
 
-| # | 层 | 产物 | 职责 | 状态 |
+| # | 层 | 产物 | 职责 | 归属 / 状态 |
 | --- | --- | --- | --- | --- |
-| ① | **内核** | `dsh-multi-tenant` | `TenantPrincipal` / `SessionOwner`、一次性认领所有权、默认拒绝式授权、`TenantSessionStore` 契约。 | ✅ 已由测试锁定，契约预发布 |
-| ② | **所有权提供方** | `TenantSessionStore` 实现 | 持久化所有权（内存 / PostgreSQL / Redis / MySQL / 第三方）。由共享契约套件证明。 | ✅ seam + 内存默认；持久提供方延后 |
-| ③ | **创生准入** | `ctx.agents` 装饰器 | 加入每一次 Agent `setup`；在 `sessions.enter` 之前建立 / 继承 / 恢复所有权。 | ✅ create / fork / subagent / resume 已运行时证明；transport 安装仍待完成 |
-| ④ | **身份平面** | transport + auth 提供方 | 把一次已认证的 HTTP/WS 请求变成 request/connection-scoped `TenantPrincipal`。**H3 在这里。** | ⏳ 仍需 M4 transport 证明最终上游需求 |
-| ⑤ | **强制平面** | `dsh-multi-tenant-web` | 租户绑定的 `ApiProxy`：守卫 session point、只对语义安全的 collection 做投影、准入门控，并默认拒绝未建模的 host/global surface。stream/respond 仍属 M4 transport 工作。 | 🚧 真实 unary `ApiProxy` + 穷举分类已完成；transport 待完成 |
-| ⑥ | **分发 / preset** | 官方 SaaS 栈 | 组合 core + store + web + auth + MCP + audit，每一块可替换。 | ⏳ |
+| ① | **内核** | `dsh-multi-tenant` | `TenantPrincipal` / `SessionOwner`、一次性认领所有权、默认拒绝式授权、`TenantSessionStore` 契约。 | **本仓库拥有。** ✅ 已由测试锁定，契约仍是 prerelease。 |
+| ② | **所有权 provider** | `TenantSessionStore` 实现 | 持久化 ownership。Provider 通过共享 contract suite 证明一致性。 | **契约由本仓库拥有；provider 可替换。** ✅ 内存参考实现；durable provider 按需求触发。 |
+| ③ | **创生准入** | `ctx.agents` decorator | 加入 Agent `setup`；在 `sessions.enter` 前建立 / 继承 / 恢复 ownership。 | **DSH 已暴露 hook 的地方由我们强制。** ✅ 有 RC6 runtime proof；RC7 evidence refresh 属于发布工作。 |
+| ④ | **身份桥接** | DSH transport scope + auth resolver/provider | 把已认证 request/connection identity 传递成 scoped `TenantPrincipal`。 | **归属拆分。** 🤝 transport scope 是 DSH 生态 seam；auth provider 在 seam 存在后作为可选 integration。 |
+| ⑤ | **强制平面** | `dsh-multi-tenant-web` | Principal-bound `ApiProxy`：guard/filter/admit/deny；未来在同一 scope 下处理 stream/respond。 | **Layer ④ 存在以后由我们拥有。** 🚧 unary spike 已有；production Web contract 受生态 seam 门控。 |
+| ⑥ | **分发 / integration** | 可选 bundle / recipe | 根据产品需要组合 kernel、provider、auth、Web、MCP、audit 或 deployment 组件。 | **不是必须交付的完整全栈。** 🧭 有价值时再增加 recipe。 |
 
 ## 图示
 
 ```mermaid
 flowchart TD
-    subgraph L4["④ Identity Plane"]
+    subgraph L4["④ Identity Bridge"]
         direction TB
-        HTTP["HTTP / WebSocket"] --> AUTH["Auth Provider<br/>(JWT / OIDC / API key)"]
-        AUTH --> PRINCIPAL["Request / connection-scoped<br/>TenantPrincipal"]
+        HTTP["HTTP / WebSocket"] --> SCOPE["DSH request / connection scope<br/>(ecosystem seam)"]
+        SCOPE --> AUTH["replaceable auth resolver/provider"]
+        AUTH --> PRINCIPAL["scoped TenantPrincipal"]
     end
 
     PRINCIPAL -->|"create / fork / subagent / resume"| GENESIS
     PRINCIPAL -->|"guard / filter / admit"| ENFORCE
 
     subgraph L3["③ Genesis Admission"]
-        GENESIS["AgentSetup hook<br/>establish / inherit / restore"]
+        GENESIS["Agent setup decorator<br/>establish / inherit / restore"]
     end
 
     subgraph L5["⑤ Enforcement Plane"]
@@ -47,52 +52,61 @@ flowchart TD
 
     subgraph L2["② Ownership Provider"]
         STORE["TenantSessionStore contract"]
-        STORE --> MEM["Memory"]
-        STORE --> PG["PostgreSQL"]
-        STORE --> REDIS["Redis"]
-        STORE --> THIRD["third-party"]
+        STORE --> MEM["Memory reference"]
+        STORE --> DURABLE["optional durable providers"]
+        STORE --> THIRD["third-party providers"]
     end
 
-    subgraph L6["⑥ Distribution / Preset"]
-        PRESET["official SaaS stack<br/>core + store + web + auth + MCP + audit"]
+    subgraph L6["⑥ Distribution / Integration"]
+        RECIPE["optional bundles / deployment recipes"]
     end
 
-    PRESET -.-> L1
-    PRESET -.-> L2
-    PRESET -.-> L3
-    PRESET -.-> L4
-    PRESET -.-> L5
+    RECIPE -.-> L1
+    RECIPE -.-> L2
+    RECIPE -.-> L3
+    RECIPE -.-> L4
+    RECIPE -.-> L5
 ```
 
 ## 请求流
 
-1. **④ 身份** —— 一次 HTTP 请求或 WS 升级被认证；auth 提供方（JWT / OIDC / API key）产出一个绑定到 request/connection 作用域的 `TenantPrincipal`。内核永远看不到认证机制。
-2. **③ 创生** —— 在 `create` / `fork` / `subagent` / `resume` 上，准入装饰器加入 Agent `setup` 钩子，并建立（create）、继承（fork / subagent）、恢复（resume）所有权 —— 全部在 `sessions.enter` 之前，因此没有所有权窗口。
-3. **⑤ 强制** —— 租户绑定的 `ApiProxy` 守卫 session-keyed 方法，只对 post-filter 后仍保持正确语义的 collection 做过滤，并拒绝未建模的 host/global surface。`session.create` 属于准入操作，不是普通 ALLOW；stream/respond 在 M4 transport 证明完成前继续默认拒绝。
-4. **① 内核** —— `MultiTenantService` 对 `TenantSessionStore` 授权（一次性认领、不可变、租户边界无条件）。
-5. **② 提供方** —— 所有权在 `TenantSessionStore` 契约之后持久化到内存 / PostgreSQL / Redis / …。
+1. **④ 身份桥接** —— deployment 对 HTTP request 或 WS upgrade 做认证，并解析出 `TenantPrincipal`。要实现 production Web isolation，需要 DSH 提供 request/connection scope，使 scoped API/security context 能在真实 transport 边界安装。Kernel 永远不知道 JWT/OIDC/API-key 的具体机制。
+2. **③ 创生** —— 在 `create` / `fork` / `subagent` / `resume` 上，admission decorator 加入 Agent `setup`，并在 `sessions.enter` 之前建立、继承或恢复 ownership。
+3. **⑤ 强制** —— tenant-bound `ApiProxy` 守卫 session-keyed method，只过滤 post-filter 后语义仍正确的 collection，并拒绝未建模/global surface。Layer ④ 提供真实 principal scope 之前，spike 中的 stream/respond 继续默认拒绝。
+4. **① 内核** —— `MultiTenantService` 通过 `TenantSessionStore` contract 做授权。0.1 版本线保持 tenant+user ownership 不可变。
+5. **② Provider** —— ownership 由选定 provider 存储。Provider 选择不会改变 kernel contract。
 
 ## 依赖方向（单向）
 
+```text
+内核原语  ◀──  能力契约  ◀──  provider / integration
 ```
-内核原语  ◀──  能力契约  ◀──  提供方
-```
 
-- **内核**有**零** transport/vendor 依赖 —— 它永远不感知 JWT / PostgreSQL / HTTP / MCP / Redis。由 `scripts/verify-packages.mjs` 强制。
-- **能力**包（③ 创生准入、⑤ 强制）拥有自己的契约，且可以依赖内核原语。
-- **提供方**（②）依赖其所实现的契约；兄弟能力不穿透彼此的实现。
+- **内核**没有 transport/vendor 依赖 —— 不感知 JWT、PostgreSQL、HTTP、MCP、Redis 或具体 deployment runtime。
+- capability package 只拥有它真正能强制的 contract。
+- provider / integration package 依赖自己实现的 contract；兄弟能力不穿透彼此实现。
+- 缺少 upstream seam 时，不通过把整个 upstream subsystem 导入或复制进 kernel 来“解决”。
 
-## H3 是假设，不是结论
+## DSH RC7 下的 H3 —— 生态 seam，不是 kernel 发布阻塞项
 
-M4 已经运行时证明 `ctx.agents` 装饰器覆盖四条创生路径，因此准入组合性不再是第二个上游假设。当前剩余假设是 **H3**：真实 HTTP/WS transport 需要一个 request/connection-scoped principal 绑定点，使准入与 `ApiProxy` 强制在正确 principal 下执行，而不依赖共享 ambient 状态。上游提案只在 M4 真实 transport 证明完成后提交；如果该证明暴露新的缺口，则提案随证据扩展。
+RC7 公开的 `ConnectionRpcHandler` 接收解码后的
+`(endpoint, payload, signal)`；真实 HTTP/WS boundary 由 DSH Web carrier 自己持有，而且官方文档明确说明目前没有 authentication layer。这些证据已经足够把 request/connection principal scope 归类为**生态拥有的 seam**。
 
-## 层 → 文档对照
+因此，发布 kernel 不需要先做一套 production-like 的本地 Web transport fork。本项目应该交付一个最小、tenant-agnostic 的 upstream proposal，让 deployment 可以基于真实 HTTP request / WS upgrade 建立或安装 request/connection-scoped API/security context。这个 seam 存在以后，Layer ⑤ 才把当前 fail-closed spike 变成 production Web enforcement。
 
-| 层 | 文档 |
+## 明确架构边界：执行隔离
+
+本架构保护的是它实际覆盖的 application/session control surface。对于 surrounding DSH deployment 已经允许执行的 Agent，本项目**不**声称提供 process、filesystem、shell、container、credential、network/egress 或 host isolation。强执行隔离属于 deployment/runtime 层，并明确不在本插件家族 0.1 guarantee 中。
+
+## Layer → Roadmap 归属
+
+| Layer | Roadmap 处理方式 |
 | --- | --- |
-| ① 内核 | `../README.md` 核心包、`./session-genesis-map.md` |
-| ② 提供方 | `dsh-multi-tenant/testing` 契约套件 |
-| ③ 创生准入 | `./session-genesis-map.md`、`./admission-composition.md`、`../adr/session-genesis.md` |
-| ④ 身份平面 | `../adr/web-enforcement.md`（H3） |
-| ⑤ 强制 | `./web-seam-map.md`、`../adr/web-enforcement.md` |
-| ⑥ preset | `../../ROADMAP.md`（M7） |
+| ① Kernel | 第一次发布阻塞项；本仓库拥有并强制 |
+| ② Provider | contract 阻塞发布；durable provider 是独立 follow-up |
+| ③ Genesis admission | RC7 compatibility evidence 阻塞发布 |
+| ④ Identity bridge | ecosystem track；不阻塞 kernel release |
+| ⑤ Web enforcement | production 工作等待 Layer ④；不阻塞 kernel |
+| ⑥ Distribution / integration | 可选 recipe，不再是“完整 SaaS 栈”必做 milestone |
+
+发布主线与生态主线见 `../../ROADMAP.md`。

--- a/packages/multi-tenant-web/README.md
+++ b/packages/multi-tenant-web/README.md
@@ -2,23 +2,38 @@
 
 # dsh-multi-tenant-web
 
-DSH Web multi-tenant integration: principal binding, RPC/mux/WS authorization.
+Experimental DSH Web tenant-bound `ApiProxy` enforcement research.
 
-> **Early spike.** No production surface yet. The web-enforcement investigation
-> lives in [`docs/`](../../docs) — see
-> [`docs/adr/web-enforcement.md`](../../docs/adr/web-enforcement.md).
+> **Not a production multi-user Web package yet.** The current code proves
+> fail-closed unary enforcement and admission composition. Production principal
+> binding depends on a DSH request/connection-scoped transport seam; this package
+> does not replace the DSH Web carrier to hide that dependency.
 
 ## Status
 
-M4 is in progress. The admission decorator (②-A) and the real `ApiProxy` facade
-with exhaustive unary classification (②-B) are done. `CLASSIFICATION` covers
-all 52 current unary RPC methods and a new DSH method fails `tsc` until it is
-classified.
+The real `ApiProxy` facade and exhaustive unary `RpcMethodMap` classification
+are implemented. The current policy is deliberately fail-closed:
 
-The v0 policy is deliberately fail-closed: session-keyed point methods are
-`guard`, only `session.list` is currently safe to `filter`, `session.create` is
-`admit` (denied until the transport installs the pre-publication admission
-bridge), and unmodelled host/deployment management plus `session.search` are
-`deny`. Streams (`events`), `respond`, and `downloads` remain denied until ②-C
-proves their real transport authorization path. H3 remains the principal-
-binding hypothesis to validate, not a filed upstream conclusion yet.
+- session-keyed point methods are `guard`;
+- only `session.list` is currently `filter`;
+- `session.create` is `admit` and remains denied until principal-scoped
+  pre-publication admission can be installed;
+- `session.search`, host/global management, streams, `respond`, and downloads
+  remain denied until their supported tenant semantics exist.
+
+DSH RC7's public `ConnectionRpcHandler` exposes decoded
+`(endpoint, payload, signal)`, while the real HTTP/WS request stays inside the DSH
+Web carrier. The official carrier also documents that it currently has no
+authentication layer. The principal-scope gap is therefore treated as an
+**ecosystem seam**.
+
+## What happens next
+
+This package does **not** block the first `dsh-multi-tenant` kernel prerelease.
+The next Web deliverable is a small, generic upstream request/connection-scope
+proposal. Once DSH exposes an adequate seam, this package can add principal-bound
+HTTP/WS admission, streams, `respond`, and a two-tenant E2E suite, then freeze a
+production public contract.
+
+See [`ROADMAP.md`](../../ROADMAP.md) and
+[`docs/adr/web-enforcement.md`](../../docs/adr/web-enforcement.md).

--- a/packages/multi-tenant-web/README.zh-CN.md
+++ b/packages/multi-tenant-web/README.zh-CN.md
@@ -2,12 +2,23 @@
 
 # dsh-multi-tenant-web
 
-DSH Web 多租户集成：主体绑定、RPC/mux/WS 授权。
+实验性的 DSH Web tenant-bound `ApiProxy` enforcement 研究。
 
-> **早期 spike。** 尚无生产 surface。web 强制调研位于 [`docs/`](../../docs) —— 见 [`docs/adr/web-enforcement.md`](../../docs/adr/web-enforcement.md)。
+> **目前还不是 production 多用户 Web package。** 当前代码证明了 fail-closed unary enforcement 与 admission composition。Production principal binding 依赖 DSH request/connection-scoped transport seam；本 package 不会为了掩盖这个依赖而替换 DSH Web carrier。
 
 ## 状态
 
-M4 进行中。准入装饰器（②-A）与真实 `ApiProxy` facade + unary 穷举分类（②-B）已完成。`CLASSIFICATION` 覆盖当前全部 52 个 unary RPC 方法；DSH 新增方法时，未分类前会直接令 `tsc` 失败。
+真实 `ApiProxy` facade 与 unary `RpcMethodMap` 穷举分类已经实现。当前策略刻意 fail-closed：
 
-v0 策略刻意默认拒绝：session-keyed point 方法为 `guard`，目前只有 `session.list` 适合 `filter`，`session.create` 为 `admit`（transport 尚未安装发布前准入 bridge 时直接拒绝），未建模的 host/deployment 管理面以及 `session.search` 都为 `deny`。流（`events`）、`respond` 与 `downloads` 在 ②-C 证明真实 transport 授权路径之前继续拒绝。H3 仍是待验证的 principal 绑定假设，而不是已经提交的上游结论。
+- session-keyed point method 为 `guard`；
+- 当前只有 `session.list` 为 `filter`；
+- `session.create` 为 `admit`，在 principal-scoped pre-publication admission 可以安装以前继续拒绝；
+- `session.search`、host/global management、streams、`respond`、downloads 在真正具备支持的 tenant 语义以前继续拒绝。
+
+DSH RC7 公开的 `ConnectionRpcHandler` 只暴露解码后的 `(endpoint, payload, signal)`，真实 HTTP/WS request 留在 DSH Web carrier 内部。官方 carrier 文档也明确说明当前没有 authentication layer。因此 principal-scope 缺口被归类为**生态 seam**。
+
+## 下一步
+
+这个 package **不阻塞**第一次 `dsh-multi-tenant` kernel prerelease。Web 的下一项交付是一个小而通用的 upstream request/connection-scope proposal。DSH 提供足够 seam 以后，本 package 再增加 principal-bound HTTP/WS admission、streams、`respond` 与 two-tenant E2E suite，然后再冻结 production public contract。
+
+参见 [`ROADMAP.md`](../../ROADMAP.md) 与 [`docs/adr/web-enforcement.md`](../../docs/adr/web-enforcement.md)。

--- a/packages/multi-tenant-web/package.json
+++ b/packages/multi-tenant-web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dsh-multi-tenant-web",
   "version": "0.1.0",
-  "description": "DSH Web multi-tenant integration: principal binding, RPC/mux/WS authorization. Early spike.",
+  "description": "Experimental DSH Web tenant-bound ApiProxy enforcement; production request/connection principal binding depends on a DSH transport seam.",
   "license": "MIT",
   "engines": {
     "node": ">=22.19"

--- a/packages/multi-tenant/README.md
+++ b/packages/multi-tenant/README.md
@@ -2,109 +2,50 @@
 
 # dsh-multi-tenant
 
-Multi-tenant SaaS extension for DeepSeek Harness (DSH): tenant identity,
-session ownership, authorization boundaries, tenant-aware MCP, and audit.
+Multi-tenant kernel primitives for DeepSeek Harness (DSH): tenant identity,
+immutable session ownership, fail-closed authorization, and a replaceable
+ownership-store contract.
 
-> **Status: early development / architecture bootstrap.** This repository
-> implements the multi-tenant **core contract** only. It is **not** a complete
-> SaaS security solution — see [What this core is not](#what-this-core-is-not).
+> **Status: first 0.1 prerelease line.** This package is intentionally small. It
+> is the kernel release candidate; Web/auth/MCP/runtime isolation are separate
+> integration or ecosystem concerns. See the repository
+> [ROADMAP](../../ROADMAP.md).
 
----
+## Supported guarantee
 
-## What this core does
+Given an authenticated `TenantPrincipal`, this package owns and authorizes access
+to opaque DSH session ids through a fail-closed ownership contract.
 
-Given an authenticated `TenantPrincipal`, `dsh-multi-tenant` owns and authorizes
-access to opaque DSH session ids through a fail-closed, durable-store-compatible
-ownership contract.
+It provides two Cordis services:
 
-Concretely, it provides two Cordis services — `ctx.tenantSessionStore` (the
-ownership-storage seam) and `ctx.multiTenant` (ownership + authorization) —
-that together:
+- `ctx.tenantSessionStore` — the replaceable ownership-storage seam;
+- `ctx.multiTenant` — claim-once ownership and authorization.
 
-- **abstracts the authenticated principal** (`TenantPrincipal`),
-- **owns sessions** with claim-once, immutable ownership,
-- **enforces the tenant boundary** unconditionally (no role crosses it),
-- **authorizes fail-closed** (unknown and foreign sessions are both denied),
-- **defines a storage seam** (`TenantSessionStore`) so ownership persistence can
-  move to a durable store without a breaking API change.
+The kernel guarantees:
 
-## What this core is not
+- **claim-once, immutable ownership**;
+- **unconditional tenant boundary** — no role can cross tenants;
+- **same-user ownership in v0.1** — same tenant but different user is denied;
+- **fail-closed authorization** — unknown and foreign sessions are denied;
+- **non-enumerating public denial** — unknown vs foreign is not disclosed;
+- **async storage contract** so a durable provider can replace the in-memory
+  reference without changing the kernel API.
 
-- ❌ Authentication / HTTP transport (no JWT, cookies, web login)
-- ❌ Transport authorization / WebSocket filtering / `events.mux` / `events.host`
-- ❌ MCP client or tenant-aware MCP credential pooling
-- ❌ Downstream data isolation / ERP token
-- ❌ Audit persistence
-- ❌ UI / billing / dashboards
-- ❌ An RBAC / role-policy framework
+## Explicit boundaries
 
-These are all on the [roadmap](#roadmap). The core is the middle of the future
-chain:
+This package is **not**:
 
-```text
-Authenticated Transport
-        ↓
-TenantPrincipal
-        ↓
-dsh-multi-tenant Core          ← this repository (Principal + Ownership + Authorization)
-        ↓
-Session ACL
-        ↓
-Tenant-aware MCP / business credentials
-        ↓
-Downstream tenant validation
-```
+- an authentication or HTTP/WebSocket transport layer;
+- a production multi-user DSH Web integration;
+- a durable database provider (the bundled in-memory provider is bootstrap/dev);
+- an MCP credential/context implementation;
+- an audit/usage store;
+- process, shell, filesystem, container, credential, or network isolation;
+- billing, UI, organization/user administration, or a general RBAC framework;
+- a team-sharing/ACL/reassignment model.
 
-## Architecture
-
-```text
-Browser / SaaS client
-        |
-        | authenticated identity
-        v
-Tenant-aware connection / API boundary
-        |
-        | TenantPrincipal
-        v
-Session authorization
-        |
-        +---------------------+
-        |                     |
-        v                     v
-Shared DeepSeek Harness   Tenant-aware MCP
-Agent Loop / LLM / Tools  credential pool
-        |
-        v
-Session persistence
-        |
-        v
-Audit / usage store
-```
-
-## Design principles
-
-- **Shared runtime, logical isolation** — one Harness process, many tenants,
-  separated by authorization rather than by process or fork.
-- **Fail closed** — unknown sessions and unauthenticated identities are denied.
-- **Identity is server-derived** — `TenantPrincipal` comes from the
-  authenticated boundary, never from a client-supplied field.
-- **Claim-once ownership** — a session's owner is immutable; a conflicting
-  claim is denied, never overwritten.
-- **Streams are authorization surfaces** — sessions, RPC, and tool/MCP streams
-  are each a boundary, not just the HTTP entry point.
-- **Defense in depth** — this core is one layer; it does not replace the
-  authenticated boundary or downstream tenant validation.
-- **Prefer plugins over forks** — build on DSH's public plugin/service seams.
-
-## Install
-
-```sh
-dsh plugin --profile web add github:GuoMonth/dsh-multi-tenant
-```
-
-The package declares [`dsh.bundle`](./package.json), so this appends its patch
-layer to the profile and mounts both `ctx.tenantSessionStore` and
-`ctx.multiTenant`.
+Those items are not all “future kernel features”. The project rule is:
+**control → enforce, ecosystem → standardize, outside control → bound**.
 
 ## Core API
 
@@ -123,12 +64,11 @@ interface SessionOwner {
 }
 ```
 
-### `TenantSessionStore` (service seam, `ctx.tenantSessionStore`)
+### `TenantSessionStore` (`ctx.tenantSessionStore`)
 
-The storage seam is a Cordis **Service**, not a plain interface: it is provided
-by a backend plugin and consumed by `MultiTenantService`. `claim` is **atomic**
-(single operation, not get-then-set) so a durable backend can map it to
-`INSERT … ON CONFLICT`:
+The storage seam is a Cordis `Service`. `claim` is one atomic contract operation
+so durable providers can implement it with their native conditional-write
+primitive.
 
 ```ts
 type ClaimResult = 'created' | 'idempotent' | 'conflict'
@@ -139,82 +79,52 @@ abstract class TenantSessionStore extends Service {
 }
 ```
 
-There is deliberately **no release/delete** in the v0 contract: ownership is
-claim-once and immutable. `InMemoryTenantSessionStore` is the default provider —
-a process-local `Map`, intended for **development/bootstrap only**, not
-production persistence. A future durable backend swaps the `tenantSessionStore`
-provider without touching `MultiTenantService`.
+There is deliberately no release/reassign API in the 0.1 contract. Ownership is
+immutable. `InMemoryTenantSessionStore` is the reference provider and is intended
+for tests/bootstrap, not production durability.
+
+Third-party providers should run the shared contract suite exported from
+`dsh-multi-tenant/testing`.
 
 ### `MultiTenantService` (`ctx.multiTenant`)
 
-Consumes `ctx.tenantSessionStore` (declared via `static inject`). All methods are
-async so a durable store can be adopted without a breaking change.
-
 | Method | Semantics |
 | --- | --- |
-| `claimSession(sessionId, principal)` | Claim-once. Unclaimed → success; same owner → idempotent; different owner → `SessionOwnershipConflictError`. |
-| `getSessionOwner(sessionId)` | Trusted-facing lookup; returns the owner or `undefined`. |
-| `canAccessSession(principal, sessionId)` | Fail-closed boolean. Same tenant + same owner → `true`; else `false`. |
-| `assertSessionAccess(principal, sessionId)` | Like above, but throws a uniform `SessionAccessDeniedError`. |
+| `claimSession(sessionId, principal)` | Unclaimed → create; same owner → idempotent; other owner → conflict. |
+| `getSessionOwner(sessionId)` | Trusted-facing owner lookup. |
+| `canAccessSession(principal, sessionId)` | Fail-closed boolean authorization. |
+| `assertSessionAccess(principal, sessionId)` | Same policy, throwing a uniform `SessionAccessDeniedError` on denial. |
 
-Authorization semantics:
-
-- **Unknown session** → denied.
-- **Tenant mismatch** → denied (unconditional; checked before anything else).
-- **Same tenant, different user** → denied (ownership only; no RBAC yet).
-- **Same tenant, same user** → allowed.
-
-Identifiers (`sessionId`, `tenantId`, `userId`) are **opaque**: the core never
-parses a tenant id out of a session id, never uses prefix-based authorization,
-and never assumes UUID/numeric shapes — only opaque exact-match identity.
+Authorization is exact-match and opaque: the kernel never parses tenant identity
+from a session id and never authorizes by prefix.
 
 ## Error privacy
 
-`assertSessionAccess` throws a single, non-enumerating `SessionAccessDeniedError`
-(`"Access to session denied."`). Unknown sessions and foreign sessions are
-indistinguishable, and the error never carries the owner's tenant or user id.
-Internal diagnostic reasons (`UNKNOWN_SESSION`, `TENANT_MISMATCH`,
-`USER_MISMATCH`) exist for tests/audit/observability but are not part of the
-public authorization result.
+`assertSessionAccess` exposes one non-enumerating denial. Unknown sessions and
+foreign sessions are intentionally indistinguishable to callers; owner tenant or
+user identity is never included in the public error.
 
-## Security boundary
+## Install / composition
 
-Cordis / DSH **scope** is a *composition and visibility* mechanism — service
-isolation and dependency wiring. It is **not** by itself a multi-tenant security
-boundary.
-
-A production deployment must enforce isolation across layers:
-
-```text
-authenticated request boundary
-        +
-session ACL                          ← this core
-        +
-tenant-aware MCP / business token
-        +
-downstream ERP / business API tenant validation
+```sh
+dsh plugin --profile web add github:GuoMonth/dsh-multi-tenant
 ```
 
-Do not treat the in-memory store or the Cordis scope as the security perimeter.
+The package bundle mounts the in-memory `tenantSessionStore` reference and the
+`multiTenant` service. A deployment that needs durability should replace the
+store provider rather than modify the kernel.
 
-## Roadmap
+## Release path
 
-- [x] project bootstrap
-- [x] `TenantPrincipal` / `SessionOwner`
-- [x] claim-once session ownership
-- [x] fail-closed core authorization
-- [x] `TenantSessionStore` seam (in-memory)
-- [x] runtime invariant validation
-- [x] Loader integration test
-- [ ] durable `TenantSessionStore` (PostgreSQL / MySQL / Redis / remote)
-- [ ] HTTP principal/auth integration
-- [ ] session RPC authorization
-- [ ] WebSocket mux filtering
-- [ ] approval/question RPC ownership
-- [ ] tenant-aware MCP
-- [ ] token usage / audit
-- [ ] DSH Web integration tests
-- [ ] npm prerelease
+The first release only depends on:
+
+1. refreshing affected DSH evidence from RC6 to the current RC7 target;
+2. passing `verify`, typecheck, tests, build, and packed-package smoke;
+3. publishing the 0.1 prerelease with this supported guarantee and boundary.
+
+Production Web principal binding, durable providers, auth providers, search,
+MCP, audit, and deployment recipes are independent follow-ups. See
+[`ROADMAP.md`](../../ROADMAP.md).
 
 ## Development
 
@@ -224,10 +134,6 @@ pnpm typecheck
 pnpm test
 pnpm build
 ```
-
-- `build` runs `tsdown`, emitting `dist/index.mjs` + `dist/index.d.mts`.
-- `typecheck` runs `tsc --noEmit`.
-- `test` runs unit, security, and a real Cordis Loader integration test.
 
 ## License
 

--- a/packages/multi-tenant/README.zh-CN.md
+++ b/packages/multi-tenant/README.zh-CN.md
@@ -2,95 +2,44 @@
 
 # dsh-multi-tenant
 
-面向 DeepSeek Harness（DSH）的多租户 SaaS 扩展：租户身份、会话所有权、授权边界、租户感知的 MCP，以及审计。
+面向 DeepSeek Harness（DSH）的多租户 kernel 原语：tenant identity、不可变 session ownership、fail-closed authorization，以及可替换的 ownership-store contract。
 
-> **状态：早期开发 / 架构引导。** 本仓库只实现多租户**核心契约**。它**不是**完整的 SaaS 安全解决方案 —— 见 [这个核心不是什么](#这个核心不是什么)。
+> **状态：第一次 0.1 prerelease 版本线。** 这个 package 刻意保持小而明确。它是 kernel release candidate；Web/auth/MCP/runtime isolation 属于独立 integration 或生态问题。参见仓库 [ROADMAP](../../ROADMAP.md)。
 
----
+## 支持的保证
 
-## 这个核心做什么
+给定一个已认证的 `TenantPrincipal`，这个 package 通过 fail-closed ownership contract 拥有并授权对不透明 DSH session id 的访问。
 
-给定一个已认证的 `TenantPrincipal`，`dsh-multi-tenant` 通过一个默认拒绝、兼容持久存储的所有权契约，拥有并授权对不透明 DSH 会话 id 的访问。
+它提供两个 Cordis service：
 
-具体而言，它提供两个 Cordis service —— `ctx.tenantSessionStore`（所有权存储 seam）与 `ctx.multiTenant`（所有权 + 授权）—— 二者共同：
+- `ctx.tenantSessionStore` —— 可替换 ownership storage seam；
+- `ctx.multiTenant` —— claim-once ownership 与 authorization。
 
-- **抽象已认证主体**（`TenantPrincipal`），
-- **拥有会话**，采用一次性认领、不可变的所有权，
-- **无条件地强制租户边界**（任何角色都不可跨越），
-- **默认拒绝式授权**（未知会话与外来会话都被拒绝），
-- **定义存储 seam**（`TenantSessionStore`），使所有权持久化可以迁移到持久存储而不破坏 API。
+Kernel 保证：
 
-## 这个核心不是什么
+- **claim-once、不可变 ownership**；
+- **无条件 tenant boundary** —— 任何 role 都不能跨 tenant；
+- **v0.1 同用户 ownership** —— 同 tenant、不同 user 仍拒绝；
+- **fail-closed authorization** —— unknown / foreign session 都拒绝；
+- **不可枚举的公开 denial** —— 不暴露 unknown 与 foreign 的区别；
+- **async storage contract** —— durable provider 可以替换内存参考实现，而无需改变 kernel API。
 
-- ❌ 认证 / HTTP transport（无 JWT、cookies、web 登录）
-- ❌ Transport 授权 / WebSocket 过滤 / `events.mux` / `events.host`
-- ❌ MCP 客户端或租户感知的 MCP 凭据池
-- ❌ 下游数据隔离 / ERP token
-- ❌ 审计持久化
-- ❌ UI / 计费 / 仪表盘
-- ❌ RBAC / 角色-策略框架
+## 明确边界
 
-这些都在[路线图](#路线图)上。核心是未来链条的中间一环：
+这个 package **不是**：
 
-```text
-Authenticated Transport
-        ↓
-TenantPrincipal
-        ↓
-dsh-multi-tenant Core          ← 本仓库（Principal + Ownership + Authorization）
-        ↓
-Session ACL
-        ↓
-Tenant-aware MCP / business credentials
-        ↓
-Downstream tenant validation
-```
+- authentication 或 HTTP/WebSocket transport 层；
+- production 多用户 DSH Web integration；
+- durable database provider（内置内存 provider 只用于 bootstrap/dev）；
+- MCP credential/context 实现；
+- audit/usage store；
+- process、shell、filesystem、container、credential 或 network isolation；
+- billing、UI、组织/用户管理或通用 RBAC framework；
+- team sharing / ACL / reassignment model。
 
-## 架构
+这些东西并不都是“未来 kernel feature”。项目规则是：**控制得住 → 严格强制；需要生态协作 → 制定标准；控制不住 → 明确边界。**
 
-```text
-Browser / SaaS client
-        |
-        | authenticated identity
-        v
-Tenant-aware connection / API boundary
-        |
-        | TenantPrincipal
-        v
-Session authorization
-        |
-        +---------------------+
-        |                     |
-        v                     v
-Shared DeepSeek Harness   Tenant-aware MCP
-Agent Loop / LLM / Tools  credential pool
-        |
-        v
-Session persistence
-        |
-        v
-Audit / usage store
-```
-
-## 设计原则
-
-- **共享运行时，逻辑隔离** —— 一个 Harness 进程，多个租户，靠授权而非进程或 fork 分隔。
-- **默认拒绝（fail closed）** —— 未知会话与未认证身份都被拒绝。
-- **身份由服务端推导** —— `TenantPrincipal` 来自已认证边界，绝不来自客户端提供的字段。
-- **一次性认领所有权** —— 会话的所有者不可变；冲突认领被拒绝，绝不被覆盖。
-- **流是授权 surface** —— session、RPC、tool/MCP 流各自都是一个边界，而不仅是 HTTP 入口点。
-- **纵深防御** —— 此核心只是一层；它不取代已认证边界或下游租户校验。
-- **优先插件而非 fork** —— 构建在 DSH 公开的 plugin/service seam 之上。
-
-## 安装
-
-```sh
-dsh plugin --profile web add github:GuoMonth/dsh-multi-tenant
-```
-
-该包声明了 [`dsh.bundle`](./package.json)，因此这会把它的 patch 层追加到 profile，并挂载 `ctx.tenantSessionStore` 与 `ctx.multiTenant` 两个 service。
-
-## 核心 API
+## Core API
 
 ### 类型
 
@@ -107,9 +56,9 @@ interface SessionOwner {
 }
 ```
 
-### `TenantSessionStore`（service seam，`ctx.tenantSessionStore`）
+### `TenantSessionStore`（`ctx.tenantSessionStore`）
 
-存储 seam 是一个 Cordis **Service**，而非普通接口：它由后端插件提供，并被 `MultiTenantService` 消费。`claim` 是**原子**的（单次操作，而非 get-then-set），以便持久后端将其映射为 `INSERT … ON CONFLICT`：
+Storage seam 是一个 Cordis `Service`。`claim` 是一个原子的 contract 操作，使 durable provider 可以映射到自身的 conditional-write primitive。
 
 ```ts
 type ClaimResult = 'created' | 'idempotent' | 'conflict'
@@ -120,68 +69,42 @@ abstract class TenantSessionStore extends Service {
 }
 ```
 
-v0 契约中**刻意没有 release/delete**：所有权是一次性认领且不可变。`InMemoryTenantSessionStore` 是默认提供方 —— 一个进程内 `Map`，仅供**开发/引导**，而非生产持久化。未来的持久后端通过替换 `tenantSessionStore` 提供方，无需改动 `MultiTenantService`。
+0.1 contract 中刻意没有 release/reassign API。Ownership 不可变。`InMemoryTenantSessionStore` 是参考 provider，只用于测试/bootstrap，不提供 production durability。
+
+第三方 provider 应运行 `dsh-multi-tenant/testing` 导出的共享 contract suite。
 
 ### `MultiTenantService`（`ctx.multiTenant`）
 
-消费 `ctx.tenantSessionStore`（经 `static inject` 声明）。所有方法都是 async，以便无需破坏性变更即可采用持久 store。
-
 | 方法 | 语义 |
 | --- | --- |
-| `claimSession(sessionId, principal)` | 一次性认领。未认领 → 成功；同所有者 → 幂等；不同所有者 → `SessionOwnershipConflictError`。 |
-| `getSessionOwner(sessionId)` | 面向可信方查询；返回所有者或 `undefined`。 |
-| `canAccessSession(principal, sessionId)` | 默认拒绝式布尔。同租户 + 同所有者 → `true`；否则 `false`。 |
-| `assertSessionAccess(principal, sessionId)` | 同上，但抛出统一的 `SessionAccessDeniedError`。 |
+| `claimSession(sessionId, principal)` | 未认领 → 创建；同 owner → 幂等；其他 owner → conflict。 |
+| `getSessionOwner(sessionId)` | 面向可信方的 owner lookup。 |
+| `canAccessSession(principal, sessionId)` | fail-closed 布尔授权。 |
+| `assertSessionAccess(principal, sessionId)` | 同一策略，拒绝时抛统一 `SessionAccessDeniedError`。 |
 
-授权语义：
-
-- **未知会话** → 拒绝。
-- **租户不匹配** → 拒绝（无条件；先于其他一切检查）。
-- **同租户、不同用户** → 拒绝（仅所有权；尚无 RBAC）。
-- **同租户、同用户** → 允许。
-
-标识符（`sessionId`、`tenantId`、`userId`）都是**不透明**的：核心绝不从会话 id 中解析租户 id，绝不使用基于前缀的授权，也绝不假设 UUID/数字形态 —— 只有不透明的精确匹配身份。
+授权基于 opaque exact-match：kernel 不从 session id 里解析 tenant identity，也不使用前缀做授权。
 
 ## 错误隐私
 
-`assertSessionAccess` 抛出单一、不可枚举的 `SessionAccessDeniedError`（`"Access to session denied."`）。未知会话与外来会话不可区分，且错误绝不携带所有者的租户或用户 id。内部诊断原因（`UNKNOWN_SESSION`、`TENANT_MISMATCH`、`USER_MISMATCH`）仅为测试/审计/可观测性存在，不属于公开授权结果的一部分。
+`assertSessionAccess` 只暴露一个不可枚举的 denial。unknown session 与 foreign session 对调用方刻意不可区分；公开错误中永远不携带 owner tenant/user identity。
 
-## 安全边界
+## 安装 / 组合
 
-Cordis / DSH 的 **scope** 是一种*组合与可见性*机制 —— service 隔离与依赖接线。它**本身**不是多租户安全边界。
-
-生产部署必须跨层强制隔离：
-
-```text
-authenticated request boundary
-        +
-session ACL                          ← 本核心
-        +
-tenant-aware MCP / business token
-        +
-downstream ERP / business API tenant validation
+```sh
+dsh plugin --profile web add github:GuoMonth/dsh-multi-tenant
 ```
 
-不要把内存 store 或 Cordis scope 当作安全边界。
+Package bundle 会挂载内存 `tenantSessionStore` 参考实现与 `multiTenant` service。需要 durability 的 deployment 应替换 store provider，而不是修改 kernel。
 
-## 路线图
+## 发布路径
 
-- [x] 项目引导
-- [x] `TenantPrincipal` / `SessionOwner`
-- [x] 一次性认领会话所有权
-- [x] 默认拒绝式核心授权
-- [x] `TenantSessionStore` seam（内存）
-- [x] 运行时不变量的验证
-- [x] Loader 集成测试
-- [ ] 持久 `TenantSessionStore`（PostgreSQL / MySQL / Redis / 远程）
-- [ ] HTTP principal/auth 集成
-- [ ] 会话 RPC 授权
-- [ ] WebSocket mux 过滤
-- [ ] approval/question RPC 所有权
-- [ ] 租户感知的 MCP
-- [ ] token 用量 / 审计
-- [ ] DSH Web 集成测试
-- [ ] npm 预发布
+第一次发布只依赖：
+
+1. 把受影响的 DSH evidence 从 RC6 刷新到当前 RC7 target；
+2. 通过 `verify`、typecheck、test、build 与 packed-package smoke；
+3. 带着本文明确的 supported guarantee 与 boundary 发布 0.1 prerelease。
+
+Production Web principal binding、durable provider、auth provider、search、MCP、audit 与 deployment recipe 都是独立 follow-up。参见 [`ROADMAP.md`](../../ROADMAP.md)。
 
 ## 开发
 
@@ -191,10 +114,6 @@ pnpm typecheck
 pnpm test
 pnpm build
 ```
-
-- `build` 运行 `tsdown`，产出 `dist/index.mjs` + `dist/index.d.mts`。
-- `typecheck` 运行 `tsc --noEmit`。
-- `test` 运行单元、安全，以及一个真实的 Cordis Loader 集成测试。
 
 ## 许可证
 

--- a/packages/multi-tenant/package.json
+++ b/packages/multi-tenant/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dsh-multi-tenant",
   "version": "0.1.0",
-  "description": "Multi-tenant SaaS extension for DeepSeek Harness (DSH): tenant identity, session ownership, authorization boundaries, tenant-aware MCP, and audit.",
+  "description": "Multi-tenant primitives for DeepSeek Harness (DSH): tenant identity, immutable session ownership, fail-closed authorization, and a replaceable ownership-store contract.",
   "author": "DeepSeek Harness community contributors",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary

Rework the roadmap around the project's three boundary rules and a near-term release goal:

- **Control → enforce**: keep strict implementation/test obligations only on surfaces this repository actually owns.
- **Ecosystem → standardize**: turn missing DSH transport scope into a small upstream contract/proposal instead of a local transport fork.
- **Outside control → bound**: explicitly remove execution isolation, billing/UI, host-global tenancy, team ACLs, and other non-kernel concerns from the 0.1 promise.

The previous M4→M8 serial roadmap is replaced by two independent tracks:

1. a short **kernel release track**: RC7 refresh → release hardening → publish the 0.1 prerelease;
2. a non-blocking **ecosystem/Web track**: upstream the principal-scope seam → production Web enforcement once the seam exists.

## Research basis

Current DeepSeek Harness master is still `0.1.0-rc.7`.

RC7's public `ConnectionRpcHandler` receives only decoded `(endpoint, payload, signal)`, while the real HTTP request / WebSocket upgrade remains owned by the DSH Web carrier. The official connection documentation also states that the Web carrier currently has no authentication layer and treats the existing host fence as reachability policy rather than authentication.

That is sufficient to classify request/connection principal scope as an **ecosystem-owned seam**. We no longer require a production-like local HTTP/WS transport clone before releasing the kernel or filing the upstream proposal.

## Roadmap changes

### First release

The first public release is now explicitly the **`dsh-multi-tenant` kernel 0.1 prerelease** (recommended `0.1.0-rc.1`) targeting DSH RC7.

Only three iterations block it:

- **R1** — bump affected DSH proof pins to RC7 and rerun only the affected admission/ApiProxy evidence;
- **R2** — release hardening: accurate package scope, supported guarantees/boundaries, existing verify/typecheck/test/build/smoke gates, packed consumer check;
- **R3** — publish/tag the kernel prerelease with RC7 evidence and threat-model boundary in release notes.

`dsh-multi-tenant-web` remains experimental and does not block the kernel release.

### Ecosystem track

- **E1** — propose a small tenant-agnostic request/connection-scoped API/security-context seam upstream to DSH;
- **E2** — after that seam exists, finish principal-bound Web admission/unary/streams/respond and add minimal two-tenant E2E;
- **E3** — search visibility, MCP context propagation, and DSH-global resource models are independent demand-gated ecosystem contracts, not serial milestones.

### Explicitly removed from the release burden

- durable store implementations (provider contract already exists; implementations are optional follow-ups);
- JWT/OIDC/API-key reference provider before the transport seam exists;
- tenant-scoped search support;
- Workspace/host-global tenant semantics;
- MCP/audit/full-stack preset as mandatory milestones;
- shell/filesystem/process/container/network isolation;
- billing/UI/org/user administration and general RBAC;
- same-tenant sharing/ACL/reassignment in v0.1;
- any permanent fork/reimplementation of DSH Web transport.

## Architecture/doc alignment

This PR also aligns the architecture and package-facing docs so they cannot pull the roadmap back toward a mandatory "complete SaaS stack":

- Layer 6 becomes optional distribution/integration recipes, not an obligation to ship core + store + Web + auth + MCP + audit;
- H3 is reclassified as an RC7 ecosystem seam in the Web ADR;
- the root README splits the kernel release track from the experimental Web track;
- package READMEs now publish supported guarantees and explicit boundaries;
- package descriptions stop claiming built-in MCP/audit or production principal binding that does not exist yet.

## Deliberately not in this PR

No runtime behavior changes.

This PR does **not** perform the RC7 dependency/lockfile migration; that is R1 and should remain a focused compatibility PR with real probe/test evidence.

It also does not change package versions or publish anything. Version selection/publish is R2/R3.

## Validation

- one commit;
- EN / zh-CN roadmap, architecture, ADR, and package-facing docs updated together;
- only package metadata descriptions changed; dependency versions and runtime graph are unchanged;
- CI should exercise the existing `verify`, typecheck, test, build, and package-smoke gates.