### PR TITLE
refactor: converge kernel contract for rc.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: Exact package version to publish (for example 0.1.0-rc.1)
+        description: Exact package version to publish (for example 0.1.0-rc.2)
         required: true
         type: string
 
@@ -77,14 +77,9 @@ jobs:
           RELEASE_VERSION: ${{ inputs.version }}
         run: node scripts/registry-preflight.mjs "$RELEASE_VERSION"
 
-      - name: Publish to npm
+      - name: Publish to npm via Trusted Publishing
         if: steps.registry.outputs.publish_needed == 'true'
         working-directory: packages/multi-tenant
-        env:
-          # First-ever publication bootstrap only. After rc.1 exists, configure
-          # npm Trusted Publishing for release.yml and remove this environment secret.
-          # npm CLI prefers OIDC trusted publishing before falling back to this token.
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_BOOTSTRAP_TOKEN }}
         run: npm publish --access public --tag next --provenance
 
       - name: Verify registry artifact

--- a/README.md
+++ b/README.md
@@ -5,61 +5,49 @@
 Composable multi-tenant plugin primitives for
 [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) (DSH).
 
-> **Phase: first kernel prerelease.** The kernel baseline is established and
-> test-pinned; its public contract remains prerelease. The current DSH target is
-> **`0.1.0-rc.7`**. The release-oriented plan is in
-> [ROADMAP.md](./ROADMAP.md), and exact evidence/version rules are in
-> [`docs/reference/compatibility.md`](./docs/reference/compatibility.md).
+> **Phase: kernel prerelease line.** `0.1.0-rc.1` is publicly published; the
+> current convergence candidate is **`0.1.0-rc.2`**. The DSH target remains
+> **`0.1.0-rc.7`**. See [ROADMAP.md](./ROADMAP.md) and
+> [`docs/reference/release.md`](./docs/reference/release.md).
 
 ## What this is
 
 A **plugin family with a small kernel**, not a promise to implement an entire
-SaaS platform. `dsh-multi-tenant` owns the tenant/session primitives this
-repository can enforce directly: identity shape, immutable session ownership,
-fail-closed authorization, and the `TenantSessionStore` provider contract.
+SaaS platform. `dsh-multi-tenant` owns only the tenant/session primitives this
+repository can enforce directly: minimal tenant/user identity, immutable session
+ownership, fail-closed authorization, and the `TenantSessionStore` provider
+contract.
 
-Other capabilities are added only when their boundary is real and useful. A DSH
-or third-party seam is handled through a minimal contract/conformance proposal;
-a surface we cannot reliably enforce is documented as a boundary instead of
-being absorbed into a local fork.
+Other capabilities enter the project only when their boundary is real and useful.
+A DSH/third-party dependency is handled through a minimal contract/conformance
+proposal; a surface we cannot reliably enforce is documented as a boundary
+instead of being absorbed into a local fork.
 
 ## Guiding principles
 
-- **Control → enforce** — where this repository owns the enforcement point, the
-  rule is strict and fail-closed, and the invariant is locked by executable
-  tests.
-- **Ecosystem → standardize** — where a guarantee depends on DSH or another
-  replaceable ecosystem component, define the smallest useful seam/contract,
-  publish conformance expectations, and collaborate upstream.
-- **Outside control → bound** — where no reliable enforcement seam exists,
-  state the threat-model / support boundary plainly. Complexity is not evidence.
-- **Fast-follow prereleases** — pin explicit DSH prereleases, record the exact
-  evidence version, and revalidate only seams affected by an upstream change.
-- **One-way dependency** — the kernel has no transport/vendor dependency (no
-  JWT, PostgreSQL, HTTP, MCP, Redis); providers and integrations stay outside.
-- **Default ≠ only** — a provider is replaceable when it passes the same shared
-  contract suite; roadmap symmetry is never a reason to implement every backend.
+- **Control → enforce** — strict fail-closed rules with executable invariants.
+- **Ecosystem → standardize** — define the smallest useful seam/contract and collaborate upstream.
+- **Outside control → bound** — state the threat-model/support boundary plainly. Complexity is not evidence.
+- **Fast-follow prereleases** — pin explicit DSH prereleases and revalidate only affected seams.
+- **One-way dependency** — no JWT/PostgreSQL/HTTP/MCP/Redis dependency in the kernel.
+- **Default ≠ only** — replaceable providers prove conformance with the shared contract suite.
 
 ## Release scope
 
-The first public 0.1 prerelease is the **kernel package**. Production Web
-multi-user enforcement is a separate ecosystem-gated track:
-
-- `dsh-multi-tenant` — release candidate: ownership, authorization, store seam,
-  testing utilities.
-- `dsh-multi-tenant-web` — experimental fail-closed enforcement spike; its
-  production contract waits for a DSH request/connection principal-scope seam.
+- `dsh-multi-tenant` — published kernel: ownership, authorization, store seam, testing utilities.
+- `dsh-multi-tenant-web` — private experimental enforcement spike; production principal binding waits for a DSH request/connection-scope seam.
 
 The 0.1 line does **not** claim shell/filesystem/process/container/network
-isolation, billing/UI/organization management, host-global resource tenancy, or
-cross-user team ACLs. See the boundary matrix in [ROADMAP.md](./ROADMAP.md).
+isolation, billing/UI/organization management, host-global resource tenancy,
+general RBAC, or cross-user team ACLs. Roles/permissions are deliberately not
+part of the kernel `TenantPrincipal`.
 
 ## Packages
 
-| Package | npm | Role |
+| Package | Distribution | Role |
 | --- | --- | --- |
-| [`packages/multi-tenant`](./packages/multi-tenant) | `dsh-multi-tenant` | Kernel: `ctx.multiTenant` + `ctx.tenantSessionStore`, claim-once ownership, fail-closed authorization, provider contract/testing. |
-| [`packages/multi-tenant-web`](./packages/multi-tenant-web) | `dsh-multi-tenant-web` | Experimental tenant-bound `ApiProxy` enforcement research; production principal binding is DSH-transport-gated. |
+| [`packages/multi-tenant`](./packages/multi-tenant) | npm `dsh-multi-tenant@next` | Kernel: `ctx.multiTenant` + `ctx.tenantSessionStore`, claim-once ownership, fail-closed authorization, provider contract/testing. |
+| [`packages/multi-tenant-web`](./packages/multi-tenant-web) | private workspace | Experimental tenant-bound `ApiProxy` research; production principal binding is DSH-transport-gated. |
 
 See [CONTRIBUTING.md](./CONTRIBUTING.md) for development policy and
 [`docs/specs/architecture.md`](./docs/specs/architecture.md) for layer ownership.
@@ -72,8 +60,6 @@ pnpm typecheck
 pnpm test
 pnpm build
 ```
-
-Root scripts delegate to every workspace package via `pnpm -r`.
 
 ## License
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -4,40 +4,38 @@
 
 面向 [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness)（DSH）的可组合多租户插件原语。
 
-> **阶段：第一次 kernel prerelease。** 内核基线已经建立并由测试锁定；公共契约仍处于 prerelease。当前 DSH 目标是 **`0.1.0-rc.7`**。面向发布的路线见 [ROADMAP.md](./ROADMAP.md)，精确 evidence/version 规则见 [`docs/reference/compatibility.md`](./docs/reference/compatibility.md)。
+> **阶段：kernel prerelease 版本线。** `0.1.0-rc.1` 已真实公开发布；当前收敛 candidate 是 **`0.1.0-rc.2`**。DSH target 仍为 **`0.1.0-rc.7`**。参见 [ROADMAP.md](./ROADMAP.zh-CN.md) 与 [`docs/reference/release.zh-CN.md`](./docs/reference/release.zh-CN.md)。
 
 ## 这是什么
 
-这是一个**带小型 kernel 的插件家族**，不是“把整套 SaaS 平台都实现掉”的承诺。`dsh-multi-tenant` 只拥有本仓库能够直接强制的 tenant/session 原语：identity shape、不可变 session ownership、fail-closed authorization，以及 `TenantSessionStore` provider contract。
+这是一个**带小型 kernel 的插件家族**，不是“把整套 SaaS 平台都实现掉”的承诺。`dsh-multi-tenant` 只拥有本仓库能够直接强制的 tenant/session 原语：最小 tenant/user identity、不可变 session ownership、fail-closed authorization，以及 `TenantSessionStore` provider contract。
 
-其他能力只有在边界真实、并且确实有价值时才进入项目。依赖 DSH 或第三方 seam 的事情，用最小 contract/conformance proposal 进行生态协作；当前无法可靠强制的 surface，则直接作为边界说明，而不是吸收到本地 fork 里。
+其他能力只有在边界真实且确实有价值时才进入项目。依赖 DSH/第三方 seam 的事情，用最小 contract/conformance proposal 进行生态协作；当前无法可靠强制的 surface 直接作为边界说明，而不是吸收到本地 fork。
 
 ## 指导原则
 
-- **控制得住 → 严格强制** —— 本仓库拥有 enforcement point 的地方，规则必须 fail-closed，并用可执行测试锁住不变量。
-- **需要生态协作 → 制定标准** —— 一个保证依赖 DSH 或其他可替换生态组件时，定义最小而有用的 seam/contract、发布一致性要求，并优先向上游协作。
-- **控制不住 → 明确边界** —— 没有可靠 enforcement seam 的地方，直接说明 threat-model / support boundary。复杂度不是证据。
-- **快速跟进 prerelease** —— 显式 pin DSH prerelease，记录 evidence 对应精确版本，只重新验证上游变化真正影响到的 seam。
-- **单向依赖** —— kernel 没有 transport/vendor 依赖（无 JWT、PostgreSQL、HTTP、MCP、Redis）；provider 与 integration 保持在外层。
-- **默认 ≠ 唯一** —— provider 通过相同共享 contract suite 即可替换；不能为了 roadmap 对称而把每一种 backend 都自己实现。
+- **控制得住 → 严格强制** —— fail-closed，并用可执行 invariant 锁住。
+- **需要生态协作 → 制定标准** —— 定义最小可用 seam/contract，并优先向上游协作。
+- **控制不住 → 明确边界** —— 直接说明 threat-model/support boundary。复杂度不是证据。
+- **快速跟进 prerelease** —— 显式 pin DSH prerelease，只重验受影响 seam。
+- **单向依赖** —— kernel 不引入 JWT/PostgreSQL/HTTP/MCP/Redis 依赖。
+- **默认 ≠ 唯一** —— provider 通过共享 contract suite 即可替换。
 
 ## 发布范围
 
-第一次公开的 0.1 prerelease 是 **kernel package**。Production Web 多用户 enforcement 属于另一条受生态 seam 门控的路线：
+- `dsh-multi-tenant` —— 已发布 kernel：ownership、authorization、store seam、testing utilities。
+- `dsh-multi-tenant-web` —— private experimental enforcement spike；production principal binding 等待 DSH request/connection-scope seam。
 
-- `dsh-multi-tenant` —— release candidate：ownership、authorization、store seam、testing utilities。
-- `dsh-multi-tenant-web` —— experimental、fail-closed 的 enforcement spike；production principal binding 等待 DSH request/connection principal-scope seam。
-
-0.1 版本线**不**声称提供 shell/filesystem/process/container/network isolation、billing/UI/组织管理、host-global resource tenancy 或跨用户 team ACL。完整边界矩阵见 [ROADMAP.md](./ROADMAP.md)。
+0.1 版本线**不**声称提供 shell/filesystem/process/container/network isolation、billing/UI/组织管理、host-global resource tenancy、general RBAC 或跨用户 team ACL。Kernel `TenantPrincipal` 刻意不包含 roles/permissions。
 
 ## 包
 
-| 包 | npm | 角色 |
+| 包 | 分发 | 角色 |
 | --- | --- | --- |
-| [`packages/multi-tenant`](./packages/multi-tenant) | `dsh-multi-tenant` | Kernel：`ctx.multiTenant` + `ctx.tenantSessionStore`，claim-once ownership、fail-closed authorization、provider contract/testing。 |
-| [`packages/multi-tenant-web`](./packages/multi-tenant-web) | `dsh-multi-tenant-web` | 实验性的 tenant-bound `ApiProxy` enforcement 研究；production principal binding 受 DSH transport seam 门控。 |
+| [`packages/multi-tenant`](./packages/multi-tenant) | npm `dsh-multi-tenant@next` | Kernel：`ctx.multiTenant` + `ctx.tenantSessionStore`，claim-once ownership、fail-closed authorization、provider contract/testing。 |
+| [`packages/multi-tenant-web`](./packages/multi-tenant-web) | private workspace | 实验性的 tenant-bound `ApiProxy` 研究；production principal binding 受 DSH transport seam 门控。 |
 
-开发规范见 [CONTRIBUTING.md](./CONTRIBUTING.md)，layer 归属见 [`docs/specs/architecture.md`](./docs/specs/architecture.md)。
+开发规范见 [CONTRIBUTING.md](./CONTRIBUTING.zh-CN.md)，layer 归属见 [`docs/specs/architecture.zh-CN.md`](./docs/specs/architecture.zh-CN.md)。
 
 ## 开发
 
@@ -47,8 +45,6 @@ pnpm typecheck
 pnpm test
 pnpm build
 ```
-
-根脚本通过 `pnpm -r` 委托给每个 workspace package。
 
 ## 许可证
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,188 +1,103 @@
 [简体中文](./ROADMAP.zh-CN.md) | English
 
-# Roadmap — converge for the first release
+# Roadmap — kernel released, converge toward stable 0.1
 
-Statuses: ✅ done · 🚧 release-blocking · 🤝 ecosystem · 🧭 later / demand-gated · ⛔ explicit boundary.
+Statuses: ✅ done · 🚧 release candidate · 🤝 ecosystem · 🧭 later / demand-gated · ⛔ explicit boundary.
 
-## Release target
+## Current state
 
-The next goal is **not** a complete multi-tenant SaaS distribution. It is a small,
-useful, honest first release of the kernel line:
+`dsh-multi-tenant` now has a real public prerelease line targeting DeepSeek
+Harness `0.1.0-rc.7`.
 
-- **`dsh-multi-tenant`** — first public **0.1 prerelease** (proposed
-  `0.1.0-rc.1`), targeting **DeepSeek Harness `0.1.0-rc.7`**.
-- **`dsh-multi-tenant-web`** — remains an **experimental enforcement spike**.
-  Its production contract is not a blocker for the kernel release because the
-  missing request/connection principal scope belongs to the DSH transport
-  ecosystem.
+- ✅ `0.1.0-rc.1` published to npm `next` with provenance.
+- ✅ Registry external-consumer smoke passed.
+- ✅ Matching Git tag / GitHub prerelease created.
+- ✅ npm Trusted Publishing is the publication path; the release workflow is now OIDC-only.
+- 🚧 `0.1.0-rc.2` is the final planned API-convergence candidate before deciding on `0.1.0` stable.
 
-The release promise is deliberately narrow: session ownership and
-fail-closed authorization on surfaces this repository controls. Anything else
-is either an ecosystem contract or an explicit boundary.
+The release promise remains deliberately narrow: immutable session ownership and
+fail-closed authorization on surfaces this repository owns.
 
 ## Boundary matrix
 
-| Surface | Classification | What this project does | Blocks first kernel release? |
-| --- | --- | --- | --- |
-| Tenant principal / session ownership / access decisions | **Control → enforce** | Own the contract and fail closed. | **Yes** — already implemented and test-pinned. |
-| `TenantSessionStore` seam + contract suite | **Control → enforce** | Own the seam; ship the in-memory reference; third parties prove providers with the shared suite. | **Yes** — already done. |
-| Agent genesis admission (`setup`) | **Control → enforce** | Keep the decorator/probe; revalidate only the affected DSH seam on each target bump. | **Yes** — RC7 evidence refreshed in R1. |
-| Unary `ApiProxy` classification | **Control → enforce** | Exhaustively classify the real `RpcMethodMap`; unknown/new methods fail closed. | **Yes** — RC7 type/evidence refreshed in R1. |
-| HTTP/WS request/connection principal scope | **Ecosystem → standardize** | Specify the smallest generic DSH seam and upstream it. Do not fork/rebuild the Web transport. | **No** for kernel; **yes** for production web enforcement. |
-| mux / host streams and `respond` | **Control after ecosystem seam** | Keep denied in the spike; implement/test only after a principal-scoped transport seam exists. | No for kernel. |
-| Auth providers (JWT/OIDC/API key) | **Later provider** | Add a replaceable reference provider only after there is a real transport principal scope. | No. |
-| Durable ownership stores | **Later provider** | Add one or more providers when there is real demand; the provider seam already exists. | No. |
-| `session.search` tenant visibility | **Ecosystem / later** | Deny for now; pursue a scoped visibility/search contract only if needed. | No. |
-| Workspace / host-global management | **Outside v0.1 scope** | Deny where exposed through the web spike; do not invent tenant semantics for DSH-global resources. | No. |
-| Tenant-aware MCP context propagation | **Ecosystem / later** | Define a conformance contract when the DSH/MCP seam is concrete and there is demand. | No. |
-| Shell / filesystem / process / container / network isolation | **Explicit boundary** | Not provided by this plugin family. Strong execution isolation belongs to the deployment/runtime layer. | No. |
-| Billing, UI, organization/user administration | **Explicit boundary** | Not a goal of this repository. | No. |
-| Team sharing / ACLs / ownership reassignment | **Explicit v0.1 boundary** | v0.1 keeps immutable tenant+user ownership. A separate same-tenant access policy may be designed later. | No. |
+| Surface | Classification | Project position |
+| --- | --- | --- |
+| Tenant/user identity + session ownership + access decisions | **Control → enforce** | Kernel contract; fail closed and test-pin it. |
+| `TenantSessionStore` seam + shared contract suite | **Control → enforce** | Kernel-owned seam; in-memory reference only. |
+| Agent genesis admission (`setup`) | **Control → enforce** | RC7 runtime proof remains a compatibility gate. |
+| Unary `ApiProxy` classification | **Control → enforce** | Exhaustive fail-closed classification in the private Web spike. |
+| HTTP/WS request/connection principal scope | **Ecosystem → standardize** | Requires a generic DSH transport seam; do not fork the transport. |
+| Production Web streams / `respond` / admission | **After ecosystem seam** | Keep unsupported surfaces denied until principal scope exists. |
+| Durable ownership stores | **Later provider** | Add only when real contributor/user demand exists. |
+| Auth providers | **Later provider** | Only after a real transport principal scope exists. |
+| `session.search` tenant visibility | **Ecosystem / later** | Deny until correct scoped-query semantics exist. |
+| MCP tenant context | **Ecosystem / later** | Standardize only when the seam and demand are concrete. |
+| Shell/filesystem/process/container/network isolation | **Explicit boundary** | Deployment/runtime responsibility, not this plugin family. |
+| Billing/UI/org/user admin/general RBAC | **Explicit boundary** | Not a repository goal. |
+| Team sharing/ACL/reassignment | **Explicit v0.1 boundary** | Separate same-tenant policy plane if ever needed. |
 
-## Done
+## Completed release track
 
-- ✅ **M0 — Engineering foundation** — monorepo, package rules, spec/ADR discipline, CI.
-- ✅ **M1 — Kernel hardening** — claim-once ownership, fail-closed access,
-  `TenantSessionStore`, shared contract tests, package smoke, architecture gates.
-- ✅ **M2 — Session genesis proof** — Agent `setup` is the before-visibility
-  admission point; create / fork / subagent / resume were established on RC6.
-- ✅ **M3 — Web enforcement spike** — real `ApiProxy` facade, exhaustive unary
-  classification, fail-closed policy, and the H3 transport gap identified.
-- ✅ **Boundary policy** — control → enforce; ecosystem → standardize; outside
-  control → bound. RC7 is the current target baseline.
-- ✅ **R1 — RC7 compatibility refresh** — DSH proof pins/lockfile refreshed to
-  RC7; source-facing seams reviewed; session-genesis and admission runtime proofs
-  pass on Node 22.19 and Node 24; DSH pin drift and runtime proofs are now CI
-  gates. Exact evidence lives in `docs/reference/compatibility.md`.
+- ✅ **R1 — RC7 compatibility refresh** — DSH target/pins centralized and the affected runtime proofs run on Node 22.19 + Node 24.
+- ✅ **R2 — Kernel release hardening** — package metadata, supported guarantees, explicit boundaries, packed external-consumer smoke, and release preflight established.
+- ✅ **R3 — First public prerelease** — `dsh-multi-tenant@0.1.0-rc.1` published to npm `next`; provenance, registry smoke, Git tag, and GitHub prerelease all succeeded.
 
-## Release track — the next few iterations
+Historical evidence remains in `docs/reference/compatibility.md`; current release mechanics live in `docs/reference/release.md`.
 
-Only these steps block the first `dsh-multi-tenant` release.
+## 🚧 rc.2 — final API subtraction before stable
 
-### ✅ R1 — RC7 compatibility refresh
+`0.1.0-rc.2` is intentionally a convergence release, not a feature release:
 
-Completed by the R1 compatibility PR:
+1. reduce `TenantPrincipal` to `{ tenantId, userId }`;
+2. remove the unused role validation/public contract;
+3. keep RBAC/policy attributes outside the ownership kernel;
+4. publish through npm Trusted Publishing/OIDC only — no bootstrap token fallback;
+5. rerun the same release proof and registry consumer smoke.
 
-1. `@deepseek-ai/dsh-host-apiproxy` and its resolved DSH graph are pinned to
-   **`0.1.0-rc.7`** with a frozen lockfile;
-2. the relevant RC6 → RC7 source seams were reviewed and the real runtime proofs
-   rerun on both supported Node lines;
-3. the exact RC7 release commit and source blobs are recorded in the
-   compatibility reference;
-4. the DSH target is centralized and CI fails on package-pin drift;
-5. no unchanged architecture was redesigned and H3 remains on the ecosystem
-   track rather than being closed with a local transport fork.
+After rc.2, do **not** create another prerelease merely for roadmap progress.
+Without a real bug, upstream compatibility change, or user feedback requiring a
+contract change, the next decision is whether the kernel is ready for `0.1.0` stable.
 
-### 🚧 R2 — Kernel release hardening
-
-1. keep package metadata aligned with the actual kernel scope — identity,
-   ownership, authorization, store seam/testing; no claims of built-in MCP,
-   audit, auth, or production Web isolation;
-2. publish clear **supported guarantees** and **explicit boundaries** in the
-   README/package docs;
-3. run the release gates: frozen install, `pnpm verify`, `pnpm typecheck`,
-   `pnpm test`, `pnpm build`, `pnpm smoke`, plus the RC compatibility probes;
-4. choose the first 0.1 prerelease version (recommended `0.1.0-rc.1`) and verify
-   the packed consumer experience.
-
-### 🚧 R3 — Publish the kernel prerelease
-
-- publish/tag the `dsh-multi-tenant` 0.1 prerelease;
-- release notes name the RC7 evidence baseline and the security boundary;
-- `dsh-multi-tenant-web` is **not** presented as a production multi-user Web
-  solution. It may remain repository-only or be published only with an explicit
-  experimental/prerelease label.
-
-After R3, the project has a real version users and ecosystem authors can build
-against without waiting for every SaaS concern to be solved.
-
-## Ecosystem track — important, but non-blocking for the kernel
+## Ecosystem track — non-blocking for the kernel
 
 ### 🤝 E1 — DSH principal-scope seam
 
-RC7 still exposes `ConnectionRpcHandler` as decoded
-`(endpoint, payload, signal)` and the Web carrier documents that it has no
-authentication layer. The required deliverable from this repository is therefore
-**a small generic upstream seam**, not a local transport fork.
+Propose the smallest tenant-agnostic request/connection-scoped security-context
+seam upstream. It must cover HTTP request scope, WebSocket connection lifetime,
+concurrent principals without ambient/global cross-talk, admission before
+session publication, and event/response correlation where required.
 
-The proposal should remain tenant-agnostic and enable a caller to derive a
-request/connection-scoped API/security context from the real HTTP request / WS
-upgrade. Conformance expectations should cover:
+### 🤝 E2 — Production Web enforcement after E1
 
-- HTTP request scope and WebSocket connection lifetime;
-- concurrent principals with no ambient/global cross-talk;
-- the ability to install a principal-bound `ApiProxy` before `session.create`
-  admission and before event delivery;
-- safe correlation for server-request responses (`respond`) if real runtime
-  evidence shows it is needed.
+Only after DSH exposes an adequate principal-scope seam should
+`dsh-multi-tenant-web` become publishable: wire admission/unary/streams/respond
+under one principal scope and add minimal two-tenant adversarial E2E.
 
-This proposal does **not** block the kernel release.
+### 🤝 E3 — Other contracts only on demand
 
-### 🤝 E2 — Production Web enforcement, after the seam exists
+Search visibility, MCP context propagation, and DSH-global resource tenancy are
+independent demand-gated contracts, not mandatory milestones.
 
-Once DSH exposes an adequate principal-scope seam:
+## Later providers
 
-1. turn `dsh-multi-tenant-web` from a spike into an installable enforcement
-   plugin;
-2. wire admission, unary guards/filtering, stream filtering, and `respond` under
-   the same principal scope;
-3. add a minimal two-tenant adversarial E2E suite for the supported Web
-   surfaces;
-4. only then freeze the Web package's public contract and consider a Web
-   prerelease.
+🧭 Durable store providers (PostgreSQL/Redis/MySQL), a reference auth provider,
+or lifecycle/admin cleanup may be added independently when there is real demand.
+They do not expand the kernel guarantee.
 
-### 🤝 E3 — Additional ecosystem contracts, only on demand
+## Explicit non-goals
 
-These are independent follow-ups, not a serial M6/M7/M8 chain:
+⛔ The 0.1 line does not claim strong process/container isolation. A tenant-authorized
+Agent still has whatever shell/filesystem/network capabilities its deployment grants.
 
-- tenant-scoped search visibility;
-- tenant-aware MCP principal/context propagation;
-- any DSH-global resource model that the ecosystem actually decides to make
-  tenant-owned.
+⛔ The repository does not become a billing system, identity directory, UI product,
+or general RBAC framework.
 
-Each starts with a seam/contract and conformance expectation, not a large local
-implementation.
+⛔ It does not reimplement DSH Web transport, search, MCP runtime, or host resource
+models to make every concern locally solvable.
 
-## Later owned providers — optional, independent packages
+⛔ v0.1 ownership is immutable `(tenantId, userId)`. Roles and permissions are not
+part of `TenantPrincipal`; cross-user sharing and admin policy require a separate
+same-tenant policy plane.
 
-🧭 These can be built after the kernel release without changing the kernel:
-
-- a durable `TenantSessionStore` provider (PostgreSQL / Redis / MySQL — choose
-  based on contributor/user demand, not roadmap symmetry);
-- a reference auth provider after E1 lands;
-- lifecycle/admin cleanup for tombstoned ownership if a real use case requires
-  it.
-
-None is required to prove the kernel contract.
-
-## Explicit boundaries / non-goals
-
-⛔ The 0.1 line does **not** claim to provide strong process/container isolation.
-A tenant-authorized Agent may still have whatever shell/filesystem/network
-capabilities the surrounding DSH deployment grants it. Deployments requiring
-strong execution isolation must enforce that outside this plugin family.
-
-⛔ This repository does not become a billing system, organization/user directory,
-UI product, or general RBAC framework.
-
-⛔ It does not reimplement the DSH Web transport, session search engine, MCP
-runtime, or host resource model simply to make every checklist row local.
-
-⛔ v0.1 ownership is immutable `(tenantId, userId)` ownership. Cross-user sharing,
-reassignment, admin inspection, and team ACLs require a separate same-tenant
-policy plane and are not silently added to the kernel.
-
-## What blocks what
-
-```text
-RC7 compatibility ✅ ──> kernel release hardening ──> dsh-multi-tenant 0.1 prerelease
-
-DSH principal-scope seam ──> production dsh-multi-tenant-web ──> Web E2E / Web release
-
-search / MCP / durable providers / auth provider / audit / UI
-        └──────────── independent, demand-gated follow-ups ────────────┘
-```
-
-The roadmap is intentionally short. A new item belongs here only when it blocks
-an owned release guarantee; ecosystem work lives on the ecosystem track, and
-unsupported concerns remain explicit boundaries.
+The roadmap stays short on purpose: owned guarantees are enforced, ecosystem
+dependencies are standardized, and everything else remains an explicit boundary.

--- a/ROADMAP.zh-CN.md
+++ b/ROADMAP.zh-CN.md
@@ -1,145 +1,85 @@
 [English](./ROADMAP.md) | 简体中文
 
-# 路线图 —— 为第一次发布收敛
+# 路线图 —— Kernel 已发布，向 stable 0.1 收敛
 
-状态：✅ 已完成 · 🚧 发布阻塞项 · 🤝 生态协作 · 🧭 后续 / 按需求触发 · ⛔ 明确边界。
+状态：✅ 已完成 · 🚧 release candidate · 🤝 生态协作 · 🧭 后续 / 按需求触发 · ⛔ 明确边界。
 
-## 发布目标
+## 当前状态
 
-下一阶段的目标**不是**做出一整套完整的多租户 SaaS 分发版，而是先发布一个小而有用、边界诚实的内核版本：
+`dsh-multi-tenant` 已经拥有真实公开的 prerelease 版本线，目标基线仍是 DeepSeek Harness `0.1.0-rc.7`。
 
-- **`dsh-multi-tenant`** —— 第一个公开的 **0.1 预发布版本**（建议
-  `0.1.0-rc.1`），目标基线为 **DeepSeek Harness `0.1.0-rc.7`**。
-- **`dsh-multi-tenant-web`** —— 继续保持**实验性的 enforcement spike**。
-  它的 production contract 不阻塞内核发布，因为缺失的 request/connection
-  principal scope 属于 DSH transport 生态能力。
+- ✅ `0.1.0-rc.1` 已发布到 npm `next`，带 provenance。
+- ✅ Registry external-consumer smoke 已通过。
+- ✅ 匹配的 Git tag / GitHub prerelease 已创建。
+- ✅ npm Trusted Publishing 已成为发布路径；release workflow 现在是 OIDC-only。
+- 🚧 `0.1.0-rc.2` 是进入 `0.1.0` stable 决策前最后一个计划中的 API 收敛 candidate。
 
-第一次发布的承诺刻意收窄：只承诺本仓库真正控制得住的 session 所有权与 fail-closed 授权。其他事情要么进入生态契约，要么明确列为边界。
+发布承诺继续刻意收窄：只承诺本仓库真正拥有的不可变 session ownership 与 fail-closed authorization。
 
 ## 边界矩阵
 
-| Surface | 分类 | 本项目负责什么 | 阻塞第一次内核发布？ |
-| --- | --- | --- | --- |
-| Tenant principal / session ownership / access decision | **控制得住 → 严格强制** | 本仓库拥有契约并默认拒绝。 | **是** —— 已实现且由测试锁定。 |
-| `TenantSessionStore` seam + contract suite | **控制得住 → 严格强制** | 本仓库拥有 seam；提供内存参考实现；第三方用共享套件证明 provider。 | **是** —— 已完成。 |
-| Agent 创生准入（`setup`） | **控制得住 → 严格强制** | 保留 decorator/probe；每次目标版本推进时只重验受影响 DSH seam。 | **是** —— R1 已刷新 RC7 evidence。 |
-| unary `ApiProxy` 分类 | **控制得住 → 严格强制** | 对真实 `RpcMethodMap` 穷举分类；未知 / 新增方法默认拒绝。 | **是** —— R1 已刷新 RC7 type/evidence。 |
-| HTTP/WS request/connection principal scope | **需要生态协作 → 制定标准** | 定义最小、通用的 DSH seam 并向上游协作。不要 fork / 重写 Web transport。 | 内核**不阻塞**；production Web **阻塞**。 |
-| mux / host stream 与 `respond` | **生态 seam 落地后由我们强制** | spike 中继续拒绝；有 principal-scoped transport seam 后再实现和测试。 | 内核不阻塞。 |
-| Auth provider（JWT/OIDC/API key） | **后续 provider** | 真实 transport principal scope 存在后，再做可替换参考 provider。 | 否。 |
-| 持久 ownership store | **后续 provider** | 有真实需求时增加 provider；provider seam 已存在。 | 否。 |
-| `session.search` 租户可见性 | **生态 / 后续** | 当前拒绝；真正需要时再推动 scoped visibility/search contract。 | 否。 |
-| Workspace / host-global management | **v0.1 范围外** | Web spike 中暴露到的地方继续拒绝；不替 DSH-global 资源凭空发明 tenant 语义。 | 否。 |
-| tenant-aware MCP context propagation | **生态 / 后续** | DSH/MCP seam 稳定且有需求时，再定义一致性契约。 | 否。 |
-| Shell / filesystem / process / container / network isolation | **明确边界** | 本插件家族不提供；强执行隔离属于 deployment/runtime 层。 | 否。 |
-| Billing、UI、组织/用户管理 | **明确边界** | 不是本仓库目标。 | 否。 |
-| 团队共享 / ACL / ownership reassignment | **v0.1 明确边界** | v0.1 保持 tenant+user 不可变所有权；未来如有需求另设计同租户 policy plane。 | 否。 |
+| Surface | 分类 | 项目立场 |
+| --- | --- | --- |
+| Tenant/user identity + session ownership + access decision | **控制得住 → 严格强制** | Kernel contract；fail closed，并由测试锁定。 |
+| `TenantSessionStore` seam + shared contract suite | **控制得住 → 严格强制** | Kernel-owned seam；只内置内存参考实现。 |
+| Agent 创生准入（`setup`） | **控制得住 → 严格强制** | RC7 runtime proof 继续作为 compatibility gate。 |
+| unary `ApiProxy` 分类 | **控制得住 → 严格强制** | private Web spike 中穷举并 fail closed。 |
+| HTTP/WS request/connection principal scope | **需要生态协作 → 制定标准** | 需要通用 DSH transport seam；不 fork transport。 |
+| Production Web streams / `respond` / admission | **生态 seam 后再强制** | principal scope 存在前，未支持 surface 继续 deny。 |
+| Durable ownership store | **后续 provider** | 只有真实 contributor/user demand 时才做。 |
+| Auth provider | **后续 provider** | 真实 transport principal scope 存在后再做。 |
+| `session.search` tenant visibility | **生态 / 后续** | 正确 scoped-query 语义存在前继续 deny。 |
+| MCP tenant context | **生态 / 后续** | seam 与需求都具体以后再标准化。 |
+| Shell/filesystem/process/container/network isolation | **明确边界** | deployment/runtime 责任，不属于本插件家族。 |
+| Billing/UI/组织用户管理/general RBAC | **明确边界** | 不是仓库目标。 |
+| Team sharing/ACL/reassignment | **v0.1 明确边界** | 真有需要时进入独立 same-tenant policy plane。 |
 
-## 已完成
+## 已完成发布主线
 
-- ✅ **M0 — 工程地基** —— monorepo、包规则、spec/ADR 纪律、CI。
-- ✅ **M1 — 内核加固** —— claim-once ownership、fail-closed access、
-  `TenantSessionStore`、共享契约测试、package smoke、架构门。
-- ✅ **M2 — Session genesis proof** —— Agent `setup` 是 visibility 前的准入点；
-  create / fork / subagent / resume 最初在 RC6 上建立 proof。
-- ✅ **M3 — Web enforcement spike** —— 真实 `ApiProxy` facade、unary 穷举分类、
-  fail-closed policy，以及 H3 transport 缺口已经识别。
-- ✅ **边界治理原则** —— 控制得住就强制；需要生态协作就制定标准；控制不住就明确边界。当前目标基线为 RC7。
-- ✅ **R1 — RC7 兼容性刷新** —— DSH proof pin/lockfile 已刷新到 RC7；相关源码 seam 已核对；session-genesis 与 admission runtime proof 在 Node 22.19 / Node 24 均通过；DSH pin 漂移检查与 runtime proof 已成为 CI gate。精确 evidence 见 `docs/reference/compatibility.md`。
+- ✅ **R1 — RC7 compatibility refresh** —— 集中 DSH target/pin，并在 Node 22.19 + Node 24 跑受影响 runtime proof。
+- ✅ **R2 — Kernel release hardening** —— package metadata、supported guarantee、explicit boundary、packed external-consumer smoke 与 release preflight 已建立。
+- ✅ **R3 — 第一次公开 prerelease** —— `dsh-multi-tenant@0.1.0-rc.1` 已发布到 npm `next`；provenance、registry smoke、Git tag 与 GitHub prerelease 全部成功。
 
-## 发布主线 —— 接下来几轮迭代
+历史 evidence 见 `docs/reference/compatibility.md`；当前发布机制见 `docs/reference/release.md`。
 
-只有下面这些事情阻塞第一次 `dsh-multi-tenant` 发布。
+## 🚧 rc.2 —— stable 前最后一次 API subtraction
 
-### ✅ R1 — RC7 兼容性刷新
+`0.1.0-rc.2` 刻意是收敛版本，不是 feature release：
 
-R1 compatibility PR 已完成以下证明：
+1. 把 `TenantPrincipal` 收成 `{ tenantId, userId }`；
+2. 删除未使用的 role validation/public contract；
+3. RBAC/policy attribute 继续留在 ownership kernel 之外；
+4. 只通过 npm Trusted Publishing/OIDC 发布，不再保留 bootstrap token fallback；
+5. 重跑完全相同的 release proof 与 registry consumer smoke。
 
-1. `@deepseek-ai/dsh-host-apiproxy` 以及解析出的 DSH dependency graph 均显式 pin 到 **`0.1.0-rc.7`**，并由 frozen lockfile 锁定；
-2. RC6 → RC7 相关源码 seam 已定向核对，真实 runtime proof 在两条支持的 Node 版本线上重新执行；
-3. 精确 RC7 release commit 与相关 source blob 已记录到 compatibility reference；
-4. DSH target 已集中管理，package pin 漂移会直接令 CI 失败；
-5. 未变化的架构没有重新设计，H3 继续留在 ecosystem track，而不是通过本地 transport fork 强行关闭。
+rc.2 以后，**不要为了 roadmap 进度再造 rc.3**。除非出现真实 bug、upstream compatibility change，或者真实用户反馈要求 contract 变化，否则下一步应该判断是否进入 `0.1.0` stable。
 
-### 🚧 R2 — 内核发布加固
-
-1. package metadata 必须和真实内核范围一致 —— identity、ownership、authorization、store seam/testing；不能声称内置 MCP、audit、auth 或 production Web isolation；
-2. 在 README / package docs 中明确发布 **supported guarantees** 与 **explicit boundaries**；
-3. 跑发布门：frozen install、`pnpm verify`、`pnpm typecheck`、`pnpm test`、`pnpm build`、`pnpm smoke`，以及 RC compatibility probe；
-4. 确定第一次 0.1 prerelease 版本（建议 `0.1.0-rc.1`），验证 packed consumer experience。
-
-### 🚧 R3 — 发布内核 prerelease
-
-- publish/tag `dsh-multi-tenant` 的 0.1 prerelease；
-- release notes 明确 RC7 evidence baseline 与 security boundary；
-- `dsh-multi-tenant-web` **不能**被描述成 production 多用户 Web 方案。它可以继续仅存在于仓库中，或者只有在明确 experimental/prerelease 标签下才发布。
-
-R3 完成以后，项目就已经有一个真实版本，用户和生态作者可以围绕它开发，而不必等所有 SaaS 问题一起解决。
-
-## 生态主线 —— 重要，但不阻塞内核发布
+## 生态主线 —— 不阻塞 kernel
 
 ### 🤝 E1 — DSH principal-scope seam
 
-RC7 当前公开的 `ConnectionRpcHandler` 仍然只有解码后的
-`(endpoint, payload, signal)`，官方 Web carrier 文档也明确说明当前没有 authentication layer。因此本项目应该交付的是**一个小而通用的上游 seam**，不是本地 transport fork。
+向上游提出最小、tenant-agnostic 的 request/connection-scoped security-context seam。它应覆盖 HTTP request scope、WebSocket connection lifetime、并发 principal 不发生 ambient/global cross-talk、session publication 前 admission，以及必要的 event/response correlation。
 
-上游 proposal 应保持 tenant-agnostic，让调用方可以基于真实 HTTP request / WS upgrade 建立 request/connection-scoped API/security context。一致性要求至少覆盖：
+### 🤝 E2 — E1 以后再做 production Web enforcement
 
-- HTTP request scope 与 WebSocket connection lifetime；
-- 并发 principal 之间没有 ambient/global cross-talk；
-- 能在 `session.create` admission 以及 event delivery 之前安装 principal-bound `ApiProxy`；
-- 如果真实 runtime evidence 证明需要，则包含 server-request response（`respond`）安全 correlation。
+只有 DSH 暴露足够 principal-scope seam 后，`dsh-multi-tenant-web` 才考虑 publish：在同一 principal scope 下接通 admission/unary/streams/respond，并增加最小 two-tenant adversarial E2E。
 
-这个 proposal **不阻塞**内核发布。
+### 🤝 E3 — 其他 contract 只按需求启动
 
-### 🤝 E2 — seam 存在以后再做 production Web enforcement
+Search visibility、MCP context propagation、DSH-global resource tenancy 都是独立、demand-gated contract，不是强制 milestone。
 
-DSH 提供足够的 principal-scope seam 后：
+## 后续 provider
 
-1. 把 `dsh-multi-tenant-web` 从 spike 变成可安装的 enforcement plugin；
-2. 在同一 principal scope 下接通 admission、unary guard/filter、stream filtering 与 `respond`；
-3. 对支持的 Web surface 增加最小 two-tenant adversarial E2E suite；
-4. 到这一步才冻结 Web package public contract，并考虑 Web prerelease。
+🧭 Durable store provider（PostgreSQL/Redis/MySQL）、reference auth provider、lifecycle/admin cleanup 都可以在真实需求出现后独立增加，不扩大 kernel guarantee。
 
-### 🤝 E3 — 其他生态 contract，只在有需求时启动
+## 明确非目标
 
-这些是独立 follow-up，不再形成串行的 M6/M7/M8 大链条：
+⛔ 0.1 版本线不声称提供强 process/container isolation。通过 tenant authorization 的 Agent 仍拥有 deployment 授予的 shell/filesystem/network 能力。
 
-- tenant-scoped search visibility；
-- tenant-aware MCP principal/context propagation；
-- 生态真正决定要 tenant-owned 的其他 DSH-global resource model。
+⛔ 仓库不会变成 billing system、identity directory、UI 产品或 general RBAC framework。
 
-每一项都先从 seam/contract + conformance expectation 开始，而不是先做大规模本地实现。
+⛔ 不会为了让所有问题本地可解，就重写 DSH Web transport、search、MCP runtime 或 host resource model。
 
-## 后续 owned provider —— 可选、独立包
+⛔ v0.1 ownership 是不可变 `(tenantId, userId)`。`TenantPrincipal` 不包含 roles/permissions；cross-user sharing 与 admin policy 必须进入独立 same-tenant policy plane。
 
-🧭 这些可以在内核发布之后独立推进，不需要改内核：
-
-- 一个 durable `TenantSessionStore` provider（PostgreSQL / Redis / MySQL —— 根据 contributor/user 真实需求选择，而不是为了 roadmap 对称而全做）；
-- E1 落地后的 reference auth provider；
-- 如果出现真实 use case，再做 tombstoned ownership 的 lifecycle/admin cleanup。
-
-它们都不是证明内核契约所必需的。
-
-## 明确边界 / 非目标
-
-⛔ 0.1 版本线**不**声称提供强 process/container isolation。一个已通过租户授权的 Agent 仍拥有其所在 DSH deployment 授予的 shell/filesystem/network 能力。需要强执行隔离的部署必须在本插件家族之外强制。
-
-⛔ 本仓库不会演变成 billing system、组织/用户目录、UI 产品或通用 RBAC framework。
-
-⛔ 不会为了让 checklist 每一行都变成本地能力，就重新实现 DSH Web transport、session search engine、MCP runtime 或 host resource model。
-
-⛔ v0.1 ownership 是不可变的 `(tenantId, userId)` ownership。跨用户共享、reassignment、admin inspection、team ACL 必须属于独立的 same-tenant policy plane，不能悄悄塞进 kernel。
-
-## 什么阻塞什么
-
-```text
-RC7 compatibility ✅ ──> kernel release hardening ──> dsh-multi-tenant 0.1 prerelease
-
-DSH principal-scope seam ──> production dsh-multi-tenant-web ──> Web E2E / Web release
-
-search / MCP / durable providers / auth provider / audit / UI
-        └──────────── 独立、按需求触发的 follow-up ─────────────┘
-```
-
-这份 Roadmap 刻意保持短小。只有真正阻塞**本仓库拥有的 release guarantee** 的事项才进入发布主线；生态事项放在生态主线；不支持的事情继续作为明确边界。
+这份 Roadmap 刻意保持短小：拥有的保证严格强制；依赖生态的地方制定标准；其余继续明确边界。

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,22 +7,27 @@ Navigation hub for `dsh-multi-tenant` documentation.
 ## Guides
 
 - [README](../README.md) — project overview
-- [CONTRIBUTING](../CONTRIBUTING.md) — how development is done (spec-driven + test-driven)
-- [ROADMAP](../ROADMAP.md) — milestones and status
+- [CONTRIBUTING](../CONTRIBUTING.md) — development policy
+- [ROADMAP](../ROADMAP.md) — current release/ecosystem direction
 
 ## Decision records (ADR)
 
-- [Session genesis ownership](./adr/session-genesis.md) — the Agent `setup` hook is the admission point (M2)
-- [Web enforcement](./adr/web-enforcement.md) — converged: H3-only upstream seam (M3)
+- [Session genesis ownership](./adr/session-genesis.md) — Agent `setup` admission point
+- [Web enforcement](./adr/web-enforcement.md) — H3 principal-scope ecosystem seam
 
 ## Specs & analysis
 
-- [Architecture — six layers](./specs/architecture.md) — the global six-layer map
-- [Session genesis map](./specs/session-genesis-map.md) — the `prepare → setup → enter → announce` lifecycle
-- [Admission composition](./specs/admission-composition.md) — how a plugin joins every Agent `setup` (M3.0)
-- [Web seam map](./specs/web-seam-map.md) — the five authorization surfaces
+- [Architecture](./specs/architecture.md) — capability/layer ownership
+- [Session genesis map](./specs/session-genesis-map.md) — `prepare → setup → enter → announce`
+- [Admission composition](./specs/admission-composition.md) — plugin admission composition
+- [Web seam map](./specs/web-seam-map.md) — authorization surfaces
 
 ## Reference
 
 - [Compatibility & versioning](./reference/compatibility.md) — Node / Cordis / DSH ranges + pinning
-- [Kernel prerelease contract](./reference/release.md) — `0.1.0-rc.1` artifact, release gates, boundaries, and R3 checklist
+- [Kernel prerelease contract](./reference/release.md) — current artifact, proof, OIDC publication, and boundaries
+
+## Releases
+
+- [`v0.1.0-rc.1`](./releases/v0.1.0-rc.1.md) — first public kernel prerelease
+- [`v0.1.0-rc.2`](./releases/v0.1.0-rc.2.md) — API subtraction / OIDC-only convergence candidate

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -2,27 +2,32 @@
 
 # 文档
 
-`dsh-multi-tenant` 文档的导航中心。
+`dsh-multi-tenant` 文档导航中心。
 
 ## 指南
 
 - [README](../README.zh-CN.md) — 项目概览
-- [CONTRIBUTING](../CONTRIBUTING.zh-CN.md) — 开发方式（规格驱动 + 测试驱动）
-- [ROADMAP](../ROADMAP.zh-CN.md) — 里程碑与状态
+- [CONTRIBUTING](../CONTRIBUTING.zh-CN.md) — 开发规范
+- [ROADMAP](../ROADMAP.zh-CN.md) — 当前 release / ecosystem 方向
 
 ## 决策记录（ADR）
 
-- [会话创生所有权](./adr/session-genesis.zh-CN.md) — Agent `setup` 钩子是准入点（M2）
-- [Web 强制](./adr/web-enforcement.zh-CN.md) — 收敛：H3-only 上游 seam（M3）
+- [会话创生所有权](./adr/session-genesis.zh-CN.md) — Agent `setup` 准入点
+- [Web 强制](./adr/web-enforcement.zh-CN.md) — H3 principal-scope 生态 seam
 
 ## 规格与分析
 
-- [架构 —— 六层](./specs/architecture.zh-CN.md) — 全局六层图
-- [会话创生图](./specs/session-genesis-map.zh-CN.md) — `prepare → setup → enter → announce` 生命周期
-- [准入组合](./specs/admission-composition.zh-CN.md) — 插件如何加入每一次 Agent `setup`（M3.0）
-- [Web seam 图](./specs/web-seam-map.zh-CN.md) — 五个授权 surface
+- [架构](./specs/architecture.zh-CN.md) — capability/layer 归属
+- [会话创生图](./specs/session-genesis-map.zh-CN.md) — `prepare → setup → enter → announce`
+- [准入组合](./specs/admission-composition.zh-CN.md) — plugin admission composition
+- [Web seam 图](./specs/web-seam-map.zh-CN.md) — authorization surfaces
 
 ## 参考
 
 - [兼容性与版本](./reference/compatibility.zh-CN.md) — Node / Cordis / DSH 范围 + pinning
-- [Kernel prerelease 发布契约](./reference/release.zh-CN.md) — `0.1.0-rc.1` artifact、发布 gate、边界与 R3 checklist
+- [Kernel prerelease 发布契约](./reference/release.zh-CN.md) — 当前 artifact、proof、OIDC 发布与边界
+
+## Releases
+
+- [`v0.1.0-rc.1`](./releases/v0.1.0-rc.1.md) — 第一次公开 kernel prerelease
+- [`v0.1.0-rc.2`](./releases/v0.1.0-rc.2.md) — API subtraction / OIDC-only 收敛 candidate

--- a/docs/reference/release.md
+++ b/docs/reference/release.md
@@ -2,28 +2,58 @@
 
 # Kernel prerelease contract
 
-This document is the release contract for the first public kernel artifact. R2 fixed the artifact and its proof; R3 only publishes and verifies it.
+The kernel has a real published prerelease line. This reference defines the
+current release artifact and the mechanical proof required before publication.
 
-## Artifact
+## Current artifact
 
 - **Package:** `dsh-multi-tenant`
-- **Version:** `0.1.0-rc.1`
+- **Candidate:** `0.1.0-rc.2`
 - **npm dist-tag:** `next`
 - **DSH compatibility target:** `0.1.0-rc.7`
 - **Node:** `^22.19.0 || >=24.0.0`
+- **Publishing:** npm Trusted Publishing / GitHub Actions OIDC
 - **Provenance:** enabled
 
-`dsh-multi-tenant-web` is private and is **not** part of this release.
+`dsh-multi-tenant-web` remains private and is not part of this release.
+
+## Why rc.2 exists
+
+`0.1.0-rc.1` successfully established the first public artifact, registry smoke,
+provenance, tag, and GitHub prerelease. Before freezing a stable 0.1 contract,
+rc.2 removes one speculative public field: `TenantPrincipal.roles`.
+
+The ownership kernel never consumed roles. Keeping the required field would have
+made every caller carry RBAC vocabulary that this package explicitly does not
+own. The principal is therefore reduced to the identity the kernel actually
+enforces:
+
+```ts
+interface TenantPrincipal {
+  tenantId: string
+  userId: string
+}
+```
+
+Roles/permissions/admin policy belong to a separate policy plane if a real use
+case later requires them.
 
 ## Release guarantee
 
-The artifact guarantees only the kernel-owned contract: opaque principal/owner identity shapes, claim-once immutable session ownership, unconditional cross-tenant denial, v0.1 same-user ownership, fail-closed unknown/foreign-session authorization, non-enumerating public denial, and the replaceable async `TenantSessionStore` contract plus shared provider test suite.
+The artifact guarantees only the kernel-owned contract: opaque tenant/user
+identity, claim-once immutable session ownership, unconditional cross-tenant
+denial, v0.1 same-user ownership, fail-closed unknown/foreign-session
+authorization, non-enumerating public denial, and the replaceable async
+`TenantSessionStore` contract plus shared provider test suite.
 
-The bundled `InMemoryTenantSessionStore` is a reference/bootstrap provider, not production durability.
+The bundled `InMemoryTenantSessionStore` is a reference/bootstrap provider, not
+production durability.
 
-## Explicit release boundary
+## Explicit boundary
 
-The prerelease does not claim authentication, production DSH Web multi-user isolation, durable storage, MCP credential/context isolation, audit persistence, team ACLs, or shell/filesystem/process/container/network isolation.
+The prerelease does not claim authentication, production DSH Web multi-user
+isolation, durable storage, MCP credential/context isolation, audit persistence,
+team ACLs, general RBAC, or shell/filesystem/process/container/network isolation.
 
 ## Pre-publication proof
 
@@ -34,47 +64,39 @@ pnpm install --frozen-lockfile
 pnpm release:check
 ```
 
-The release workflow reruns this full proof from `main` before touching npm.
+The release workflow reruns this proof from `main` before touching npm.
 
-## R3 publication workflow
+## OIDC-only publication
 
-Publication is implemented by `.github/workflows/release.yml` and is intentionally manual (`workflow_dispatch`). The operator must type the exact package version and dispatch from `main`. The job runs in the `npm-release` GitHub Environment and:
+Publication is implemented by `.github/workflows/release.yml` and is manual
+(`workflow_dispatch`). The operator types the exact package version and dispatches
+from `main`. The job runs in the `npm-release` GitHub Environment with
+`id-token: write` and no npm publish token fallback.
 
-1. verifies the requested version and npm trusted-publishing capability;
-2. runs the full `release:check` gate;
-3. checks the npm package name/repository and whether the exact version already exists;
-4. publishes only when the exact version is absent;
-5. verifies `next`, repository metadata, integrity, and a clean external consumer from the registry;
-6. creates the matching `v0.1.0-rc.1` Git tag and GitHub prerelease only after registry verification succeeds.
+The workflow:
 
-The workflow is safe to rerun: if the exact npm version already exists under this repository, the publish step is skipped and post-publish verification/tag/release can recover.
+1. validates branch/version and npm trusted-publishing capability;
+2. runs `release:check`;
+3. checks npm package ownership and exact-version state;
+4. publishes through npm Trusted Publishing/OIDC only when the version is absent;
+5. verifies `next`, repository metadata, integrity, and a clean external consumer;
+6. creates the matching Git tag and GitHub prerelease only after registry smoke succeeds.
 
-## First-publication bootstrap
+It is safe to rerun: an existing matching npm version skips duplicate publish and
+continues verification/tag/release recovery.
 
-npm trusted publishing is configured per existing package. Because `dsh-multi-tenant` has never been published before, `0.1.0-rc.1` needs a one-time bootstrap credential.
-
-Recommended bootstrap:
-
-1. create/configure the GitHub Environment `npm-release` (restrict it to `main`; add a required reviewer if desired);
-2. create a short-lived npm granular token that is allowed to create/publish the package under the account's 2FA policy;
-3. store it **only** as the `NPM_BOOTSTRAP_TOKEN` secret in the `npm-release` Environment;
-4. run `Publish kernel prerelease` from `main` with version `0.1.0-rc.1`;
-5. after the package exists, configure npm Trusted Publishing for:
-   - GitHub owner: `GuoMonth`
-   - repository: `dsh-multi-tenant`
-   - workflow filename: `release.yml`
-   - environment: `npm-release`
-   - allowed action: `npm publish`;
-6. delete `NPM_BOOTSTRAP_TOKEN` and, after trusted publishing is proven, restrict traditional token publishing on npm.
-
-The workflow grants `id-token: write` and publishes with provenance. With trusted publishing configured, npm uses short-lived OIDC credentials; the bootstrap token is no longer needed.
+The first-publication bootstrap token used for rc.1 is no longer part of the
+workflow. Maintainers should remove/revoke any remaining bootstrap credential.
 
 ## Post-publication verification
 
-The workflow runs `scripts/registry-smoke.mjs` against the exact published version. A human can additionally verify DSH installation with:
+The workflow runs `scripts/registry-smoke.mjs` against the exact version. A human
+can additionally verify DSH installation with:
 
 ```sh
 dsh plugin --profile <profile> add dsh-multi-tenant@next
 ```
 
-R3 is complete only when the npm version exists, `next` resolves to it, the registry smoke passes, and the matching GitHub prerelease/tag exist.
+After rc.2, the project should prefer observation and real feedback over adding
+more speculative kernel API. Barring a real bug or upstream compatibility change,
+the next release decision is whether the contract is ready for `0.1.0` stable.

--- a/docs/reference/release.zh-CN.md
+++ b/docs/reference/release.zh-CN.md
@@ -2,79 +2,77 @@
 
 # Kernel prerelease 发布契约
 
-本文档定义第一次公开 kernel artifact 的 release contract。R2 已经把 artifact 与验证门固定下来；R3 只负责真正发布与发布后验证。
+Kernel 已经拥有真实公开的 prerelease 版本线。本文档定义当前 release artifact，以及发布前必须通过的机械化证明。
 
-## Artifact
+## 当前 artifact
 
 - **Package：** `dsh-multi-tenant`
-- **Version：** `0.1.0-rc.1`
+- **Candidate：** `0.1.0-rc.2`
 - **npm dist-tag：** `next`
 - **DSH compatibility target：** `0.1.0-rc.7`
 - **Node：** `^22.19.0 || >=24.0.0`
+- **Publishing：** npm Trusted Publishing / GitHub Actions OIDC
 - **Provenance：** enabled
 
-`dsh-multi-tenant-web` 是 private package，**不属于**本次 release。
+`dsh-multi-tenant-web` 继续保持 private，不属于本次 release。
+
+## 为什么需要 rc.2
+
+`0.1.0-rc.1` 已经成功建立第一个公开 artifact，并完成 registry smoke、provenance、Git tag 与 GitHub prerelease。进入 stable 0.1 以前，rc.2 做最后一次主动 API subtraction：删除 `TenantPrincipal.roles`。
+
+Ownership kernel 从未读取 roles。继续把它作为 required public field，会迫使每个调用方携带一个本 package 明确不拥有的 RBAC vocabulary。因此 principal 收敛到 kernel 真正强制的 identity：
+
+```ts
+interface TenantPrincipal {
+  tenantId: string
+  userId: string
+}
+```
+
+未来如果真实需求需要 roles / permissions / admin policy，应进入独立 policy plane。
 
 ## Release guarantee
 
-Artifact 只承诺 kernel 自己拥有的 contract：opaque principal/owner identity shape、claim-once 不可变 session ownership、无条件 cross-tenant denial、v0.1 same-user ownership、fail-closed unknown/foreign-session authorization、不可枚举的公开 denial，以及可替换 async `TenantSessionStore` contract 与共享 provider test suite。
+Artifact 只承诺 kernel 自己拥有的 contract：opaque tenant/user identity、claim-once 不可变 session ownership、无条件 cross-tenant denial、v0.1 same-user ownership、fail-closed unknown/foreign-session authorization、不可枚举公开 denial，以及可替换 async `TenantSessionStore` contract 与共享 provider test suite。
 
 内置 `InMemoryTenantSessionStore` 是 reference/bootstrap provider，不提供 production durability。
 
-## 明确发布边界
+## 明确边界
 
-本 prerelease 不声称提供 authentication、production DSH Web 多用户隔离、durable storage、MCP credential/context isolation、audit persistence、team ACL，也不提供 shell/filesystem/process/container/network isolation。
+本 prerelease 不声称提供 authentication、production DSH Web 多用户隔离、durable storage、MCP credential/context isolation、audit persistence、team ACL、general RBAC，也不提供 shell/filesystem/process/container/network isolation。
 
 ## 发布前验证
-
-从干净 checkout 开始：
 
 ```sh
 pnpm install --frozen-lockfile
 pnpm release:check
 ```
 
-真正 publish 前，release workflow 会从 `main` 再完整执行一次该验证。
+真正 publish 前，release workflow 会从 `main` 再完整执行一次。
 
-## R3 发布 workflow
+## OIDC-only 发布
 
-发布由 `.github/workflows/release.yml` 完成，并且刻意只允许手工 `workflow_dispatch`。操作者必须输入精确 package version，并从 `main` 触发。Job 运行在 `npm-release` GitHub Environment 中，会：
+发布由 `.github/workflows/release.yml` 完成，并刻意保持手工 `workflow_dispatch`。操作者必须输入精确 package version，并从 `main` 触发。Job 运行在 `npm-release` GitHub Environment 中，具备 `id-token: write`，**不再存在 npm publish token fallback**。
 
-1. 核对请求版本与 npm trusted-publishing capability；
+Workflow 会：
+
+1. 核对 branch/version 与 npm trusted-publishing capability；
 2. 跑完整 `release:check`；
-3. 核对 npm package name/repository，以及精确 version 是否已存在；
-4. 只有 version 不存在时才 publish；
-5. 从 registry 验证 `next`、repository metadata、integrity，并在干净 external consumer 中实际安装和调用；
-6. registry 验证成功以后，才创建匹配的 `v0.1.0-rc.1` Git tag 与 GitHub prerelease。
+3. 核对 npm package ownership 与精确 version 状态；
+4. version 不存在时，仅通过 npm Trusted Publishing/OIDC publish；
+5. 验证 `next`、repository metadata、integrity，并在干净 external consumer 中安装调用；
+6. registry smoke 成功以后才创建匹配的 Git tag 与 GitHub prerelease。
 
-Workflow 可安全重跑：如果精确 npm version 已经存在且属于本仓库，会跳过重复 publish，继续完成 registry verification / tag / GitHub release。
+Workflow 可安全重跑：如果匹配版本已经存在，会跳过重复 publish，继续完成 verification/tag/release recovery。
 
-## 第一次发布 bootstrap
-
-npm Trusted Publishing 是针对“已经存在的 package”配置的。由于 `dsh-multi-tenant` 此前从未发布，`0.1.0-rc.1` 需要一次性 bootstrap credential。
-
-推荐流程：
-
-1. 创建/配置 GitHub Environment `npm-release`（限制为 `main`；如需要可增加 required reviewer）；
-2. 创建一个短有效期 npm granular token，使其在当前账户 2FA policy 下能够创建/发布 package；
-3. token **只**保存为 `npm-release` Environment secret：`NPM_BOOTSTRAP_TOKEN`；
-4. 在 `main` 上运行 `Publish kernel prerelease`，version 输入 `0.1.0-rc.1`；
-5. package 创建成功后，在 npm 配置 Trusted Publishing：
-   - GitHub owner：`GuoMonth`
-   - repository：`dsh-multi-tenant`
-   - workflow filename：`release.yml`
-   - environment：`npm-release`
-   - allowed action：`npm publish`；
-6. 删除 `NPM_BOOTSTRAP_TOKEN`；Trusted Publishing 验证成功以后，再在 npm 侧限制传统 token publishing。
-
-Workflow 授予 `id-token: write` 并启用 provenance。Trusted Publishing 配好以后，npm 使用短生命周期 OIDC credential，不再需要 bootstrap token。
+rc.1 首次发布使用过的 bootstrap token 已经不再属于 workflow。维护者应删除/revoke 任何仍然存在的 bootstrap credential。
 
 ## 发布后验证
 
-Workflow 会对精确版本运行 `scripts/registry-smoke.mjs`。还可以人工用 DSH 再验证一次：
+Workflow 会对精确版本运行 `scripts/registry-smoke.mjs`。还可以人工使用 DSH 验证：
 
 ```sh
 dsh plugin --profile <profile> add dsh-multi-tenant@next
 ```
 
-只有 npm version 已存在、`next` 指向它、registry smoke 成功、并且匹配的 GitHub prerelease/tag 都存在时，R3 才算完成。
+rc.2 以后，项目应该优先观察真实使用反馈，不再给 kernel 增加推测性 API。除非出现真实 bug 或 upstream compatibility change，否则下一次 release decision 应该是判断是否进入 `0.1.0` stable。

--- a/docs/releases/v0.1.0-rc.2.md
+++ b/docs/releases/v0.1.0-rc.2.md
@@ -1,0 +1,65 @@
+# dsh-multi-tenant 0.1.0-rc.2
+
+`0.1.0-rc.2` is a **convergence release**, not a feature release. It removes one
+speculative public API field before the 0.1 contract is considered for stable.
+
+## API subtraction
+
+`TenantPrincipal` is now exactly:
+
+```ts
+interface TenantPrincipal {
+  tenantId: string
+  userId: string
+}
+```
+
+The required `roles` field from rc.1 has been removed, together with role-count /
+role-length validation. The ownership kernel never consumed roles; retaining the
+field would have forced every integration to adopt RBAC vocabulary that the
+kernel explicitly does not own.
+
+Callers that only supplied `roles` to satisfy the rc.1 type should simply remove
+that property. Code that actually depended on `principal.roles` must move that
+policy into its authentication/authorization layer rather than the ownership
+kernel.
+
+The security invariants are unchanged:
+
+- claim-once immutable `(tenantId, userId)` ownership;
+- unconditional cross-tenant denial;
+- same tenant + different user denied in v0.1;
+- unknown and foreign sessions fail closed;
+- public denial remains non-enumerating;
+- `TenantSessionStore` remains replaceable and contract-tested.
+
+## Publishing convergence
+
+The release workflow is now **OIDC-only** through npm Trusted Publishing. The
+one-time `NPM_BOOTSTRAP_TOKEN` fallback used to create the package for rc.1 is no
+longer referenced by the repository.
+
+The workflow still requires:
+
+- dispatch from `main` with the exact version;
+- GitHub Environment `npm-release`;
+- `id-token: write`;
+- full `pnpm release:check` before publication;
+- registry ownership/version preflight;
+- registry external-consumer smoke before creating the Git tag / GitHub prerelease.
+
+## Compatibility baseline
+
+- DeepSeek Harness target: `0.1.0-rc.7`
+- Node: `^22.19.0 || >=24.0.0`
+- npm channel: `next`
+
+## Explicit boundary
+
+This package still does **not** provide production multi-user DSH Web transport,
+authentication, durable storage, MCP credential isolation, audit persistence,
+general RBAC/team ACLs, or shell/filesystem/process/container/network isolation.
+
+After rc.2, the project should stop adding speculative kernel API. Without a real
+bug, upstream compatibility change, or concrete user feedback requiring another
+contract change, the next release decision is whether to publish `0.1.0` stable.

--- a/packages/multi-tenant-web/tests/bind-tenant.test.ts
+++ b/packages/multi-tenant-web/tests/bind-tenant.test.ts
@@ -9,8 +9,8 @@ import type { ApiProxy } from '@deepseek-ai/dsh-host-apiproxy/api'
 import { bindTenant } from '../src/bind-tenant.ts'
 import { CLASSIFICATION } from '../src/classification.ts'
 
-const alice = { tenantId: 'acme', userId: 'alice', roles: ['member'] }
-const bob = { tenantId: 'acme', userId: 'bob', roles: ['member'] }
+const alice = { tenantId: 'acme', userId: 'alice' }
+const bob = { tenantId: 'acme', userId: 'bob' }
 
 async function makeMultiTenant(): Promise<MultiTenantService> {
   const ctx = new Context()

--- a/packages/multi-tenant/README.md
+++ b/packages/multi-tenant/README.md
@@ -2,13 +2,13 @@
 
 # dsh-multi-tenant
 
-Multi-tenant kernel primitives for DeepSeek Harness (DSH): tenant identity,
-immutable session ownership, fail-closed authorization, and a replaceable
-ownership-store contract.
+Multi-tenant kernel primitives for DeepSeek Harness (DSH): minimal tenant/user
+identity, immutable session ownership, fail-closed authorization, and a
+replaceable ownership-store contract.
 
-> **Release candidate: `0.1.0-rc.1`.** This package is intentionally small. It
-> is the only publishable artifact in the first 0.1 release line; Web/auth/MCP/
-> runtime isolation are separate integration or ecosystem concerns. The current
+> **Release candidate: `0.1.0-rc.2`.** The kernel stays intentionally small. It
+> is the only publishable artifact in this 0.1 release line; Web/auth/MCP/runtime
+> isolation remain integration, ecosystem, or deployment concerns. The current
 > DSH compatibility target is `0.1.0-rc.7`.
 
 ## Supported guarantee
@@ -18,13 +18,13 @@ to opaque DSH session ids through a fail-closed ownership contract.
 
 It provides two Cordis services:
 
-- `ctx.tenantSessionStore` — the replaceable ownership-storage seam;
+- `ctx.tenantSessionStore` — replaceable ownership storage;
 - `ctx.multiTenant` — claim-once ownership and authorization.
 
 The kernel guarantees:
 
 - **claim-once, immutable ownership**;
-- **unconditional tenant boundary** — no role can cross tenants;
+- **unconditional tenant boundary** — cross-tenant access is always denied;
 - **same-user ownership in v0.1** — same tenant but different user is denied;
 - **fail-closed authorization** — unknown and foreign sessions are denied;
 - **non-enumerating public denial** — unknown vs foreign is not disclosed;
@@ -44,8 +44,13 @@ This package is **not**:
 - billing, UI, organization/user administration, or a general RBAC framework;
 - a team-sharing/ACL/reassignment model.
 
-Those items are not all “future kernel features”. The project rule is:
-**control → enforce, ecosystem → standardize, outside control → bound**.
+Roles, permissions, admin flags, and other policy attributes are deliberately
+**not part of `TenantPrincipal`**. If same-tenant sharing or RBAC becomes a real
+requirement, it belongs to a separate policy plane rather than this ownership
+kernel.
+
+Project rule: **control → enforce, ecosystem → standardize, outside control →
+bound**.
 
 ## Core API
 
@@ -55,7 +60,6 @@ Those items are not all “future kernel features”. The project rule is:
 interface TenantPrincipal {
   tenantId: string
   userId: string
-  roles: readonly string[]
 }
 
 interface SessionOwner {
@@ -65,10 +69,6 @@ interface SessionOwner {
 ```
 
 ### `TenantSessionStore` (`ctx.tenantSessionStore`)
-
-The storage seam is a Cordis `Service`. `claim` is one atomic contract operation
-so durable providers can implement it with their native conditional-write
-primitive.
 
 ```ts
 type ClaimResult = 'created' | 'idempotent' | 'conflict'
@@ -80,11 +80,9 @@ abstract class TenantSessionStore extends Service {
 ```
 
 There is deliberately no release/reassign API in the 0.1 contract. Ownership is
-immutable. `InMemoryTenantSessionStore` is the reference provider and is intended
-for tests/bootstrap, not production durability.
-
-Third-party providers should run the shared contract suite exported from
-`dsh-multi-tenant/testing`.
+immutable. `InMemoryTenantSessionStore` is the reference provider for
+tests/bootstrap, not production durability. Third-party providers should run the
+shared contract suite exported from `dsh-multi-tenant/testing`.
 
 ### `MultiTenantService` (`ctx.multiTenant`)
 
@@ -93,7 +91,7 @@ Third-party providers should run the shared contract suite exported from
 | `claimSession(sessionId, principal)` | Unclaimed → create; same owner → idempotent; other owner → conflict. |
 | `getSessionOwner(sessionId)` | Trusted-facing owner lookup. |
 | `canAccessSession(principal, sessionId)` | Fail-closed boolean authorization. |
-| `assertSessionAccess(principal, sessionId)` | Same policy, throwing a uniform `SessionAccessDeniedError` on denial. |
+| `assertSessionAccess(principal, sessionId)` | Same policy, throwing uniform `SessionAccessDeniedError` on denial. |
 
 Authorization is exact-match and opaque: the kernel never parses tenant identity
 from a session id and never authorizes by prefix.
@@ -106,21 +104,18 @@ user identity is never included in the public error.
 
 ## Install / composition
 
-The first npm prerelease is published on the **`next`** dist-tag, not `latest`.
-After R3 publishes it, install into a DSH profile with:
+Prereleases are published on the **`next`** dist-tag, not `latest`:
 
 ```sh
 dsh plugin --profile <profile> add dsh-multi-tenant@next
 ```
 
-The package declares `dsh.bundle`; DSH therefore adds its bundle layer to the
-profile. The bundled layer mounts the in-memory `tenantSessionStore` reference
-and the `multiTenant` service. A deployment that needs durability should replace
-the store provider rather than modify the kernel.
+The package declares `dsh.bundle`; DSH adds its bundle layer to the profile. The
+bundled layer mounts the in-memory `tenantSessionStore` reference and
+`multiTenant`. Deployments needing durability replace the store provider rather
+than modify the kernel.
 
 ## Release verification
-
-From the repository root:
 
 ```sh
 pnpm install --frozen-lockfile
@@ -128,9 +123,9 @@ pnpm release:check
 ```
 
 `release:check` covers package/architecture invariants, release-manifest
-preflight, typecheck, unit/contract tests, build, a packed external-consumer
-smoke test, and the RC7 DSH runtime proofs. See
-[`docs/reference/release.md`](../../docs/reference/release.md).
+preflight, typecheck, unit/contract tests, build, packed external-consumer smoke,
+and the RC7 DSH runtime proofs. Publication uses npm Trusted Publishing/OIDC;
+see [`docs/reference/release.md`](../../docs/reference/release.md).
 
 Production Web principal binding, durable providers, auth providers, search,
 MCP, audit, and deployment recipes are independent follow-ups. See

--- a/packages/multi-tenant/README.zh-CN.md
+++ b/packages/multi-tenant/README.zh-CN.md
@@ -2,9 +2,9 @@
 
 # dsh-multi-tenant
 
-面向 DeepSeek Harness（DSH）的多租户 kernel 原语：tenant identity、不可变 session ownership、fail-closed authorization，以及可替换的 ownership-store contract。
+面向 DeepSeek Harness（DSH）的多租户 kernel 原语：最小 tenant/user identity、不可变 session ownership、fail-closed authorization，以及可替换的 ownership-store contract。
 
-> **Release candidate：`0.1.0-rc.1`。** 这个 package 刻意保持小而明确。它是第一次 0.1 版本线中**唯一可发布的 artifact**；Web/auth/MCP/runtime isolation 属于独立 integration 或生态问题。当前 DSH compatibility target 为 `0.1.0-rc.7`。
+> **Release candidate：`0.1.0-rc.2`。** 这个 kernel 刻意保持小而明确。它仍是 0.1 版本线中**唯一可发布的 artifact**；Web/auth/MCP/runtime isolation 属于 integration、ecosystem 或 deployment concern。当前 DSH compatibility target 为 `0.1.0-rc.7`。
 
 ## 支持的保证
 
@@ -12,13 +12,13 @@
 
 它提供两个 Cordis service：
 
-- `ctx.tenantSessionStore` —— 可替换 ownership storage seam；
+- `ctx.tenantSessionStore` —— 可替换 ownership storage；
 - `ctx.multiTenant` —— claim-once ownership 与 authorization。
 
 Kernel 保证：
 
 - **claim-once、不可变 ownership**；
-- **无条件 tenant boundary** —— 任何 role 都不能跨 tenant；
+- **无条件 tenant boundary** —— cross-tenant access 永远拒绝；
 - **v0.1 同用户 ownership** —— 同 tenant、不同 user 仍拒绝；
 - **fail-closed authorization** —— unknown / foreign session 都拒绝；
 - **不可枚举的公开 denial** —— 不暴露 unknown 与 foreign 的区别；
@@ -37,7 +37,9 @@ Kernel 保证：
 - billing、UI、组织/用户管理或通用 RBAC framework；
 - team sharing / ACL / reassignment model。
 
-这些东西并不都是“未来 kernel feature”。项目规则是：**控制得住 → 严格强制；需要生态协作 → 制定标准；控制不住 → 明确边界。**
+`TenantPrincipal` **刻意不包含 roles、permissions、admin flag 等 policy attribute**。未来如果真的需要同租户 sharing 或 RBAC，应进入独立 policy plane，而不是重新污染 ownership kernel。
+
+项目规则：**控制得住 → 严格强制；需要生态协作 → 制定标准；控制不住 → 明确边界。**
 
 ## Core API
 
@@ -47,7 +49,6 @@ Kernel 保证：
 interface TenantPrincipal {
   tenantId: string
   userId: string
-  roles: readonly string[]
 }
 
 interface SessionOwner {
@@ -58,8 +59,6 @@ interface SessionOwner {
 
 ### `TenantSessionStore`（`ctx.tenantSessionStore`）
 
-Storage seam 是一个 Cordis `Service`。`claim` 是一个原子的 contract 操作，使 durable provider 可以映射到自身的 conditional-write primitive。
-
 ```ts
 type ClaimResult = 'created' | 'idempotent' | 'conflict'
 
@@ -69,9 +68,7 @@ abstract class TenantSessionStore extends Service {
 }
 ```
 
-0.1 contract 中刻意没有 release/reassign API。Ownership 不可变。`InMemoryTenantSessionStore` 是参考 provider，只用于测试/bootstrap，不提供 production durability。
-
-第三方 provider 应运行 `dsh-multi-tenant/testing` 导出的共享 contract suite。
+0.1 contract 中刻意没有 release/reassign API。Ownership 不可变。`InMemoryTenantSessionStore` 是测试/bootstrap 参考 provider，不提供 production durability。第三方 provider 应运行 `dsh-multi-tenant/testing` 导出的共享 contract suite。
 
 ### `MultiTenantService`（`ctx.multiTenant`）
 
@@ -90,24 +87,22 @@ abstract class TenantSessionStore extends Service {
 
 ## 安装 / 组合
 
-第一次 npm prerelease 使用 **`next`** dist-tag，而不是 `latest`。R3 发布以后，可安装到 DSH profile：
+Prerelease 使用 **`next`** dist-tag，而不是 `latest`：
 
 ```sh
 dsh plugin --profile <profile> add dsh-multi-tenant@next
 ```
 
-Package 声明了 `dsh.bundle`，因此 DSH 会把它的 bundle layer 加入 profile。内置 layer 会挂载内存 `tenantSessionStore` 参考实现与 `multiTenant` service。需要 durability 的 deployment 应替换 store provider，而不是修改 kernel。
+Package 声明了 `dsh.bundle`，DSH 会把它的 bundle layer 加入 profile。内置 layer 会挂载内存 `tenantSessionStore` 参考实现与 `multiTenant`。需要 durability 的 deployment 应替换 store provider，而不是修改 kernel。
 
 ## 发布验证
-
-在仓库根目录执行：
 
 ```sh
 pnpm install --frozen-lockfile
 pnpm release:check
 ```
 
-`release:check` 覆盖 package/architecture invariant、release-manifest preflight、typecheck、unit/contract test、build、真实 packed external-consumer smoke，以及 RC7 DSH runtime proof。详细见 [`docs/reference/release.zh-CN.md`](../../docs/reference/release.zh-CN.md)。
+`release:check` 覆盖 package/architecture invariant、release-manifest preflight、typecheck、unit/contract test、build、packed external-consumer smoke，以及 RC7 DSH runtime proof。发布使用 npm Trusted Publishing/OIDC；详见 [`docs/reference/release.zh-CN.md`](../../docs/reference/release.zh-CN.md)。
 
 Production Web principal binding、durable provider、auth provider、search、MCP、audit 与 deployment recipe 都是独立 follow-up。参见 [`ROADMAP.md`](../../ROADMAP.md)。
 

--- a/packages/multi-tenant/demo/fixture.ts
+++ b/packages/multi-tenant/demo/fixture.ts
@@ -6,8 +6,8 @@ export let completed: Promise<void> = Promise.resolve()
 
 export function apply(ctx: Context): void {
   completed = (async () => {
-    const alice = { tenantId: 'acme', userId: 'alice', roles: ['member'] }
-    const eve = { tenantId: 'evilcorp', userId: 'alice', roles: ['member'] }
+    const alice = { tenantId: 'acme', userId: 'alice' }
+    const eve = { tenantId: 'evilcorp', userId: 'alice' }
 
     await ctx.multiTenant.claimSession('s1', alice)
     const owner = await ctx.multiTenant.getSessionOwner('s1')

--- a/packages/multi-tenant/package.json
+++ b/packages/multi-tenant/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-multi-tenant",
-  "version": "0.1.0-rc.1",
+  "version": "0.1.0-rc.2",
   "description": "Multi-tenant primitives for DeepSeek Harness (DSH): tenant identity, immutable session ownership, fail-closed authorization, and a replaceable ownership-store contract.",
   "author": "DeepSeek Harness community contributors",
   "license": "MIT",

--- a/packages/multi-tenant/src/index.ts
+++ b/packages/multi-tenant/src/index.ts
@@ -1,20 +1,18 @@
 /**
- * dsh-multi-tenant — Multi-tenant SaaS extension for DeepSeek Harness (DSH).
+ * dsh-multi-tenant — Multi-tenant kernel primitives for DeepSeek Harness (DSH).
  *
  * Exposes two Cordis services:
- *   - `ctx.tenantSessionStore` — the ownership-storage seam (abstract), with
- *     the in-memory backend as the default provider.
- *   - `ctx.multiTenant` — the session-ownership + authorization service.
+ *   - `ctx.tenantSessionStore` — the replaceable ownership-storage seam.
+ *   - `ctx.multiTenant` — claim-once session ownership and authorization.
  *
- * Public surface is deliberately small. Internal diagnostic types
- * (access-denial reasons, decisions) are not re-exported.
+ * Public surface is deliberately small. Policy/RBAC concerns are not part of
+ * this kernel contract.
  *
  * @module dsh-multi-tenant
  */
 
 import { MultiTenantService } from './service.ts'
 
-// Augment the Cordis context so consumers can type `ctx.multiTenant`.
 declare module '@deepseek-ai/cordis' {
   interface Context {
     multiTenant: MultiTenantService

--- a/packages/multi-tenant/src/service.ts
+++ b/packages/multi-tenant/src/service.ts
@@ -6,9 +6,9 @@
  * durable-store-compatible ownership contract.
  *
  * The service is storage-agnostic: it consumes the `tenantSessionStore` service
- * seam (a separate Cordis Service provider) and never constructs or inspects a
- * backend itself. Ownership is claim-once and immutable; the tenant boundary is
- * unconditional and checked before any other consideration.
+ * seam and never constructs or inspects a backend itself. Ownership is
+ * claim-once and immutable; the tenant boundary is unconditional and checked
+ * before the same-user ownership rule.
  *
  * @module dsh-multi-tenant/service
  */
@@ -20,7 +20,6 @@ import { validateSessionId, validateTenantPrincipal } from './validation.ts'
 import type { AccessDecision, SessionOwner, TenantPrincipal } from './types.ts'
 
 export class MultiTenantService extends Service {
-  /** The ownership backend is provided by a separate Cordis service. */
   static inject = ['tenantSessionStore']
 
   constructor(ctx: Context) {
@@ -31,18 +30,6 @@ export class MultiTenantService extends Service {
     return this.ctx.tenantSessionStore
   }
 
-  /**
-   * Claim ownership of `sessionId` for `principal`, exactly once.
-   *
-   * - Unclaimed → establishes ownership and succeeds.
-   * - Already claimed by the same tenant/user → idempotent success.
-   * - Already claimed by a different tenant/user → {@link SessionOwnershipConflictError};
-   *   the existing owner is never overwritten.
-   *
-   * There is deliberately no reassignment or release API: ownership is
-   * immutable, and lifecycle cleanup belongs to a future Admin/Session-lifecycle
-   * plane, not this core.
-   */
   async claimSession(sessionId: string, principal: TenantPrincipal): Promise<void> {
     validateSessionId(sessionId)
     validateTenantPrincipal(principal)
@@ -55,18 +42,11 @@ export class MultiTenantService extends Service {
       case 'conflict':
         throw new SessionOwnershipConflictError()
       default:
-        // Fail closed: a store result outside the ClaimResult contract must
-        // never be treated as a successful claim.
         throw new MultiTenantError('tenant session store returned an invalid claim result')
     }
   }
 
-  /**
-   * Return the recorded owner, or `undefined` if unknown.
-   *
-   * This is a trusted-facing lookup (server components, audit, tests) and is
-   * NOT a non-enumerating surface; the authorization methods are.
-   */
+  /** Trusted-facing owner lookup. */
   async getSessionOwner(sessionId: string): Promise<SessionOwner | undefined> {
     validateSessionId(sessionId)
     return this.store.get(sessionId)
@@ -77,35 +57,21 @@ export class MultiTenantService extends Service {
     return (await this.evaluateAccess(principal, sessionId)).allowed
   }
 
-  /**
-   * Authorization that throws on denial. The thrown {@link SessionAccessDeniedError}
-   * is uniform: it does not distinguish an unknown session from a foreign one,
-   * and it never carries owner tenant/user identity.
-   */
+  /** Throw a uniform, non-enumerating denial when access is not allowed. */
   async assertSessionAccess(principal: TenantPrincipal, sessionId: string): Promise<void> {
     const decision = await this.evaluateAccess(principal, sessionId)
-    if (!decision.allowed) {
-      throw new SessionAccessDeniedError()
-    }
+    if (!decision.allowed) throw new SessionAccessDeniedError()
   }
 
-  /**
-   * Internal authorization decision with a diagnostic reason.
-   *
-   * `protected` so tests, future audit, and observability can inspect the
-   * reason. The PUBLIC API (`canAccessSession` / `assertSessionAccess`) never
-   * exposes it — the reason is diagnostic, not a transport value.
-   */
+  /** Internal diagnostic decision; denial reasons never cross the public API. */
   protected async evaluateAccess(principal: TenantPrincipal, sessionId: string): Promise<AccessDecision> {
     validateSessionId(sessionId)
     validateTenantPrincipal(principal)
     const owner = await this.store.get(sessionId)
-    if (!owner) {
-      return { allowed: false, reason: 'UNKNOWN_SESSION' }
-    }
-    // The tenant boundary is unconditional and checked first: no role, present
-    // or future, may cross it. Cross-tenant inspection is a separate Admin /
-    // Audit Plane concern, not `canAccessSession`.
+    if (!owner) return { allowed: false, reason: 'UNKNOWN_SESSION' }
+
+    // Cross-tenant access is unconditionally denied. Policy attributes outside
+    // this minimal ownership kernel cannot override this boundary.
     if (owner.tenantId !== principal.tenantId) {
       return { allowed: false, reason: 'TENANT_MISMATCH' }
     }

--- a/packages/multi-tenant/src/types.ts
+++ b/packages/multi-tenant/src/types.ts
@@ -10,30 +10,23 @@
  */
 
 /**
- * An authenticated caller identity, established by a server-side boundary.
+ * The minimal authenticated identity required by the ownership kernel.
  *
- * A `TenantPrincipal` is never assembled from client-supplied fields: the
- * authenticated transport derives it (verified session token, authenticated
- * API key, …) and hands it to this core. The core trusts the principal it is
- * given but never trusts a tenant id that arrives out-of-band.
+ * A `TenantPrincipal` is established by a server-side authentication boundary;
+ * it is never assembled from client-supplied tenant fields. Roles, permissions,
+ * admin flags, and other policy attributes are deliberately NOT part of this
+ * contract. If the ecosystem later needs same-tenant sharing or RBAC, that
+ * belongs to a separate policy plane rather than the ownership identity.
  */
 export interface TenantPrincipal {
   /** Opaque tenant identifier. Never parsed out of a session id. */
   tenantId: string
   /** User identifier, unique within the tenant. */
   userId: string
-  /**
-   * Roles the user holds within the tenant. Present for future authorization
-   * layers; the v0 core does NOT consult roles for access — ownership only.
-   */
-  roles: readonly string[]
 }
 
 /**
  * The recorded owner of a session — the minimal authorization binding.
- *
- * Deliberately smaller than `TenantPrincipal`: roles are an attribute of the
- * *caller* at request time, not a property pinned to the session.
  */
 export interface SessionOwner {
   tenantId: string
@@ -64,10 +57,7 @@ export type AccessDenialReason =
   | 'TENANT_MISMATCH'
   | 'USER_MISMATCH'
 
-/**
- * Internal authorization decision, as a discriminated union: an allowed
- * decision carries no reason, and a denial always carries one.
- */
+/** Internal authorization decision. */
 export type AccessDecision =
   | { allowed: true }
   | { allowed: false; reason: AccessDenialReason }

--- a/packages/multi-tenant/src/validation.ts
+++ b/packages/multi-tenant/src/validation.ts
@@ -13,8 +13,6 @@ import { ValidationError } from './errors.ts'
 import type { TenantPrincipal } from './types.ts'
 
 export const MAX_IDENTIFIER_LENGTH = 256
-export const MAX_ROLE_COUNT = 32
-export const MAX_ROLE_LENGTH = 64
 
 /** An opaque identifier must be a non-empty, trimmed string of bounded length. */
 function requireOpaqueId(value: unknown, label: string): void {
@@ -37,7 +35,7 @@ export function validateSessionId(sessionId: unknown): void {
   requireOpaqueId(sessionId, 'sessionId')
 }
 
-/** Reject a malformed principal (empty/whitespace/over-long identity, bad roles). */
+/** Reject a malformed minimal ownership principal. Extra policy fields are ignored. */
 export function validateTenantPrincipal(principal: unknown): void {
   if (typeof principal !== 'object' || principal === null) {
     throw new ValidationError('principal must be an object')
@@ -45,19 +43,4 @@ export function validateTenantPrincipal(principal: unknown): void {
   const p = principal as TenantPrincipal
   requireOpaqueId(p.tenantId, 'tenantId')
   requireOpaqueId(p.userId, 'userId')
-
-  if (!Array.isArray(p.roles)) {
-    throw new ValidationError('roles must be an array')
-  }
-  if (p.roles.length > MAX_ROLE_COUNT) {
-    throw new ValidationError(`roles exceeds ${MAX_ROLE_COUNT} entries`)
-  }
-  for (const role of p.roles) {
-    if (typeof role !== 'string' || role.length === 0 || role !== role.trim()) {
-      throw new ValidationError('roles must contain only non-empty strings without surrounding whitespace')
-    }
-    if (role.length > MAX_ROLE_LENGTH) {
-      throw new ValidationError(`a role exceeds ${MAX_ROLE_LENGTH} characters`)
-    }
-  }
 }

--- a/packages/multi-tenant/tests/multi-tenant.test.ts
+++ b/packages/multi-tenant/tests/multi-tenant.test.ts
@@ -11,11 +11,9 @@ import {
 } from '../src/index.ts'
 import type { AccessDecision, ClaimResult, SessionOwner, TenantPrincipal } from '../src/types.ts'
 
-const alice: TenantPrincipal = { tenantId: 'acme', userId: 'alice', roles: ['member'] }
-const bob: TenantPrincipal = { tenantId: 'acme', userId: 'bob', roles: ['member'] }
-const eve: TenantPrincipal = { tenantId: 'evilcorp', userId: 'alice', roles: ['member'] }
-const acmeAdmin: TenantPrincipal = { tenantId: 'acme', userId: 'root', roles: ['tenant-admin'] }
-const foreignAdmin: TenantPrincipal = { tenantId: 'evilcorp', userId: 'root', roles: ['tenant-admin', 'platform-admin'] }
+const alice: TenantPrincipal = { tenantId: 'acme', userId: 'alice' }
+const bob: TenantPrincipal = { tenantId: 'acme', userId: 'bob' }
+const eve: TenantPrincipal = { tenantId: 'evilcorp', userId: 'alice' }
 
 describe('MultiTenantService', () => {
   let ctx: Context
@@ -97,10 +95,10 @@ describe('MultiTenantService', () => {
       await expect(multiTenant.assertSessionAccess(alice, 'missing')).rejects.toThrow(SessionAccessDeniedError)
     })
 
-    it('does not let any role cross the tenant boundary', async () => {
+    it('does not let out-of-contract policy hints override the tenant boundary', async () => {
       await multiTenant.claimSession('s1', alice)
-      await expect(multiTenant.canAccessSession(foreignAdmin, 's1')).resolves.toBe(false)
-      await expect(multiTenant.canAccessSession(acmeAdmin, 's1')).resolves.toBe(false)
+      const foreignWithPolicyHint = { tenantId: 'evilcorp', userId: 'root', admin: true }
+      await expect(multiTenant.canAccessSession(foreignWithPolicyHint, 's1')).resolves.toBe(false)
     })
 
     it('surfaces a uniform error for unknown vs foreign sessions', async () => {
@@ -141,16 +139,9 @@ describe('MultiTenantService', () => {
     it('rejects an empty userId', async () => {
       await expect(multiTenant.claimSession('s1', { ...alice, userId: '' })).rejects.toThrow(ValidationError)
     })
-
-    it('rejects an invalid role entry', async () => {
-      await expect(
-        multiTenant.claimSession('s1', { ...alice, roles: ['member', ''] }),
-      ).rejects.toThrow(ValidationError)
-    })
   })
 })
 
-/** A test subclass that exposes the internal denial reason for assertions. */
 class InspectableMultiTenantService extends MultiTenantService {
   async reason(principal: TenantPrincipal, sessionId: string): Promise<AccessDecision> {
     return this.evaluateAccess(principal, sessionId)

--- a/scripts/package-smoke.mjs
+++ b/scripts/package-smoke.mjs
@@ -1,11 +1,8 @@
 #!/usr/bin/env node
 /**
- * Package smoke (M1.3): prove the kernel's published tarball is a valid
- * distributable for an external consumer. Build → pack → verify tarball
- * contents and every `exports` target → install the tarball into a clean
- * temp consumer → import the published subpaths and run a claim/access smoke.
- *
- * Run from the repo root: `node scripts/package-smoke.mjs`.
+ * Package smoke: prove the kernel's packed tarball is a valid distributable for
+ * an external consumer. Build → pack → verify tarball contents/exports → install
+ * into a clean temp consumer → exercise the public kernel subpaths.
  */
 import { execFileSync } from 'node:child_process'
 import { mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs'
@@ -17,7 +14,6 @@ const root = fileURLToPath(new URL('..', import.meta.url))
 const pkgDir = join(root, 'packages', 'multi-tenant')
 const pkg = JSON.parse(readFileSync(join(pkgDir, 'package.json'), 'utf8'))
 
-/** Recursively collect every file-path string leaf under an `exports` map. */
 function collectTargets(exports, acc = []) {
   if (typeof exports === 'string') {
     acc.push(exports)
@@ -32,7 +28,6 @@ function collectTargets(exports, acc = []) {
 const tmp = mkdtempSync(join(tmpdir(), 'dsh-mt-pack-'))
 const consumer = mkdtempSync(join(tmpdir(), 'dsh-mt-consumer-'))
 try {
-  // 1. fresh build, then pack.
   execFileSync('pnpm', ['--filter', 'dsh-multi-tenant', 'build'], { cwd: root, stdio: 'ignore' })
   execFileSync('pnpm', ['--filter', 'dsh-multi-tenant', 'pack', '--pack-destination', tmp], {
     cwd: root,
@@ -41,7 +36,6 @@ try {
   const tarball = readdirSync(tmp).find(f => f.endsWith('.tgz'))
   if (!tarball) throw new Error('pnpm pack produced no tarball')
 
-  // 2. verify the tarball ships the intended files and every exports target.
   const listing = execFileSync('tar', ['-tzf', join(tmp, tarball)], { encoding: 'utf8' })
   const lines = listing.split('\n')
   const has = f => lines.some(line => line === f || line.endsWith(`/${f}`))
@@ -54,7 +48,6 @@ try {
   const unresolved = targets.filter(t => !has(t.replace(/^\.\//, '')))
   if (unresolved.length) throw new Error(`exports targets missing from tarball: ${unresolved.join(', ')}`)
 
-  // 3. install the tarball into a clean consumer and exercise the published subpaths.
   writeFileSync(join(consumer, 'package.json'), JSON.stringify({ name: 'smoke-consumer', private: true, type: 'module' }))
   execFileSync('pnpm', ['add', join(tmp, tarball), '@deepseek-ai/cordis@4.0.1'], { cwd: consumer, stdio: 'ignore' })
   writeFileSync(join(consumer, 'smoke.mjs'), [
@@ -65,7 +58,7 @@ try {
     'const ctx = new Context();',
     'await ctx.plugin(Store);',
     'await ctx.plugin(Service);',
-    'const alice = { tenantId: "acme", userId: "alice", roles: ["member"] };',
+    'const alice = { tenantId: "acme", userId: "alice" };',
     'await ctx.multiTenant.claimSession("s1", alice);',
     'if ((await ctx.multiTenant.canAccessSession(alice, "s1")) !== true) throw new Error("smoke: same-user should be allowed");',
     'await assertTenantSessionStoreContract(async (c) => { await c.plugin(Store); return c.tenantSessionStore });',

--- a/scripts/registry-smoke.mjs
+++ b/scripts/registry-smoke.mjs
@@ -1,11 +1,5 @@
 #!/usr/bin/env node
-/**
- * Post-publication registry smoke.
- *
- * Verifies the exact version and `next` dist-tag from npm, installs the registry
- * artifact into a clean consumer, imports every public kernel subpath used by
- * consumers, and exercises claim/access plus the shared store contract.
- */
+/** Post-publication registry smoke for the exact kernel prerelease. */
 import { execFileSync } from 'node:child_process'
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
@@ -48,9 +42,7 @@ for (let attempt = 1; attempt <= 10; attempt++) {
   await new Promise((resolve) => setTimeout(resolve, 3000))
 }
 
-if (registryVersion !== version) {
-  throw new Error(`registry did not resolve ${PACKAGE_NAME}@${version}`)
-}
+if (registryVersion !== version) throw new Error(`registry did not resolve ${PACKAGE_NAME}@${version}`)
 
 const nextVersion = npmJson(['view', `${PACKAGE_NAME}@next`, 'version'])
 if (nextVersion !== version) {
@@ -67,34 +59,26 @@ if (!integrity) throw new Error('registry artifact is missing dist.integrity')
 
 const consumer = mkdtempSync(join(tmpdir(), 'dsh-mt-registry-consumer-'))
 try {
-  writeFileSync(
-    join(consumer, 'package.json'),
-    JSON.stringify({ name: 'registry-smoke-consumer', private: true, type: 'module' }),
-  )
+  writeFileSync(join(consumer, 'package.json'), JSON.stringify({ name: 'registry-smoke-consumer', private: true, type: 'module' }))
+  execFileSync('pnpm', ['add', `${PACKAGE_NAME}@${version}`, '@deepseek-ai/cordis@4.0.1'], {
+    cwd: consumer,
+    stdio: 'ignore',
+  })
 
-  execFileSync(
-    'pnpm',
-    ['add', `${PACKAGE_NAME}@${version}`, '@deepseek-ai/cordis@4.0.1'],
-    { cwd: consumer, stdio: 'ignore' },
-  )
-
-  writeFileSync(
-    join(consumer, 'smoke.mjs'),
-    [
-      'import { Context } from "@deepseek-ai/cordis";',
-      'import Store from "dsh-multi-tenant/store";',
-      'import Service from "dsh-multi-tenant";',
-      'import { assertTenantSessionStoreContract } from "dsh-multi-tenant/testing";',
-      'const ctx = new Context();',
-      'await ctx.plugin(Store);',
-      'await ctx.plugin(Service);',
-      'const alice = { tenantId: "acme", userId: "alice", roles: ["member"] };',
-      'await ctx.multiTenant.claimSession("registry-s1", alice);',
-      'if ((await ctx.multiTenant.canAccessSession(alice, "registry-s1")) !== true) throw new Error("registry smoke: owner access denied");',
-      'await assertTenantSessionStoreContract(async (c) => { await c.plugin(Store); return c.tenantSessionStore });',
-      'console.log("registry consumer smoke passed");',
-    ].join('\n'),
-  )
+  writeFileSync(join(consumer, 'smoke.mjs'), [
+    'import { Context } from "@deepseek-ai/cordis";',
+    'import Store from "dsh-multi-tenant/store";',
+    'import Service from "dsh-multi-tenant";',
+    'import { assertTenantSessionStoreContract } from "dsh-multi-tenant/testing";',
+    'const ctx = new Context();',
+    'await ctx.plugin(Store);',
+    'await ctx.plugin(Service);',
+    'const alice = { tenantId: "acme", userId: "alice" };',
+    'await ctx.multiTenant.claimSession("registry-s1", alice);',
+    'if ((await ctx.multiTenant.canAccessSession(alice, "registry-s1")) !== true) throw new Error("registry smoke: owner access denied");',
+    'await assertTenantSessionStoreContract(async (c) => { await c.plugin(Store); return c.tenantSessionStore });',
+    'console.log("registry consumer smoke passed");',
+  ].join('\n'))
 
   execFileSync('node', ['smoke.mjs'], {
     cwd: consumer,
@@ -105,6 +89,4 @@ try {
   rmSync(consumer, { recursive: true, force: true })
 }
 
-console.log(
-  `registry smoke passed: ${PACKAGE_NAME}@${version}; next=${version}; integrity=${integrity.slice(0, 20)}…`,
-)
+console.log(`registry smoke passed: ${PACKAGE_NAME}@${version}; next=${version}; integrity=${integrity.slice(0, 20)}…`)

--- a/scripts/release-preflight.mjs
+++ b/scripts/release-preflight.mjs
@@ -1,10 +1,8 @@
 #!/usr/bin/env node
 /**
- * Release-manifest preflight for the first kernel prerelease.
- *
+ * Release-manifest preflight for the current kernel prerelease.
  * Runtime/API behavior is covered by verify/test/smoke/probe:dsh; this script
- * prevents packaging/publication mistakes and keeps the R3 release contract
- * executable.
+ * prevents packaging/publication drift.
  */
 import { existsSync, readFileSync, readdirSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
@@ -13,7 +11,7 @@ import { join } from 'node:path'
 const root = fileURLToPath(new URL('..', import.meta.url))
 const packagesDir = join(root, 'packages')
 const expectedKernelName = 'dsh-multi-tenant'
-const expectedKernelVersion = '0.1.0-rc.1'
+const expectedKernelVersion = '0.1.0-rc.2'
 const expectedTag = 'next'
 const expectedRepository = 'git+https://github.com/GuoMonth/dsh-multi-tenant.git'
 const errors = []
@@ -65,9 +63,18 @@ const web = packages.find(({ pkg }) => pkg.name === 'dsh-multi-tenant-web')
 if (!web) errors.push('dsh-multi-tenant-web: package not found')
 else if (web.pkg.private !== true) errors.push('dsh-multi-tenant-web: must stay private until its production contract is ready')
 
+const releaseWorkflowPath = join(root, '.github/workflows/release.yml')
+if (!existsSync(releaseWorkflowPath)) {
+  errors.push('release artifact missing: .github/workflows/release.yml')
+} else {
+  const workflow = readFileSync(releaseWorkflowPath, 'utf8')
+  if (!workflow.includes('id-token: write')) errors.push('release workflow must grant id-token: write for npm OIDC')
+  if (!workflow.includes('environment: npm-release')) errors.push('release workflow must use the npm-release environment')
+  if (workflow.includes('NPM_BOOTSTRAP_TOKEN')) errors.push('release workflow must be OIDC-only; bootstrap token fallback is not allowed')
+}
+
 for (const requiredPath of [
-  '.github/workflows/release.yml',
-  'docs/releases/v0.1.0-rc.1.md',
+  'docs/releases/v0.1.0-rc.2.md',
   'scripts/registry-preflight.mjs',
   'scripts/registry-smoke.mjs',
 ]) {
@@ -79,4 +86,4 @@ if (errors.length) {
   process.exit(1)
 }
 
-console.log(`release preflight passed: ${expectedKernelName}@${expectedKernelVersion} -> dist-tag ${expectedTag}, provenance enabled; experimental Web package is private`)
+console.log(`release preflight passed: ${expectedKernelName}@${expectedKernelVersion} -> ${expectedTag}; OIDC-only publishing; experimental Web package is private`)


### PR DESCRIPTION
## Summary

Prepare `dsh-multi-tenant@0.1.0-rc.2` as the final planned API-convergence candidate before deciding on `0.1.0` stable.

This PR is intentionally subtractive. It adds no new multi-tenant capability. The final diff is one commit and is net-negative in lines: it removes speculative API/validation and collapses the pre-release roadmap around facts that are already complete.

## Principal contract subtraction

`TenantPrincipal` is reduced from:

```ts
{ tenantId, userId, roles }
```

to:

```ts
{ tenantId, userId }
```

The kernel never consumed `roles`; it only validated and carried them. Keeping a required RBAC-shaped field would force every integration to adopt policy vocabulary that this ownership kernel explicitly does not own.

Accordingly this PR:

- removes `roles` from the public `TenantPrincipal` type;
- removes role-count/role-length validation and the associated validation tests;
- updates fixtures, Web tests, packed consumer smoke, and registry smoke to use the minimal principal;
- adds an adversarial test showing an out-of-contract policy hint cannot override the cross-tenant boundary;
- documents that roles/permissions/admin policy belong to a separate policy plane if a real future use case requires them.

This is a prerelease API subtraction: rc.1 callers that supplied `roles` only to satisfy the type should simply omit it. Code that actually reads `principal.roles` must move that policy outside the ownership kernel.

## Release convergence

- bump kernel candidate to `0.1.0-rc.2`;
- add `docs/releases/v0.1.0-rc.2.md`;
- update release preflight to the rc.2 artifact;
- remove the `NPM_BOOTSTRAP_TOKEN` fallback from `release.yml`;
- make the release gate fail if a bootstrap-token reference returns;
- keep `id-token: write`, `npm-release` Environment, provenance, registry preflight/smoke, and tag/GitHub prerelease recovery.

The release workflow is now OIDC-only through npm Trusted Publishing. This matches npm's current GitHub Actions trusted-publishing model: short-lived OIDC credentials with `id-token: write`, no long-lived publish token.

## Roadmap/doc convergence

The Roadmap is shortened around current facts instead of preserving a long pre-release checklist:

- R1 ✅ RC7 compatibility refresh
- R2 ✅ kernel release hardening
- R3 ✅ `0.1.0-rc.1` published with provenance + registry smoke + Git tag/GitHub prerelease
- rc.2 🚧 final planned API subtraction
- next decision after rc.2: real feedback/bug/upstream change, otherwise consider `0.1.0` stable

The ecosystem track remains independent: DSH principal-scope seam → production Web enforcement; durable stores/auth/search/MCP remain demand-gated; process/container isolation and general RBAC remain explicit boundaries.

## Deliberately not in this PR

- no durable store implementation;
- no auth/JWT/OIDC provider;
- no Web/H3 transport implementation;
- no MCP/audit feature;
- no team ACL/sharing/reassignment;
- no sandbox/process/container isolation;
- no new package.

## Validation — green on final head

GitHub Actions run `32226220345` completed successfully with all four lanes green:

- ✅ quality / Node 22.19.0 — frozen install, architecture verify, **rc.2 release preflight**, typecheck, tests, build, packed external-consumer smoke
- ✅ quality / Node 24 — same full gate chain
- ✅ DSH RC compatibility / Node 22.19.0 — real RC7 runtime proofs
- ✅ DSH RC compatibility / Node 24 — real RC7 runtime proofs

The release preflight specifically proves that `release.yml` grants `id-token: write`, uses the `npm-release` Environment, and contains no `NPM_BOOTSTRAP_TOKEN` fallback. The packed smoke proves the real rc.2 tarball can be installed and exercised by a clean consumer using the minimal `{ tenantId, userId }` principal.

After merge, publish `0.1.0-rc.2` through the existing manual release workflow. That publication will be the first end-to-end proof of the configured npm Trusted Publisher with no npm publish token present.