### PR TITLE
build: harden first kernel prerelease

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
 
       - uses: pnpm/action-setup@v4
         with:
-          version: 11
+          version: 11.7.0
 
       - uses: actions/setup-node@v4
         with:
@@ -38,6 +38,9 @@ jobs:
 
       - name: Verify package and architecture invariants
         run: pnpm verify
+
+      - name: Verify release manifest
+        run: pnpm release:preflight
 
       - name: Typecheck
         run: pnpm typecheck
@@ -64,7 +67,7 @@ jobs:
 
       - uses: pnpm/action-setup@v4
         with:
-          version: 11
+          version: 11.7.0
 
       - uses: actions/setup-node@v4
         with:

--- a/docs/README.md
+++ b/docs/README.md
@@ -25,3 +25,4 @@ Navigation hub for `dsh-multi-tenant` documentation.
 ## Reference
 
 - [Compatibility & versioning](./reference/compatibility.md) — Node / Cordis / DSH ranges + pinning
+- [Kernel prerelease contract](./reference/release.md) — `0.1.0-rc.1` artifact, release gates, boundaries, and R3 checklist

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -25,3 +25,4 @@
 ## 参考
 
 - [兼容性与版本](./reference/compatibility.zh-CN.md) — Node / Cordis / DSH 范围 + pinning
+- [Kernel prerelease 发布契约](./reference/release.zh-CN.md) — `0.1.0-rc.1` artifact、发布 gate、边界与 R3 checklist

--- a/docs/reference/release.md
+++ b/docs/reference/release.md
@@ -1,0 +1,86 @@
+[简体中文](./release.zh-CN.md) | English
+
+# Kernel prerelease contract
+
+This document is the release contract for the first public kernel artifact. It
+keeps R3 mechanical: R2 decides what may be published and what must be proven;
+R3 performs the publication.
+
+## Artifact
+
+- **Package:** `dsh-multi-tenant`
+- **Version:** `0.1.0-rc.1`
+- **npm dist-tag:** `next`
+- **DSH compatibility target:** `0.1.0-rc.7`
+- **Node:** `^22.19.0 || >=24.0.0`
+
+`dsh-multi-tenant-web` is a private workspace package and is **not** part of this
+release.
+
+The kernel package sets `publishConfig.tag = next`, so an ordinary publish does
+not move the npm `latest` tag to a prerelease. The Web workspace sets
+`private: true`, so npm-compatible publishing tools must refuse to publish it.
+
+## Release guarantee
+
+The artifact guarantees only the kernel-owned contract:
+
+- opaque `TenantPrincipal` / `SessionOwner` identity shapes;
+- claim-once, immutable session ownership;
+- unconditional cross-tenant denial;
+- v0.1 same-user ownership (same tenant, different user is denied);
+- fail-closed unknown/foreign-session authorization;
+- non-enumerating public denial;
+- replaceable async `TenantSessionStore` contract and shared provider test suite.
+
+The bundled `InMemoryTenantSessionStore` is a reference/bootstrap provider, not
+production durability.
+
+## Explicit release boundary
+
+The prerelease does not claim authentication, production DSH Web multi-user
+isolation, durable storage, MCP credential/context isolation, audit persistence,
+team ACLs, or shell/filesystem/process/container/network isolation. These are
+either ecosystem/later-provider work or explicit non-goals in the roadmap.
+
+## One-command preflight
+
+From a clean checkout:
+
+```sh
+pnpm install --frozen-lockfile
+pnpm release:check
+```
+
+`release:check` runs:
+
+1. package/architecture verification and DSH pin-drift checks;
+2. release-manifest preflight (one publishable workspace, exact version/tag,
+   bundle/exports/files metadata, Web package private);
+3. typecheck and unit/contract tests;
+4. build;
+5. packed external-consumer smoke (real tarball, clean consumer install/import);
+6. RC7 session-genesis and Agent admission runtime proofs.
+
+GitHub CI runs the quality and DSH-compatibility gates on both Node 22.19.0 and
+Node 24.
+
+## R3 publication checklist
+
+R3 should remain a publication-only change/process:
+
+1. merge R2 with all CI lanes green;
+2. publish from the exact `main` commit that passed the gates;
+3. publish **only** `dsh-multi-tenant@0.1.0-rc.1`;
+4. keep the prerelease on `next`, not `latest`;
+5. create the matching Git tag / GitHub release;
+6. release notes name the DSH RC7 evidence baseline and repeat the explicit
+   security boundary;
+7. verify the registry artifact by installing it through DSH:
+
+```sh
+dsh plugin --profile <profile> add dsh-multi-tenant@next
+```
+
+Publication authentication/provenance mechanics belong to R3; they should not
+change the package contract established here.

--- a/docs/reference/release.zh-CN.md
+++ b/docs/reference/release.zh-CN.md
@@ -1,0 +1,73 @@
+[English](./release.md) | 简体中文
+
+# Kernel prerelease 发布契约
+
+本文档定义第一次公开 kernel artifact 的 release contract。目标是让 R3 只做机械化发布：R2 决定“允许发布什么、必须证明什么”，R3 负责真正 publish。
+
+## Artifact
+
+- **Package：** `dsh-multi-tenant`
+- **Version：** `0.1.0-rc.1`
+- **npm dist-tag：** `next`
+- **DSH compatibility target：** `0.1.0-rc.7`
+- **Node：** `^22.19.0 || >=24.0.0`
+
+`dsh-multi-tenant-web` 是 private workspace package，**不属于**这次 release。
+
+Kernel package 设置 `publishConfig.tag = next`，因此普通 publish 不会把 npm `latest` 指向 prerelease。Web workspace 设置 `private: true`，npm-compatible publish 工具必须拒绝发布它。
+
+## Release guarantee
+
+Artifact 只承诺 kernel 自己拥有的 contract：
+
+- opaque `TenantPrincipal` / `SessionOwner` identity shape；
+- claim-once、不可变 session ownership；
+- 无条件 cross-tenant denial；
+- v0.1 same-user ownership（同 tenant、不同 user 仍拒绝）；
+- fail-closed unknown/foreign-session authorization；
+- 不可枚举的公开 denial；
+- 可替换 async `TenantSessionStore` contract 与共享 provider test suite。
+
+内置 `InMemoryTenantSessionStore` 是 reference/bootstrap provider，不提供 production durability。
+
+## 明确发布边界
+
+这个 prerelease 不声称提供 authentication、production DSH Web 多用户隔离、durable storage、MCP credential/context isolation、audit persistence、team ACL，也不提供 shell/filesystem/process/container/network isolation。这些事情要么属于 ecosystem/later-provider track，要么已经在 roadmap 中明确列为 non-goal。
+
+## 一条命令做 preflight
+
+从干净 checkout 开始：
+
+```sh
+pnpm install --frozen-lockfile
+pnpm release:check
+```
+
+`release:check` 会执行：
+
+1. package/architecture verify 与 DSH pin-drift check；
+2. release-manifest preflight（唯一 publishable workspace、精确 version/tag、bundle/exports/files metadata、Web package private）；
+3. typecheck 与 unit/contract test；
+4. build；
+5. packed external-consumer smoke（真实 tarball、干净 consumer install/import）；
+6. RC7 session-genesis 与 Agent admission runtime proof。
+
+GitHub CI 会在 Node 22.19.0 与 Node 24 两条线上同时执行 quality 与 DSH compatibility gate。
+
+## R3 发布 checklist
+
+R3 应保持为“只发布”的变更/流程：
+
+1. R2 合并前所有 CI lane 必须全绿；
+2. 从通过全部 gate 的精确 `main` commit 发布；
+3. **只**发布 `dsh-multi-tenant@0.1.0-rc.1`；
+4. prerelease 保持在 `next`，不要移动 `latest`；
+5. 创建匹配的 Git tag / GitHub release；
+6. release notes 标出 DSH RC7 evidence baseline，并重复明确 security boundary；
+7. 通过 DSH 实际安装 registry artifact 做发布后验证：
+
+```sh
+dsh plugin --profile <profile> add dsh-multi-tenant@next
+```
+
+Publish authentication / provenance 的具体机制属于 R3；不要在那一步重新改变这里已经确定的 package contract。

--- a/package.json
+++ b/package.json
@@ -2,12 +2,15 @@
   "name": "dsh-multi-tenant-root",
   "private": true,
   "type": "module",
+  "packageManager": "pnpm@11.7.0",
   "scripts": {
     "build": "pnpm -r build",
     "typecheck": "pnpm -r typecheck",
     "test": "pnpm -r test",
     "verify": "node scripts/verify-packages.mjs",
     "probe:dsh": "node scripts/session-genesis-probe.mjs && node scripts/admission-decorator-probe.mjs",
-    "smoke": "node scripts/package-smoke.mjs"
+    "smoke": "node scripts/package-smoke.mjs",
+    "release:preflight": "node scripts/release-preflight.mjs",
+    "release:check": "pnpm verify && pnpm release:preflight && pnpm typecheck && pnpm test && pnpm build && pnpm smoke && pnpm probe:dsh"
   }
 }

--- a/packages/multi-tenant-web/README.md
+++ b/packages/multi-tenant-web/README.md
@@ -4,10 +4,10 @@
 
 Experimental DSH Web tenant-bound `ApiProxy` enforcement research.
 
-> **Not a production multi-user Web package yet.** The current code proves
-> fail-closed unary enforcement and admission composition. Production principal
-> binding depends on a DSH request/connection-scoped transport seam; this package
-> does not replace the DSH Web carrier to hide that dependency.
+> **Repository-only in the 0.1 kernel release.** This workspace package is
+> `private: true` and is intentionally not publishable while its production
+> principal-binding contract depends on a DSH request/connection-scoped transport
+> seam. R3 publishes only `dsh-multi-tenant`.
 
 ## Status
 
@@ -29,11 +29,11 @@ authentication layer. The principal-scope gap is therefore treated as an
 
 ## What happens next
 
-This package does **not** block the first `dsh-multi-tenant` kernel prerelease.
-The next Web deliverable is a small, generic upstream request/connection-scope
-proposal. Once DSH exposes an adequate seam, this package can add principal-bound
-HTTP/WS admission, streams, `respond`, and a two-tenant E2E suite, then freeze a
-production public contract.
+This package does **not** block or ship with the first `dsh-multi-tenant` kernel
+prerelease. The next Web deliverable is a small, generic upstream
+request/connection-scope proposal. Once DSH exposes an adequate seam, this
+package can add principal-bound HTTP/WS admission, streams, `respond`, and a
+two-tenant E2E suite, then freeze a production public contract.
 
 See [`ROADMAP.md`](../../ROADMAP.md) and
 [`docs/adr/web-enforcement.md`](../../docs/adr/web-enforcement.md).

--- a/packages/multi-tenant-web/README.zh-CN.md
+++ b/packages/multi-tenant-web/README.zh-CN.md
@@ -4,7 +4,7 @@
 
 实验性的 DSH Web tenant-bound `ApiProxy` enforcement 研究。
 
-> **目前还不是 production 多用户 Web package。** 当前代码证明了 fail-closed unary enforcement 与 admission composition。Production principal binding 依赖 DSH request/connection-scoped transport seam；本 package 不会为了掩盖这个依赖而替换 DSH Web carrier。
+> **在 0.1 kernel release 中仅保留在仓库。** 这个 workspace package 已设为 `private: true`，在 production principal-binding contract 仍依赖 DSH request/connection-scoped transport seam 时，刻意禁止发布。R3 只发布 `dsh-multi-tenant`。
 
 ## 状态
 
@@ -19,6 +19,6 @@ DSH RC7 公开的 `ConnectionRpcHandler` 只暴露解码后的 `(endpoint, paylo
 
 ## 下一步
 
-这个 package **不阻塞**第一次 `dsh-multi-tenant` kernel prerelease。Web 的下一项交付是一个小而通用的 upstream request/connection-scope proposal。DSH 提供足够 seam 以后，本 package 再增加 principal-bound HTTP/WS admission、streams、`respond` 与 two-tenant E2E suite，然后再冻结 production public contract。
+这个 package **不阻塞，也不会随第一次 `dsh-multi-tenant` kernel prerelease 一起发布**。Web 的下一项交付是一个小而通用的 upstream request/connection-scope proposal。DSH 提供足够 seam 以后，本 package 再增加 principal-bound HTTP/WS admission、streams、`respond` 与 two-tenant E2E suite，然后再冻结 production public contract。
 
 参见 [`ROADMAP.md`](../../ROADMAP.md) 与 [`docs/adr/web-enforcement.md`](../../docs/adr/web-enforcement.md)。

--- a/packages/multi-tenant-web/package.json
+++ b/packages/multi-tenant-web/package.json
@@ -1,6 +1,7 @@
 {
   "name": "dsh-multi-tenant-web",
   "version": "0.1.0",
+  "private": true,
   "description": "Experimental DSH Web tenant-bound ApiProxy enforcement; production request/connection principal binding depends on a DSH transport seam.",
   "license": "MIT",
   "engines": {

--- a/packages/multi-tenant/README.md
+++ b/packages/multi-tenant/README.md
@@ -6,10 +6,10 @@ Multi-tenant kernel primitives for DeepSeek Harness (DSH): tenant identity,
 immutable session ownership, fail-closed authorization, and a replaceable
 ownership-store contract.
 
-> **Status: first 0.1 prerelease line.** This package is intentionally small. It
-> is the kernel release candidate; Web/auth/MCP/runtime isolation are separate
-> integration or ecosystem concerns. See the repository
-> [ROADMAP](../../ROADMAP.md).
+> **Release candidate: `0.1.0-rc.1`.** This package is intentionally small. It
+> is the only publishable artifact in the first 0.1 release line; Web/auth/MCP/
+> runtime isolation are separate integration or ecosystem concerns. The current
+> DSH compatibility target is `0.1.0-rc.7`.
 
 ## Supported guarantee
 
@@ -106,21 +106,31 @@ user identity is never included in the public error.
 
 ## Install / composition
 
+The first npm prerelease is published on the **`next`** dist-tag, not `latest`.
+After R3 publishes it, install into a DSH profile with:
+
 ```sh
-dsh plugin --profile web add github:GuoMonth/dsh-multi-tenant
+dsh plugin --profile <profile> add dsh-multi-tenant@next
 ```
 
-The package bundle mounts the in-memory `tenantSessionStore` reference and the
-`multiTenant` service. A deployment that needs durability should replace the
-store provider rather than modify the kernel.
+The package declares `dsh.bundle`; DSH therefore adds its bundle layer to the
+profile. The bundled layer mounts the in-memory `tenantSessionStore` reference
+and the `multiTenant` service. A deployment that needs durability should replace
+the store provider rather than modify the kernel.
 
-## Release path
+## Release verification
 
-The first release only depends on:
+From the repository root:
 
-1. refreshing affected DSH evidence from RC6 to the current RC7 target;
-2. passing `verify`, typecheck, tests, build, and packed-package smoke;
-3. publishing the 0.1 prerelease with this supported guarantee and boundary.
+```sh
+pnpm install --frozen-lockfile
+pnpm release:check
+```
+
+`release:check` covers package/architecture invariants, release-manifest
+preflight, typecheck, unit/contract tests, build, a packed external-consumer
+smoke test, and the RC7 DSH runtime proofs. See
+[`docs/reference/release.md`](../../docs/reference/release.md).
 
 Production Web principal binding, durable providers, auth providers, search,
 MCP, audit, and deployment recipes are independent follow-ups. See

--- a/packages/multi-tenant/README.zh-CN.md
+++ b/packages/multi-tenant/README.zh-CN.md
@@ -4,7 +4,7 @@
 
 面向 DeepSeek Harness（DSH）的多租户 kernel 原语：tenant identity、不可变 session ownership、fail-closed authorization，以及可替换的 ownership-store contract。
 
-> **状态：第一次 0.1 prerelease 版本线。** 这个 package 刻意保持小而明确。它是 kernel release candidate；Web/auth/MCP/runtime isolation 属于独立 integration 或生态问题。参见仓库 [ROADMAP](../../ROADMAP.md)。
+> **Release candidate：`0.1.0-rc.1`。** 这个 package 刻意保持小而明确。它是第一次 0.1 版本线中**唯一可发布的 artifact**；Web/auth/MCP/runtime isolation 属于独立 integration 或生态问题。当前 DSH compatibility target 为 `0.1.0-rc.7`。
 
 ## 支持的保证
 
@@ -90,19 +90,24 @@ abstract class TenantSessionStore extends Service {
 
 ## 安装 / 组合
 
+第一次 npm prerelease 使用 **`next`** dist-tag，而不是 `latest`。R3 发布以后，可安装到 DSH profile：
+
 ```sh
-dsh plugin --profile web add github:GuoMonth/dsh-multi-tenant
+dsh plugin --profile <profile> add dsh-multi-tenant@next
 ```
 
-Package bundle 会挂载内存 `tenantSessionStore` 参考实现与 `multiTenant` service。需要 durability 的 deployment 应替换 store provider，而不是修改 kernel。
+Package 声明了 `dsh.bundle`，因此 DSH 会把它的 bundle layer 加入 profile。内置 layer 会挂载内存 `tenantSessionStore` 参考实现与 `multiTenant` service。需要 durability 的 deployment 应替换 store provider，而不是修改 kernel。
 
-## 发布路径
+## 发布验证
 
-第一次发布只依赖：
+在仓库根目录执行：
 
-1. 把受影响的 DSH evidence 从 RC6 刷新到当前 RC7 target；
-2. 通过 `verify`、typecheck、test、build 与 packed-package smoke；
-3. 带着本文明确的 supported guarantee 与 boundary 发布 0.1 prerelease。
+```sh
+pnpm install --frozen-lockfile
+pnpm release:check
+```
+
+`release:check` 覆盖 package/architecture invariant、release-manifest preflight、typecheck、unit/contract test、build、真实 packed external-consumer smoke，以及 RC7 DSH runtime proof。详细见 [`docs/reference/release.zh-CN.md`](../../docs/reference/release.zh-CN.md)。
 
 Production Web principal binding、durable provider、auth provider、search、MCP、audit 与 deployment recipe 都是独立 follow-up。参见 [`ROADMAP.md`](../../ROADMAP.md)。
 

--- a/packages/multi-tenant/package.json
+++ b/packages/multi-tenant/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-multi-tenant",
-  "version": "0.1.0",
+  "version": "0.1.0-rc.1",
   "description": "Multi-tenant primitives for DeepSeek Harness (DSH): tenant identity, immutable session ownership, fail-closed authorization, and a replaceable ownership-store contract.",
   "author": "DeepSeek Harness community contributors",
   "license": "MIT",
@@ -13,7 +13,8 @@
     "url": "https://github.com/GuoMonth/dsh-multi-tenant/issues"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "next"
   },
   "sideEffects": false,
   "type": "module",

--- a/scripts/release-preflight.mjs
+++ b/scripts/release-preflight.mjs
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+/**
+ * Release-manifest preflight for the first kernel prerelease.
+ *
+ * This intentionally checks only release-owned facts. Runtime/API behavior is
+ * covered by verify/test/smoke/probe:dsh; this script prevents packaging and
+ * publication mistakes such as publishing the experimental Web package or
+ * accidentally tagging a prerelease as latest.
+ */
+import { readFileSync, readdirSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { join } from 'node:path'
+
+const root = fileURLToPath(new URL('..', import.meta.url))
+const packagesDir = join(root, 'packages')
+const expectedKernelName = 'dsh-multi-tenant'
+const expectedKernelVersion = '0.1.0-rc.1'
+const expectedTag = 'next'
+const errors = []
+
+const packages = readdirSync(packagesDir).map((dirName) => {
+  const dir = join(packagesDir, dirName)
+  const pkg = JSON.parse(readFileSync(join(dir, 'package.json'), 'utf8'))
+  return { dirName, dir, pkg }
+})
+
+const publishable = packages.filter(({ pkg }) => pkg.private !== true)
+if (publishable.length !== 1 || publishable[0]?.pkg.name !== expectedKernelName) {
+  errors.push(`exactly one workspace package must be publishable (${expectedKernelName}); got ${publishable.map(({ pkg }) => pkg.name).join(', ') || 'none'}`)
+}
+
+const kernel = packages.find(({ pkg }) => pkg.name === expectedKernelName)
+if (!kernel) {
+  errors.push(`${expectedKernelName}: package not found`)
+} else {
+  const { pkg, dir } = kernel
+  if (pkg.version !== expectedKernelVersion) {
+    errors.push(`${expectedKernelName}: version must be ${expectedKernelVersion}, got ${String(pkg.version)}`)
+  }
+  if (pkg.publishConfig?.access !== 'public') {
+    errors.push(`${expectedKernelName}: publishConfig.access must be public`)
+  }
+  if (pkg.publishConfig?.tag !== expectedTag) {
+    errors.push(`${expectedKernelName}: publishConfig.tag must be ${expectedTag}`)
+  }
+  if (pkg.license !== 'MIT') errors.push(`${expectedKernelName}: license must be MIT`)
+  if (!pkg.repository?.url) errors.push(`${expectedKernelName}: repository.url is required`)
+  if (!pkg.homepage) errors.push(`${expectedKernelName}: homepage is required`)
+  if (!pkg.bugs?.url) errors.push(`${expectedKernelName}: bugs.url is required`)
+  if (pkg.dsh?.bundle?.patch !== './cordis.patch.yml') {
+    errors.push(`${expectedKernelName}: dsh.bundle.patch must be ./cordis.patch.yml`)
+  }
+  if (!pkg.scripts?.prepare) errors.push(`${expectedKernelName}: prepare script is required for source installs`)
+
+  const files = new Set(pkg.files ?? [])
+  for (const required of ['dist', 'README.md', 'LICENSE', 'cordis.patch.yml']) {
+    if (!files.has(required)) errors.push(`${expectedKernelName}: files must include ${required}`)
+  }
+
+  const exports = pkg.exports ?? {}
+  for (const required of ['.', './store', './testing', './cordis.patch.yml']) {
+    if (!(required in exports)) errors.push(`${expectedKernelName}: exports must include ${required}`)
+  }
+
+  const readme = readFileSync(join(dir, 'README.md'), 'utf8')
+  for (const heading of ['## Supported guarantee', '## Explicit boundaries']) {
+    if (!readme.includes(heading)) errors.push(`${expectedKernelName}: README missing ${heading}`)
+  }
+}
+
+const web = packages.find(({ pkg }) => pkg.name === 'dsh-multi-tenant-web')
+if (!web) {
+  errors.push('dsh-multi-tenant-web: package not found')
+} else if (web.pkg.private !== true) {
+  errors.push('dsh-multi-tenant-web: must stay private until its production contract is ready')
+}
+
+if (errors.length) {
+  console.error('release preflight failed:\n- ' + errors.join('\n- '))
+  process.exit(1)
+}
+
+console.log(`release preflight passed: ${expectedKernelName}@${expectedKernelVersion} -> dist-tag ${expectedTag}; experimental Web package is private`)


### PR DESCRIPTION
## Summary

R2 turns the already-proven kernel into a deliberately publishable prerelease artifact without expanding product scope.

The release contract is now explicit and executable:

- **only** `dsh-multi-tenant` is publishable;
- its first public version is **`0.1.0-rc.1`**;
- prerelease publication is pinned to the npm **`next`** dist-tag rather than `latest`;
- `dsh-multi-tenant-web` is `private: true` and therefore cannot be accidentally published with the kernel;
- the repository toolchain pins **pnpm 11.7.0** for reproducible release verification;
- a new `release:preflight` gate checks release metadata and boundaries, and `release:check` provides one command for the full pre-publication proof.

## Release-owned changes

### Kernel package

- `dsh-multi-tenant` -> `0.1.0-rc.1`
- `publishConfig.access = public`
- `publishConfig.tag = next`
- existing bundle, exports, files, peer/runtime boundary and `prepare` behavior remain unchanged

### Experimental Web package

`dsh-multi-tenant-web` is now explicitly `private: true`. It remains buildable/testable inside the monorepo, but R3 cannot accidentally publish it while the DSH principal-scope ecosystem seam is unresolved.

### Executable release preflight

`scripts/release-preflight.mjs` fails if:

- more than one workspace package is publishable;
- the kernel name/version/public access/dist-tag drift;
- required repository/license/bundle/files/exports metadata disappears;
- the kernel README loses its supported-guarantee or explicit-boundary sections;
- the Web package becomes publishable.

The root now exposes:

```sh
pnpm release:preflight
pnpm release:check
```

`release:check` composes the existing strong gates rather than duplicating them: verify, release preflight, typecheck, tests, build, packed external-consumer smoke, and RC7 DSH runtime probes.

## CI/toolchain hardening

- pin pnpm to `11.7.0` in the repository and GitHub Actions;
- run release-manifest preflight in both Node quality lanes;
- retain the R1 matrix: Node 22.19.0 + Node 24 for quality and RC7 compatibility.

## Documentation

- kernel package docs name the exact release candidate and `next` install channel;
- Web package docs state that it is repository-only/private for the 0.1 kernel release;
- add `docs/reference/release.md` / zh-CN with the artifact contract, supported guarantee, boundaries, one-command preflight, and R3 publication checklist.

The install command documented for the published prerelease follows DSH's npm bundle flow:

```sh
dsh plugin --profile <profile> add dsh-multi-tenant@next
```

## Deliberately not in R2

- no runtime/kernel policy changes;
- no H3/Web transport implementation;
- no durable store/auth/MCP/audit features;
- no npm credentials, trusted-publishing workflow, provenance setup, tag creation, or actual publication — those belong to R3.

## Validation — green

GitHub Actions completed successfully with all four lanes green:

- ✅ quality / Node 22.19.0 — frozen install, architecture verify, release preflight, typecheck, tests, build, packed external-consumer smoke
- ✅ quality / Node 24 — frozen install, architecture verify, release preflight, typecheck, tests, build, packed external-consumer smoke
- ✅ DSH RC compatibility / Node 22.19.0 — real RC7 runtime proofs
- ✅ DSH RC compatibility / Node 24 — real RC7 runtime proofs

The packed smoke exercised the real `dsh-multi-tenant-0.1.0-rc.1.tgz` shape through a clean external consumer on both supported Node lines.

After this PR merges, R2 is complete and R3 is publication-only: configure/choose npm publishing authentication + provenance, publish the one kernel artifact, tag/release it, then verify installation from the registry.