### PR TITLE
fix: unblock npm trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           version: 11.7.0
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: 24.x
           registry-url: https://registry.npmjs.org

--- a/scripts/release-preflight.mjs
+++ b/scripts/release-preflight.mjs
@@ -70,6 +70,7 @@ if (!existsSync(releaseWorkflowPath)) {
   const workflow = readFileSync(releaseWorkflowPath, 'utf8')
   if (!workflow.includes('id-token: write')) errors.push('release workflow must grant id-token: write for npm OIDC')
   if (!workflow.includes('environment: npm-release')) errors.push('release workflow must use the npm-release environment')
+  if (!workflow.includes('actions/setup-node@v7')) errors.push('release workflow must use actions/setup-node@v7 so npm OIDC is not shadowed by the v6 dummy auth token')
   if (workflow.includes('NPM_BOOTSTRAP_TOKEN')) errors.push('release workflow must be OIDC-only; bootstrap token fallback is not allowed')
 }
 


### PR DESCRIPTION
## Summary

Fix the rc.2 OIDC publication failure from Actions run `32227245328`.

The release artifact itself is healthy: invocation validation, frozen install, full `release:check`, and registry ownership/version preflight all passed. The failure occurred only at `npm publish`.

## Root cause

`release.yml` used `actions/setup-node@v6` with `registry-url`. In the failed run, the publish step environment contained the v6 dummy `NODE_AUTH_TOKEN=XXXXX-XXXXX-XXXXX-XXXXX` and the generated npm config carried token-auth state. npm therefore did not complete the Trusted Publisher OIDC path and returned the misleading:

```text
E404 Not Found - PUT https://registry.npmjs.org/dsh-multi-tenant
```

This matches the known `setup-node` Trusted Publishing interaction. `actions/setup-node@v7` removed the dummy `NODE_AUTH_TOKEN` fallback specifically because it could interfere with generated npm auth configuration.

## Changes

- upgrade **only the release workflow** from `actions/setup-node@v6` to `@v7`;
- extend `release:preflight` to require `actions/setup-node@v7` for the OIDC-only release path;
- keep all other release behavior unchanged: `id-token: write`, `npm-release` Environment, no bootstrap token, provenance, registry smoke, tag, and GitHub prerelease.

No kernel/API/package behavior changes.

## Validation — green

GitHub Actions run `32227461566` completed successfully with all four lanes green:

- ✅ quality / Node 22.19.0 — frozen install, architecture verify, rc.2 release preflight, typecheck, tests, build, packed consumer smoke
- ✅ quality / Node 24 — same full gate chain
- ✅ DSH RC compatibility / Node 22.19.0
- ✅ DSH RC compatibility / Node 24

The preflight now locks `actions/setup-node@v7`, so the known v6 dummy-token regression cannot silently return to the OIDC-only release path.

## After merge

Rerun `Publish kernel prerelease` from `main` with `0.1.0-rc.2`. The failed run did **not** publish rc.2, so registry preflight should still require publication. Successful `npm publish` will then be the first end-to-end proof of the configured npm Trusted Publisher with no npm publish token present.