### PR TITLE
release: publish first kernel prerelease

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,124 @@
+name: Publish kernel prerelease
+
+run-name: Publish dsh-multi-tenant ${{ inputs.version }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Exact package version to publish (for example 0.1.0-rc.1)
+        required: true
+        type: string
+
+permissions:
+  contents: write
+  id-token: write
+
+concurrency:
+  group: npm-kernel-release
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: publish dsh-multi-tenant
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    environment: npm-release
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 11.7.0
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24.x
+          registry-url: https://registry.npmjs.org
+          package-manager-cache: false
+
+      - name: Verify release invocation
+        env:
+          REQUESTED_VERSION: ${{ inputs.version }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "$GITHUB_REF" != "refs/heads/main" ]; then
+            echo "Releases must be dispatched from main; got $GITHUB_REF" >&2
+            exit 1
+          fi
+          ACTUAL_VERSION=$(node -p "require('./packages/multi-tenant/package.json').version")
+          if [ "$REQUESTED_VERSION" != "$ACTUAL_VERSION" ]; then
+            echo "Requested version $REQUESTED_VERSION does not match package version $ACTUAL_VERSION" >&2
+            exit 1
+          fi
+          node - <<'NODE'
+          const { execFileSync } = require('node:child_process')
+          const version = execFileSync('npm', ['--version'], { encoding: 'utf8' }).trim()
+          const [major, minor] = version.split('.').map(Number)
+          if (major < 11 || (major === 11 && minor < 5)) {
+            throw new Error(`npm ${version} is too old for trusted publishing; require >=11.5.1`)
+          }
+          console.log(`npm ${version} satisfies trusted-publishing requirements`)
+          NODE
+
+      - name: Install dependencies (frozen)
+        run: pnpm install --frozen-lockfile
+
+      - name: Run full release proof
+        run: pnpm release:check
+
+      - name: Check registry ownership and version state
+        id: registry
+        env:
+          RELEASE_VERSION: ${{ inputs.version }}
+        run: node scripts/registry-preflight.mjs "$RELEASE_VERSION"
+
+      - name: Publish to npm
+        if: steps.registry.outputs.publish_needed == 'true'
+        working-directory: packages/multi-tenant
+        env:
+          # First-ever publication bootstrap only. After rc.1 exists, configure
+          # npm Trusted Publishing for release.yml and remove this environment secret.
+          # npm CLI prefers OIDC trusted publishing before falling back to this token.
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_BOOTSTRAP_TOKEN }}
+        run: npm publish --access public --tag next --provenance
+
+      - name: Verify registry artifact
+        env:
+          RELEASE_VERSION: ${{ inputs.version }}
+        run: node scripts/registry-smoke.mjs "$RELEASE_VERSION"
+
+      - name: Create matching Git tag and GitHub prerelease
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_VERSION: ${{ inputs.version }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          TAG="v${RELEASE_VERSION}"
+          git fetch --tags origin
+
+          if git rev-parse "refs/tags/${TAG}" >/dev/null 2>&1; then
+            TAG_SHA=$(git rev-list -n 1 "$TAG")
+            if [ "$TAG_SHA" != "$GITHUB_SHA" ]; then
+              echo "Existing tag $TAG points to $TAG_SHA, not release commit $GITHUB_SHA" >&2
+              exit 1
+            fi
+          else
+            git tag "$TAG" "$GITHUB_SHA"
+            git push origin "$TAG"
+          fi
+
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "GitHub release $TAG already exists; leaving it unchanged"
+          else
+            gh release create "$TAG" \
+              --verify-tag \
+              --prerelease \
+              --title "dsh-multi-tenant ${RELEASE_VERSION}" \
+              --notes-file "docs/releases/v${RELEASE_VERSION}.md"
+          fi

--- a/docs/reference/release.md
+++ b/docs/reference/release.md
@@ -2,9 +2,7 @@
 
 # Kernel prerelease contract
 
-This document is the release contract for the first public kernel artifact. It
-keeps R3 mechanical: R2 decides what may be published and what must be proven;
-R3 performs the publication.
+This document is the release contract for the first public kernel artifact. R2 fixed the artifact and its proof; R3 only publishes and verifies it.
 
 ## Artifact
 
@@ -13,37 +11,21 @@ R3 performs the publication.
 - **npm dist-tag:** `next`
 - **DSH compatibility target:** `0.1.0-rc.7`
 - **Node:** `^22.19.0 || >=24.0.0`
+- **Provenance:** enabled
 
-`dsh-multi-tenant-web` is a private workspace package and is **not** part of this
-release.
-
-The kernel package sets `publishConfig.tag = next`, so an ordinary publish does
-not move the npm `latest` tag to a prerelease. The Web workspace sets
-`private: true`, so npm-compatible publishing tools must refuse to publish it.
+`dsh-multi-tenant-web` is private and is **not** part of this release.
 
 ## Release guarantee
 
-The artifact guarantees only the kernel-owned contract:
+The artifact guarantees only the kernel-owned contract: opaque principal/owner identity shapes, claim-once immutable session ownership, unconditional cross-tenant denial, v0.1 same-user ownership, fail-closed unknown/foreign-session authorization, non-enumerating public denial, and the replaceable async `TenantSessionStore` contract plus shared provider test suite.
 
-- opaque `TenantPrincipal` / `SessionOwner` identity shapes;
-- claim-once, immutable session ownership;
-- unconditional cross-tenant denial;
-- v0.1 same-user ownership (same tenant, different user is denied);
-- fail-closed unknown/foreign-session authorization;
-- non-enumerating public denial;
-- replaceable async `TenantSessionStore` contract and shared provider test suite.
-
-The bundled `InMemoryTenantSessionStore` is a reference/bootstrap provider, not
-production durability.
+The bundled `InMemoryTenantSessionStore` is a reference/bootstrap provider, not production durability.
 
 ## Explicit release boundary
 
-The prerelease does not claim authentication, production DSH Web multi-user
-isolation, durable storage, MCP credential/context isolation, audit persistence,
-team ACLs, or shell/filesystem/process/container/network isolation. These are
-either ecosystem/later-provider work or explicit non-goals in the roadmap.
+The prerelease does not claim authentication, production DSH Web multi-user isolation, durable storage, MCP credential/context isolation, audit persistence, team ACLs, or shell/filesystem/process/container/network isolation.
 
-## One-command preflight
+## Pre-publication proof
 
 From a clean checkout:
 
@@ -52,35 +34,47 @@ pnpm install --frozen-lockfile
 pnpm release:check
 ```
 
-`release:check` runs:
+The release workflow reruns this full proof from `main` before touching npm.
 
-1. package/architecture verification and DSH pin-drift checks;
-2. release-manifest preflight (one publishable workspace, exact version/tag,
-   bundle/exports/files metadata, Web package private);
-3. typecheck and unit/contract tests;
-4. build;
-5. packed external-consumer smoke (real tarball, clean consumer install/import);
-6. RC7 session-genesis and Agent admission runtime proofs.
+## R3 publication workflow
 
-GitHub CI runs the quality and DSH-compatibility gates on both Node 22.19.0 and
-Node 24.
+Publication is implemented by `.github/workflows/release.yml` and is intentionally manual (`workflow_dispatch`). The operator must type the exact package version and dispatch from `main`. The job runs in the `npm-release` GitHub Environment and:
 
-## R3 publication checklist
+1. verifies the requested version and npm trusted-publishing capability;
+2. runs the full `release:check` gate;
+3. checks the npm package name/repository and whether the exact version already exists;
+4. publishes only when the exact version is absent;
+5. verifies `next`, repository metadata, integrity, and a clean external consumer from the registry;
+6. creates the matching `v0.1.0-rc.1` Git tag and GitHub prerelease only after registry verification succeeds.
 
-R3 should remain a publication-only change/process:
+The workflow is safe to rerun: if the exact npm version already exists under this repository, the publish step is skipped and post-publish verification/tag/release can recover.
 
-1. merge R2 with all CI lanes green;
-2. publish from the exact `main` commit that passed the gates;
-3. publish **only** `dsh-multi-tenant@0.1.0-rc.1`;
-4. keep the prerelease on `next`, not `latest`;
-5. create the matching Git tag / GitHub release;
-6. release notes name the DSH RC7 evidence baseline and repeat the explicit
-   security boundary;
-7. verify the registry artifact by installing it through DSH:
+## First-publication bootstrap
+
+npm trusted publishing is configured per existing package. Because `dsh-multi-tenant` has never been published before, `0.1.0-rc.1` needs a one-time bootstrap credential.
+
+Recommended bootstrap:
+
+1. create/configure the GitHub Environment `npm-release` (restrict it to `main`; add a required reviewer if desired);
+2. create a short-lived npm granular token that is allowed to create/publish the package under the account's 2FA policy;
+3. store it **only** as the `NPM_BOOTSTRAP_TOKEN` secret in the `npm-release` Environment;
+4. run `Publish kernel prerelease` from `main` with version `0.1.0-rc.1`;
+5. after the package exists, configure npm Trusted Publishing for:
+   - GitHub owner: `GuoMonth`
+   - repository: `dsh-multi-tenant`
+   - workflow filename: `release.yml`
+   - environment: `npm-release`
+   - allowed action: `npm publish`;
+6. delete `NPM_BOOTSTRAP_TOKEN` and, after trusted publishing is proven, restrict traditional token publishing on npm.
+
+The workflow grants `id-token: write` and publishes with provenance. With trusted publishing configured, npm uses short-lived OIDC credentials; the bootstrap token is no longer needed.
+
+## Post-publication verification
+
+The workflow runs `scripts/registry-smoke.mjs` against the exact published version. A human can additionally verify DSH installation with:
 
 ```sh
 dsh plugin --profile <profile> add dsh-multi-tenant@next
 ```
 
-Publication authentication/provenance mechanics belong to R3; they should not
-change the package contract established here.
+R3 is complete only when the npm version exists, `next` resolves to it, the registry smoke passes, and the matching GitHub prerelease/tag exist.

--- a/docs/reference/release.zh-CN.md
+++ b/docs/reference/release.zh-CN.md
@@ -2,7 +2,7 @@
 
 # Kernel prerelease 发布契约
 
-本文档定义第一次公开 kernel artifact 的 release contract。目标是让 R3 只做机械化发布：R2 决定“允许发布什么、必须证明什么”，R3 负责真正 publish。
+本文档定义第一次公开 kernel artifact 的 release contract。R2 已经把 artifact 与验证门固定下来；R3 只负责真正发布与发布后验证。
 
 ## Artifact
 
@@ -11,30 +11,21 @@
 - **npm dist-tag：** `next`
 - **DSH compatibility target：** `0.1.0-rc.7`
 - **Node：** `^22.19.0 || >=24.0.0`
+- **Provenance：** enabled
 
-`dsh-multi-tenant-web` 是 private workspace package，**不属于**这次 release。
-
-Kernel package 设置 `publishConfig.tag = next`，因此普通 publish 不会把 npm `latest` 指向 prerelease。Web workspace 设置 `private: true`，npm-compatible publish 工具必须拒绝发布它。
+`dsh-multi-tenant-web` 是 private package，**不属于**本次 release。
 
 ## Release guarantee
 
-Artifact 只承诺 kernel 自己拥有的 contract：
-
-- opaque `TenantPrincipal` / `SessionOwner` identity shape；
-- claim-once、不可变 session ownership；
-- 无条件 cross-tenant denial；
-- v0.1 same-user ownership（同 tenant、不同 user 仍拒绝）；
-- fail-closed unknown/foreign-session authorization；
-- 不可枚举的公开 denial；
-- 可替换 async `TenantSessionStore` contract 与共享 provider test suite。
+Artifact 只承诺 kernel 自己拥有的 contract：opaque principal/owner identity shape、claim-once 不可变 session ownership、无条件 cross-tenant denial、v0.1 same-user ownership、fail-closed unknown/foreign-session authorization、不可枚举的公开 denial，以及可替换 async `TenantSessionStore` contract 与共享 provider test suite。
 
 内置 `InMemoryTenantSessionStore` 是 reference/bootstrap provider，不提供 production durability。
 
 ## 明确发布边界
 
-这个 prerelease 不声称提供 authentication、production DSH Web 多用户隔离、durable storage、MCP credential/context isolation、audit persistence、team ACL，也不提供 shell/filesystem/process/container/network isolation。这些事情要么属于 ecosystem/later-provider track，要么已经在 roadmap 中明确列为 non-goal。
+本 prerelease 不声称提供 authentication、production DSH Web 多用户隔离、durable storage、MCP credential/context isolation、audit persistence、team ACL，也不提供 shell/filesystem/process/container/network isolation。
 
-## 一条命令做 preflight
+## 发布前验证
 
 从干净 checkout 开始：
 
@@ -43,31 +34,47 @@ pnpm install --frozen-lockfile
 pnpm release:check
 ```
 
-`release:check` 会执行：
+真正 publish 前，release workflow 会从 `main` 再完整执行一次该验证。
 
-1. package/architecture verify 与 DSH pin-drift check；
-2. release-manifest preflight（唯一 publishable workspace、精确 version/tag、bundle/exports/files metadata、Web package private）；
-3. typecheck 与 unit/contract test；
-4. build；
-5. packed external-consumer smoke（真实 tarball、干净 consumer install/import）；
-6. RC7 session-genesis 与 Agent admission runtime proof。
+## R3 发布 workflow
 
-GitHub CI 会在 Node 22.19.0 与 Node 24 两条线上同时执行 quality 与 DSH compatibility gate。
+发布由 `.github/workflows/release.yml` 完成，并且刻意只允许手工 `workflow_dispatch`。操作者必须输入精确 package version，并从 `main` 触发。Job 运行在 `npm-release` GitHub Environment 中，会：
 
-## R3 发布 checklist
+1. 核对请求版本与 npm trusted-publishing capability；
+2. 跑完整 `release:check`；
+3. 核对 npm package name/repository，以及精确 version 是否已存在；
+4. 只有 version 不存在时才 publish；
+5. 从 registry 验证 `next`、repository metadata、integrity，并在干净 external consumer 中实际安装和调用；
+6. registry 验证成功以后，才创建匹配的 `v0.1.0-rc.1` Git tag 与 GitHub prerelease。
 
-R3 应保持为“只发布”的变更/流程：
+Workflow 可安全重跑：如果精确 npm version 已经存在且属于本仓库，会跳过重复 publish，继续完成 registry verification / tag / GitHub release。
 
-1. R2 合并前所有 CI lane 必须全绿；
-2. 从通过全部 gate 的精确 `main` commit 发布；
-3. **只**发布 `dsh-multi-tenant@0.1.0-rc.1`；
-4. prerelease 保持在 `next`，不要移动 `latest`；
-5. 创建匹配的 Git tag / GitHub release；
-6. release notes 标出 DSH RC7 evidence baseline，并重复明确 security boundary；
-7. 通过 DSH 实际安装 registry artifact 做发布后验证：
+## 第一次发布 bootstrap
+
+npm Trusted Publishing 是针对“已经存在的 package”配置的。由于 `dsh-multi-tenant` 此前从未发布，`0.1.0-rc.1` 需要一次性 bootstrap credential。
+
+推荐流程：
+
+1. 创建/配置 GitHub Environment `npm-release`（限制为 `main`；如需要可增加 required reviewer）；
+2. 创建一个短有效期 npm granular token，使其在当前账户 2FA policy 下能够创建/发布 package；
+3. token **只**保存为 `npm-release` Environment secret：`NPM_BOOTSTRAP_TOKEN`；
+4. 在 `main` 上运行 `Publish kernel prerelease`，version 输入 `0.1.0-rc.1`；
+5. package 创建成功后，在 npm 配置 Trusted Publishing：
+   - GitHub owner：`GuoMonth`
+   - repository：`dsh-multi-tenant`
+   - workflow filename：`release.yml`
+   - environment：`npm-release`
+   - allowed action：`npm publish`；
+6. 删除 `NPM_BOOTSTRAP_TOKEN`；Trusted Publishing 验证成功以后，再在 npm 侧限制传统 token publishing。
+
+Workflow 授予 `id-token: write` 并启用 provenance。Trusted Publishing 配好以后，npm 使用短生命周期 OIDC credential，不再需要 bootstrap token。
+
+## 发布后验证
+
+Workflow 会对精确版本运行 `scripts/registry-smoke.mjs`。还可以人工用 DSH 再验证一次：
 
 ```sh
 dsh plugin --profile <profile> add dsh-multi-tenant@next
 ```
 
-Publish authentication / provenance 的具体机制属于 R3；不要在那一步重新改变这里已经确定的 package contract。
+只有 npm version 已存在、`next` 指向它、registry smoke 成功、并且匹配的 GitHub prerelease/tag 都存在时，R3 才算完成。

--- a/docs/releases/v0.1.0-rc.1.md
+++ b/docs/releases/v0.1.0-rc.1.md
@@ -1,0 +1,48 @@
+# dsh-multi-tenant 0.1.0-rc.1
+
+First public prerelease of the `dsh-multi-tenant` kernel for DeepSeek Harness.
+
+## Compatibility
+
+- DeepSeek Harness target: `0.1.0-rc.7`
+- RC7 release commit: `99f6f02fecdb7dff40c3fbc9470f5907c29f74ca`
+- Node: `^22.19.0 || >=24.0.0`
+- npm channel: `next`
+
+## What this release provides
+
+- opaque `TenantPrincipal` / `SessionOwner` identity shapes;
+- claim-once, immutable session ownership;
+- unconditional cross-tenant denial;
+- v0.1 same-user ownership (same tenant, different user is denied);
+- fail-closed authorization for unknown and foreign sessions;
+- non-enumerating public denial;
+- replaceable async `TenantSessionStore` contract;
+- in-memory reference provider and shared provider contract suite.
+
+## Explicit boundaries
+
+This prerelease is a kernel, not a complete multi-tenant SaaS distribution. It does **not** provide:
+
+- authentication or HTTP/WebSocket principal binding;
+- production multi-user DSH Web isolation;
+- durable ownership storage out of the box;
+- tenant-aware MCP credential/context isolation;
+- audit persistence;
+- team sharing / ACL / reassignment;
+- shell, filesystem, process, container, credential, or network isolation;
+- billing, UI, or organization/user administration.
+
+`dsh-multi-tenant-web` remains repository-only/private until the required DSH request/connection principal-scope ecosystem seam exists.
+
+## Install
+
+```sh
+dsh plugin --profile <profile> add dsh-multi-tenant@next
+```
+
+The bundled `InMemoryTenantSessionStore` is intended for bootstrap/testing. Production deployments that require durable ownership should provide a `TenantSessionStore` implementation that passes the shared contract suite.
+
+## Verification
+
+Before publication, the release pipeline reruns the full release proof: frozen dependency install, package/architecture checks, release manifest preflight, typecheck, unit/security/contract tests, build, packed external-consumer smoke, and the RC7 session-genesis/admission runtime probes. After publication it installs the exact registry artifact into a clean consumer and exercises the public package subpaths and ownership contract.

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
     "probe:dsh": "node scripts/session-genesis-probe.mjs && node scripts/admission-decorator-probe.mjs",
     "smoke": "node scripts/package-smoke.mjs",
     "release:preflight": "node scripts/release-preflight.mjs",
+    "release:registry-preflight": "node scripts/registry-preflight.mjs",
+    "release:registry-smoke": "node scripts/registry-smoke.mjs",
     "release:check": "pnpm verify && pnpm release:preflight && pnpm typecheck && pnpm test && pnpm build && pnpm smoke && pnpm probe:dsh"
   }
 }

--- a/packages/multi-tenant/package.json
+++ b/packages/multi-tenant/package.json
@@ -14,7 +14,8 @@
   },
   "publishConfig": {
     "access": "public",
-    "tag": "next"
+    "tag": "next",
+    "provenance": true
   },
   "sideEffects": false,
   "type": "module",

--- a/scripts/registry-preflight.mjs
+++ b/scripts/registry-preflight.mjs
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+/**
+ * Read-only npm registry preflight used immediately before publication.
+ *
+ * It prevents publishing into an already-owned package name and makes release
+ * workflow reruns idempotent when the exact version is already present.
+ */
+import { execFileSync } from 'node:child_process'
+import { appendFileSync } from 'node:fs'
+
+const PACKAGE_NAME = 'dsh-multi-tenant'
+const EXPECTED_REPOSITORY = 'https://github.com/guomonth/dsh-multi-tenant'
+const version = process.argv[2]
+
+if (!version) {
+  console.error('usage: node scripts/registry-preflight.mjs <version>')
+  process.exit(2)
+}
+
+function normalizeRepository(value) {
+  return String(value ?? '')
+    .trim()
+    .replace(/^git\+/, '')
+    .replace(/\.git$/, '')
+    .replace(/\/$/, '')
+    .toLowerCase()
+}
+
+function npmView(spec, field) {
+  try {
+    const out = execFileSync('npm', ['view', spec, field, '--json'], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    }).trim()
+    return { found: true, value: out ? JSON.parse(out) : undefined }
+  } catch (error) {
+    const text = `${error.stdout ?? ''}\n${error.stderr ?? ''}`
+    if (/E404|404 Not Found/i.test(text)) return { found: false }
+    throw error
+  }
+}
+
+const packageRepo = npmView(PACKAGE_NAME, 'repository.url')
+if (packageRepo.found) {
+  const actualRepo = normalizeRepository(packageRepo.value)
+  if (actualRepo !== EXPECTED_REPOSITORY) {
+    console.error(
+      `${PACKAGE_NAME} already exists in npm with repository ${String(packageRepo.value)}; ` +
+        `expected ${EXPECTED_REPOSITORY}. Refusing to publish.`,
+    )
+    process.exit(1)
+  }
+  console.log(`${PACKAGE_NAME} already exists and points at the expected repository`)
+} else {
+  console.log(`${PACKAGE_NAME} does not yet exist in npm; first-publication bootstrap is required`)
+}
+
+const exact = npmView(`${PACKAGE_NAME}@${version}`, 'version')
+const publishNeeded = !exact.found
+
+if (exact.found && exact.value !== version) {
+  console.error(`registry returned unexpected version ${String(exact.value)} for requested ${version}`)
+  process.exit(1)
+}
+
+console.log(
+  publishNeeded
+    ? `${PACKAGE_NAME}@${version} is not present; publication is required`
+    : `${PACKAGE_NAME}@${version} already exists; publication step will be skipped`,
+)
+
+if (process.env.GITHUB_OUTPUT) {
+  appendFileSync(process.env.GITHUB_OUTPUT, `publish_needed=${publishNeeded}\n`)
+}

--- a/scripts/registry-smoke.mjs
+++ b/scripts/registry-smoke.mjs
@@ -1,0 +1,110 @@
+#!/usr/bin/env node
+/**
+ * Post-publication registry smoke.
+ *
+ * Verifies the exact version and `next` dist-tag from npm, installs the registry
+ * artifact into a clean consumer, imports every public kernel subpath used by
+ * consumers, and exercises claim/access plus the shared store contract.
+ */
+import { execFileSync } from 'node:child_process'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+const PACKAGE_NAME = 'dsh-multi-tenant'
+const EXPECTED_REPOSITORY = 'https://github.com/guomonth/dsh-multi-tenant'
+const version = process.argv[2]
+
+if (!version) {
+  console.error('usage: node scripts/registry-smoke.mjs <version>')
+  process.exit(2)
+}
+
+function npmJson(args) {
+  const out = execFileSync('npm', [...args, '--json'], {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  }).trim()
+  return out ? JSON.parse(out) : undefined
+}
+
+function normalizeRepository(value) {
+  return String(value ?? '')
+    .trim()
+    .replace(/^git\+/, '')
+    .replace(/\.git$/, '')
+    .replace(/\/$/, '')
+    .toLowerCase()
+}
+
+let registryVersion
+for (let attempt = 1; attempt <= 10; attempt++) {
+  try {
+    registryVersion = npmJson(['view', `${PACKAGE_NAME}@${version}`, 'version'])
+    if (registryVersion === version) break
+  } catch (error) {
+    if (attempt === 10) throw error
+  }
+  await new Promise((resolve) => setTimeout(resolve, 3000))
+}
+
+if (registryVersion !== version) {
+  throw new Error(`registry did not resolve ${PACKAGE_NAME}@${version}`)
+}
+
+const nextVersion = npmJson(['view', `${PACKAGE_NAME}@next`, 'version'])
+if (nextVersion !== version) {
+  throw new Error(`npm next dist-tag resolves to ${String(nextVersion)}, expected ${version}`)
+}
+
+const repository = npmJson(['view', `${PACKAGE_NAME}@${version}`, 'repository.url'])
+if (normalizeRepository(repository) !== EXPECTED_REPOSITORY) {
+  throw new Error(`registry repository mismatch: ${String(repository)}`)
+}
+
+const integrity = npmJson(['view', `${PACKAGE_NAME}@${version}`, 'dist.integrity'])
+if (!integrity) throw new Error('registry artifact is missing dist.integrity')
+
+const consumer = mkdtempSync(join(tmpdir(), 'dsh-mt-registry-consumer-'))
+try {
+  writeFileSync(
+    join(consumer, 'package.json'),
+    JSON.stringify({ name: 'registry-smoke-consumer', private: true, type: 'module' }),
+  )
+
+  execFileSync(
+    'pnpm',
+    ['add', `${PACKAGE_NAME}@${version}`, '@deepseek-ai/cordis@4.0.1'],
+    { cwd: consumer, stdio: 'ignore' },
+  )
+
+  writeFileSync(
+    join(consumer, 'smoke.mjs'),
+    [
+      'import { Context } from "@deepseek-ai/cordis";',
+      'import Store from "dsh-multi-tenant/store";',
+      'import Service from "dsh-multi-tenant";',
+      'import { assertTenantSessionStoreContract } from "dsh-multi-tenant/testing";',
+      'const ctx = new Context();',
+      'await ctx.plugin(Store);',
+      'await ctx.plugin(Service);',
+      'const alice = { tenantId: "acme", userId: "alice", roles: ["member"] };',
+      'await ctx.multiTenant.claimSession("registry-s1", alice);',
+      'if ((await ctx.multiTenant.canAccessSession(alice, "registry-s1")) !== true) throw new Error("registry smoke: owner access denied");',
+      'await assertTenantSessionStoreContract(async (c) => { await c.plugin(Store); return c.tenantSessionStore });',
+      'console.log("registry consumer smoke passed");',
+    ].join('\n'),
+  )
+
+  execFileSync('node', ['smoke.mjs'], {
+    cwd: consumer,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  })
+} finally {
+  rmSync(consumer, { recursive: true, force: true })
+}
+
+console.log(
+  `registry smoke passed: ${PACKAGE_NAME}@${version}; next=${version}; integrity=${integrity.slice(0, 20)}…`,
+)

--- a/scripts/release-preflight.mjs
+++ b/scripts/release-preflight.mjs
@@ -2,12 +2,11 @@
 /**
  * Release-manifest preflight for the first kernel prerelease.
  *
- * This intentionally checks only release-owned facts. Runtime/API behavior is
- * covered by verify/test/smoke/probe:dsh; this script prevents packaging and
- * publication mistakes such as publishing the experimental Web package or
- * accidentally tagging a prerelease as latest.
+ * Runtime/API behavior is covered by verify/test/smoke/probe:dsh; this script
+ * prevents packaging/publication mistakes and keeps the R3 release contract
+ * executable.
  */
-import { readFileSync, readdirSync } from 'node:fs'
+import { existsSync, readFileSync, readdirSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import { join } from 'node:path'
 
@@ -16,6 +15,7 @@ const packagesDir = join(root, 'packages')
 const expectedKernelName = 'dsh-multi-tenant'
 const expectedKernelVersion = '0.1.0-rc.1'
 const expectedTag = 'next'
+const expectedRepository = 'git+https://github.com/GuoMonth/dsh-multi-tenant.git'
 const errors = []
 
 const packages = readdirSync(packagesDir).map((dirName) => {
@@ -34,22 +34,15 @@ if (!kernel) {
   errors.push(`${expectedKernelName}: package not found`)
 } else {
   const { pkg, dir } = kernel
-  if (pkg.version !== expectedKernelVersion) {
-    errors.push(`${expectedKernelName}: version must be ${expectedKernelVersion}, got ${String(pkg.version)}`)
-  }
-  if (pkg.publishConfig?.access !== 'public') {
-    errors.push(`${expectedKernelName}: publishConfig.access must be public`)
-  }
-  if (pkg.publishConfig?.tag !== expectedTag) {
-    errors.push(`${expectedKernelName}: publishConfig.tag must be ${expectedTag}`)
-  }
+  if (pkg.version !== expectedKernelVersion) errors.push(`${expectedKernelName}: version must be ${expectedKernelVersion}, got ${String(pkg.version)}`)
+  if (pkg.publishConfig?.access !== 'public') errors.push(`${expectedKernelName}: publishConfig.access must be public`)
+  if (pkg.publishConfig?.tag !== expectedTag) errors.push(`${expectedKernelName}: publishConfig.tag must be ${expectedTag}`)
+  if (pkg.publishConfig?.provenance !== true) errors.push(`${expectedKernelName}: publishConfig.provenance must be true`)
   if (pkg.license !== 'MIT') errors.push(`${expectedKernelName}: license must be MIT`)
-  if (!pkg.repository?.url) errors.push(`${expectedKernelName}: repository.url is required`)
+  if (pkg.repository?.url !== expectedRepository) errors.push(`${expectedKernelName}: repository.url must be ${expectedRepository}`)
   if (!pkg.homepage) errors.push(`${expectedKernelName}: homepage is required`)
   if (!pkg.bugs?.url) errors.push(`${expectedKernelName}: bugs.url is required`)
-  if (pkg.dsh?.bundle?.patch !== './cordis.patch.yml') {
-    errors.push(`${expectedKernelName}: dsh.bundle.patch must be ./cordis.patch.yml`)
-  }
+  if (pkg.dsh?.bundle?.patch !== './cordis.patch.yml') errors.push(`${expectedKernelName}: dsh.bundle.patch must be ./cordis.patch.yml`)
   if (!pkg.scripts?.prepare) errors.push(`${expectedKernelName}: prepare script is required for source installs`)
 
   const files = new Set(pkg.files ?? [])
@@ -69,10 +62,16 @@ if (!kernel) {
 }
 
 const web = packages.find(({ pkg }) => pkg.name === 'dsh-multi-tenant-web')
-if (!web) {
-  errors.push('dsh-multi-tenant-web: package not found')
-} else if (web.pkg.private !== true) {
-  errors.push('dsh-multi-tenant-web: must stay private until its production contract is ready')
+if (!web) errors.push('dsh-multi-tenant-web: package not found')
+else if (web.pkg.private !== true) errors.push('dsh-multi-tenant-web: must stay private until its production contract is ready')
+
+for (const requiredPath of [
+  '.github/workflows/release.yml',
+  'docs/releases/v0.1.0-rc.1.md',
+  'scripts/registry-preflight.mjs',
+  'scripts/registry-smoke.mjs',
+]) {
+  if (!existsSync(join(root, requiredPath))) errors.push(`release artifact missing: ${requiredPath}`)
 }
 
 if (errors.length) {
@@ -80,4 +79,4 @@ if (errors.length) {
   process.exit(1)
 }
 
-console.log(`release preflight passed: ${expectedKernelName}@${expectedKernelVersion} -> dist-tag ${expectedTag}; experimental Web package is private`)
+console.log(`release preflight passed: ${expectedKernelName}@${expectedKernelVersion} -> dist-tag ${expectedTag}, provenance enabled; experimental Web package is private`)


### PR DESCRIPTION
## Summary

R3 prepares the first real publication of `dsh-multi-tenant@0.1.0-rc.1` without changing kernel behavior or widening scope.

The final release path is intentionally small:

- manual GitHub Actions dispatch from `main`;
- protected `npm-release` Environment boundary;
- full `pnpm release:check` before npm is touched;
- read-only registry ownership/version preflight;
- publish only the kernel package to the `next` channel with provenance;
- verify the exact registry artifact in a clean external consumer;
- only after registry verification, create the matching Git tag and GitHub prerelease.

## Registry fact established during R3

A temporary read-only GitHub Actions probe queried the real npm registry and confirmed that **`dsh-multi-tenant` does not currently exist**. The temporary probe workflow is not present in the final diff.

This matters because npm Trusted Publishing is configured for an existing package. The first-ever `0.1.0-rc.1` publication therefore needs a one-time bootstrap credential; after the package exists, publishing can move permanently to OIDC Trusted Publishing.

## Release workflow

Adds `.github/workflows/release.yml` with:

- `workflow_dispatch` and an explicit version input;
- hard failure unless dispatched from `main` and the input exactly matches package.json;
- GitHub Environment `npm-release`;
- `contents: write` only for tag/GitHub Release and `id-token: write` for npm OIDC/provenance;
- Node 24 + pnpm 11.7.0;
- full frozen install + `pnpm release:check`;
- npm package/repository ownership preflight;
- idempotent version handling: an already-published matching version skips duplicate `npm publish` but still allows verification/release recovery;
- post-publish registry smoke;
- matching `v0.1.0-rc.1` tag and GitHub prerelease created only after registry verification.

## Bootstrap -> Trusted Publishing

For the first publication only, the workflow can consume `NPM_BOOTSTRAP_TOKEN` from the `npm-release` Environment. The token should be short-lived and deleted immediately after rc.1 exists.

Then configure npm Trusted Publishing for:

- GitHub owner: `GuoMonth`
- repository: `dsh-multi-tenant`
- workflow filename: `release.yml`
- environment: `npm-release`
- allowed action: `npm publish`

After that, the same workflow uses short-lived OIDC credentials and no long-lived publish token is required.

## Supply-chain / registry checks

- `publishConfig.provenance = true` is release-preflight enforced.
- `repository.url` is checked exactly because npm Trusted Publishing/provenance binds publication to the source repository.
- `scripts/registry-preflight.mjs` refuses to publish if the npm package name already belongs to a different repository.
- `scripts/registry-smoke.mjs` checks the exact version, `next` dist-tag, repository metadata, integrity, then installs the registry package into a clean consumer and exercises the public kernel subpaths and ownership/store contract.

## Release notes / contract

Adds `docs/releases/v0.1.0-rc.1.md` and updates the bilingual release contract with the one-time bootstrap boundary, Trusted Publisher transition, exact workflow semantics, and R3 completion criteria.

## Deliberately not in R3

- no runtime/kernel policy changes;
- no Web/H3 implementation;
- no durable store/auth/MCP/audit work;
- no general release framework;
- no staged publishing workflow;
- no permanent npm token architecture.

## Validation — green on final head

GitHub Actions completed successfully with all four existing lanes green:

- ✅ quality / Node 22.19.0 — frozen install, architecture verify, release preflight, typecheck, tests, build, packed external-consumer smoke
- ✅ quality / Node 24 — frozen install, architecture verify, release preflight, typecheck, tests, build, packed external-consumer smoke
- ✅ DSH RC compatibility / Node 22.19.0 — real RC7 runtime proofs
- ✅ DSH RC compatibility / Node 24 — real RC7 runtime proofs

A separate temporary read-only registry probe also completed successfully and established that the package name is currently absent from npm; that probe is intentionally removed from the final diff.

## Completion criteria

This PR prepares the mechanism; R3 is **not** marked complete merely by merging it. After merge:

1. create/configure the `npm-release` GitHub Environment;
2. add the one-time `NPM_BOOTSTRAP_TOKEN` Environment secret;
3. dispatch `Publish kernel prerelease` from `main` with `0.1.0-rc.1`;
4. require registry smoke + tag/GitHub prerelease creation to succeed;
5. configure npm Trusted Publishing for `release.yml` and delete the bootstrap token;
6. only then mark ROADMAP R3 complete.
