### PR TITLE
fix: remove token-auth npmrc from OIDC release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,6 @@ jobs:
       - uses: actions/setup-node@v7
         with:
           node-version: 24.x
-          registry-url: https://registry.npmjs.org
           package-manager-cache: false
 
       - name: Verify release invocation

--- a/scripts/release-preflight.mjs
+++ b/scripts/release-preflight.mjs
@@ -70,7 +70,8 @@ if (!existsSync(releaseWorkflowPath)) {
   const workflow = readFileSync(releaseWorkflowPath, 'utf8')
   if (!workflow.includes('id-token: write')) errors.push('release workflow must grant id-token: write for npm OIDC')
   if (!workflow.includes('environment: npm-release')) errors.push('release workflow must use the npm-release environment')
-  if (!workflow.includes('actions/setup-node@v7')) errors.push('release workflow must use actions/setup-node@v7 so npm OIDC is not shadowed by the v6 dummy auth token')
+  if (!workflow.includes('actions/setup-node@v7')) errors.push('release workflow must use actions/setup-node@v7')
+  if (workflow.includes('registry-url:')) errors.push('release workflow must not let setup-node generate token auth; npm Trusted Publishing owns registry authentication')
   if (workflow.includes('NPM_BOOTSTRAP_TOKEN')) errors.push('release workflow must be OIDC-only; bootstrap token fallback is not allowed')
 }
 


### PR DESCRIPTION
## Summary

Fix the second rc.2 Trusted Publishing failure from Actions run `32228445716`.

The release artifact is still healthy: invocation validation, frozen install, full `release:check`, registry preflight, build and packed smoke all passed. The failure remained isolated to `npm publish`.

## Root cause

`actions/setup-node@v7` removed the v6 dummy `NODE_AUTH_TOKEN` environment fallback, but `registry-url:` still causes setup-node to generate npm auth configuration containing:

```text
//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}
```

The failed run proves this path is active: `NODE_AUTH_TOKEN` is no longer present in the publish step, yet pnpm repeatedly reports:

```text
Failed to replace env in config: ${NODE_AUTH_TOKEN}
```

That generated token-auth state prevents npm CLI from cleanly taking the Trusted Publisher OIDC path and the registry returns the misleading `E404` on PUT.

## Changes

- remove `registry-url:` from the release workflow's `actions/setup-node@v7` step;
- keep npm's default public registry rather than asking setup-node to create token auth configuration;
- extend `release:preflight` to reject `registry-url:` in the OIDC-only release workflow;
- keep `id-token: write`, `npm-release` Environment, no bootstrap token, provenance, registry smoke, tag and GitHub prerelease behavior unchanged.

No kernel/API/package behavior changes.

## Why this is the minimal fix

This package has no private npm dependencies and publishes to npm's default public registry, so release-time registry auth configuration is unnecessary. Trusted Publishing should own publication authentication entirely.

## After merge

Rerun `Publish kernel prerelease` from `main` with `0.1.0-rc.2`. The previous failed runs did not publish rc.2, so registry preflight should still require publication.