### PR TITLE
build: freeze v0.2 runtime contract on DSH 0.1.1-rc.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,44 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  dsh-source:
+    name: DSH source baseline
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout project
+        uses: actions/checkout@v4
+
+      - name: Resolve pinned DSH identity
+        id: target
+        shell: bash
+        run: |
+          set -euo pipefail
+          node --input-type=module <<'NODE' >> "$GITHUB_OUTPUT"
+          import { DSH_TARGET } from './scripts/dsh-target.mjs'
+          console.log(`repository=${DSH_TARGET.repository}`)
+          console.log(`version=${DSH_TARGET.version}`)
+          console.log(`commit=${DSH_TARGET.commit}`)
+          NODE
+
+      - name: Checkout exact upstream DSH release
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ steps.target.outputs.repository }}
+          ref: ${{ steps.target.outputs.commit }}
+          path: .upstream/deepseek-harness
+          persist-credentials: false
+
+      - name: Verify upstream source identity
+        shell: bash
+        run: |
+          set -euo pipefail
+          ACTUAL_COMMIT=$(git -C .upstream/deepseek-harness rev-parse HEAD)
+          ACTUAL_VERSION=$(node -p "require('./.upstream/deepseek-harness/package.json').version")
+          test "$ACTUAL_COMMIT" = "${{ steps.target.outputs.commit }}"
+          test "$ACTUAL_VERSION" = "${{ steps.target.outputs.version }}"
+          echo "DSH source baseline verified: $ACTUAL_VERSION @ $ACTUAL_COMMIT"
+
   quality:
     name: quality (Node ${{ matrix.node }})
     runs-on: ubuntu-latest
@@ -55,7 +93,7 @@ jobs:
         run: pnpm smoke
 
   dsh-compat:
-    name: DSH RC compatibility (Node ${{ matrix.node }})
+    name: DSH compatibility (Node ${{ matrix.node }})
     runs-on: ubuntu-latest
     timeout-minutes: 15
     strategy:
@@ -73,5 +111,5 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
 
-      - name: Run real DSH runtime proofs
+      - name: Run published DSH runtime proofs
         run: pnpm probe:dsh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,14 +1,9 @@
-name: Publish runtime prerelease
+name: Publish latest package
 
-run-name: Publish dsh-multi-tenant ${{ inputs.version }}
+run-name: Publish dsh-multi-tenant from main
 
 on:
   workflow_dispatch:
-    inputs:
-      version:
-        description: Exact package version to publish (for example 0.2.0-rc.1)
-        required: true
-        type: string
 
 permissions:
   contents: write
@@ -39,9 +34,7 @@ jobs:
           node-version: 24.x
           package-manager-cache: false
 
-      - name: Verify release invocation
-        env:
-          REQUESTED_VERSION: ${{ inputs.version }}
+      - name: Resolve release identity
         shell: bash
         run: |
           set -euo pipefail
@@ -49,11 +42,10 @@ jobs:
             echo "Releases must be dispatched from main; got $GITHUB_REF" >&2
             exit 1
           fi
-          ACTUAL_VERSION=$(node -p "require('./packages/multi-tenant/package.json').version")
-          if [ "$REQUESTED_VERSION" != "$ACTUAL_VERSION" ]; then
-            echo "Requested version $REQUESTED_VERSION does not match package version $ACTUAL_VERSION" >&2
-            exit 1
-          fi
+          RELEASE_VERSION=$(node -p "require('./packages/multi-tenant/package.json').version")
+          echo "RELEASE_VERSION=$RELEASE_VERSION" >> "$GITHUB_ENV"
+          echo "Publishing dsh-multi-tenant@$RELEASE_VERSION as npm latest"
+
           node - <<'NODE'
           const { execFileSync } = require('node:child_process')
           const version = execFileSync('npm', ['--version'], { encoding: 'utf8' }).trim()
@@ -72,24 +64,19 @@ jobs:
 
       - name: Check registry ownership and version state
         id: registry
-        env:
-          RELEASE_VERSION: ${{ inputs.version }}
         run: node scripts/registry-preflight.mjs "$RELEASE_VERSION"
 
       - name: Publish to npm via Trusted Publishing
         if: steps.registry.outputs.publish_needed == 'true'
         working-directory: packages/multi-tenant
-        run: npm publish --access public --tag next --provenance
+        run: npm publish --access public --provenance
 
-      - name: Verify registry artifact
-        env:
-          RELEASE_VERSION: ${{ inputs.version }}
+      - name: Verify registry artifact and latest tag
         run: node scripts/registry-smoke.mjs "$RELEASE_VERSION"
 
-      - name: Create matching Git tag and GitHub prerelease
+      - name: Create matching Git tag and GitHub release
         env:
           GH_TOKEN: ${{ github.token }}
-          RELEASE_VERSION: ${{ inputs.version }}
         shell: bash
         run: |
           set -euo pipefail
@@ -110,9 +97,13 @@ jobs:
           if gh release view "$TAG" >/dev/null 2>&1; then
             echo "GitHub release $TAG already exists; leaving it unchanged"
           else
+            RELEASE_FLAGS=()
+            if [[ "$RELEASE_VERSION" == *-* ]]; then
+              RELEASE_FLAGS+=(--prerelease)
+            fi
             gh release create "$TAG" \
               --verify-tag \
-              --prerelease \
+              "${RELEASE_FLAGS[@]}" \
               --title "dsh-multi-tenant ${RELEASE_VERSION}" \
               --notes-file "docs/releases/v${RELEASE_VERSION}.md"
           fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,115 +2,112 @@
 
 # Contributing
 
-## Development model: spec-driven, then test-driven
+## Engineering model: global structure first
 
-This repository develops by **spec first, test second, implementation third**.
+This repository optimizes for long-term structural correctness and rapid iteration, not prerelease compatibility.
 
-1. **Spec** — a capability starts as a written spec: a *Seam Map* (surfaces +
-   gaps), a contract sketch, or an *ADR* that records the decision. No
-   implementation until the contract is written down.
-2. **Test** — write the contract test *before* the implementation. A provider's
-   contract test is a **shared suite** that any implementation of that seam must
-   pass.
-3. **Implement** — the smallest thing that satisfies the spec and the test.
+Before changing code, model the system globally:
 
-Current spec artifacts: `docs/specs/web-seam-map.md` (web surfaces) and
-`docs/adr/web-enforcement.md` (hard conclusions + upstream seam
-proposal).
+1. **Ownership/data structure** — what is the canonical tree/graph, and which invalid states should be impossible to represent?
+2. **State transitions** — what are the explicit lifecycle states, publication boundaries, cancellation paths and teardown order?
+3. **Semantic types** — which identity/capability/lifecycle meanings should TypeScript encode instead of leaving as loosely related fields?
+4. **Native framework structure** — can Cordis/DSH already express the dependency, lifecycle or registration plane instead of adding another registry/facade?
+5. **Executable contract** — what test or conformance harness proves the abstraction independently of one implementation?
+
+Only then implement the smallest coherent structure. Do not accumulate local patches around a weak model.
 
 ## Boundary-first decision rule
 
-Before adding implementation, classify the surface being discussed:
+Classify every guarantee:
 
-1. **Controlled by this repository → enforce it.** If we own the reliable
-   enforcement point, make the rule fail-closed and prove the invariant with
-   executable tests.
-2. **Owned by the ecosystem → standardize it.** If the guarantee depends on a
-   DSH or third-party seam, define the smallest reusable contract / seam,
-   publish conformance expectations, and collaborate upstream. A local spike is
-   evidence; it is not permission to permanently fork or reimplement the
-   upstream subsystem.
-3. **Not reliably enforceable → bound it.** State the threat-model / support
-   boundary and keep the promise narrow. Do not add broad architectural
-   machinery merely to claim coverage over a surface we still cannot prove.
+1. **Controlled by this repository -> enforce it.** Own the reliable boundary, make it fail closed where appropriate, and prove it.
+2. **Owned by the ecosystem -> standardize it.** Define or consume the smallest reusable DSH/provider seam and executable conformance contract.
+3. **Not reliably enforceable -> bound it.** State the support/security boundary rather than hiding it behind a parallel registry or local fork.
 
-Complexity is not evidence. A PR whose main effect is to absorb an upstream or
-uncontrolled responsibility into this repository should be rejected or
-deferred unless it demonstrates a stable, independently owned boundary.
+## Runtime structural rules
 
-## Prerelease-following discipline
+The v0.2 runtime is a canonical ownership tree:
 
-DeepSeek Harness is moving quickly, so this project optimizes for **small,
-explicit compatibility deltas** rather than long-lived local forks. The current
-target baseline is **DSH `0.1.0-rc.7`**.
+```text
+Root -> Tenant -> Principal -> derived integration fibers -> DSH operations
+```
 
-- Pin explicit prerelease versions; never make compatibility depend on an
-  unqualified `latest` tag.
-- Record the exact DSH version / commit used by a probe or architectural
-  conclusion.
-- Historical evidence is immutable evidence: an RC6 proof stays labelled RC6
-  until the affected seam is revalidated for RC7. Do not rewrite the label just
-  because source looks similar.
-- On a DSH bump, identify which seams changed and rerun only the affected
-  probes / conformance checks. Do not redesign unchanged layers.
-- Keep compatibility upgrades separate from unrelated feature expansion when
-  practical, so regressions and upstream changes remain easy to review and
-  revert.
+Contributions must preserve these semantics:
 
-See `docs/reference/compatibility.md` for the current target and evidence policy.
+- Tenant and Principal share canonical registry semantics;
+- Principal identity is structurally nested under Tenant;
+- asynchronous creation is unpublished until setup/commit succeeds;
+- preparing creation is cancellable lifecycle state, not only a Promise;
+- registry teardown closes admission, cancels preparing transactions, then drains published scopes;
+- Principal Context is a capability root; operations derive fibers and explicitly inject dependencies;
+- DSH Agent/Preset registration scope remains separate from Cordis Tenant/Principal service isolation;
+- the v0.1 ownership kernel remains shared and is not replaced by Context metadata.
+
+If a proposed feature requires repeated exceptions to these rules, revisit the abstraction before adding exceptions.
+
+## Strong types and semantics
+
+Prefer TypeScript types/generics that carry meaning:
+
+- use distinct identity/state/definition types instead of generic dictionaries;
+- normalize optional input into explicit internal data shapes;
+- make parent-child structure encode invariants where possible;
+- expose only lifecycle states consumers can actually observe;
+- avoid APIs that force upper layers to know lower-layer creation recipes;
+- keep one source of truth for package version, DSH baseline and other identities.
+
+Compiler failures such as `exactOptionalPropertyTypes` violations are design feedback; fix the data shape rather than weakening compiler settings.
+
+## DSH compatibility discipline
+
+Current exact baseline:
+
+- version: `0.1.1-rc.2`
+- release commit: `b150a551b8d465e31e418e1b2eaf5e79bbb7d28e`
+
+`scripts/dsh-target.mjs` is authoritative. The baseline is manually advanced and never floats.
+
+A DSH refresh must:
+
+1. select an explicit version + release commit;
+2. update every DSH-facing pin consistently;
+3. regenerate the lockfile from the real registry;
+4. verify the exact upstream source identity in GitHub Actions;
+5. rerun the exact-version published-package runtime probes;
+6. fix failures structurally rather than weakening evidence;
+7. update current docs while preserving historical release evidence.
+
+See `docs/reference/compatibility.md`.
 
 ## Package conventions
 
-- One package = one **independently composable / replaceable capability**, or
-  one **indivisible security boundary**. Never a code-size threshold, and never
-  a fragment of a single security invariant.
-- Prefer **native DSH/Cordis seams** (Service, event/waterfall, typed
-  protocol). Do not invent a Service merely to create a package boundary.
-- **Contract and default implementation may co-locate** (especially early). A
-  package may be a *pure provider* or a *pure integration*; extract a separate
-  package only when a provider gains independent install / replace / lifecycle
-  value.
-- **Do not scaffold speculative packages.** Create a package only when an
-  independent composition / replacement / dependency / versioning / lifecycle /
-  security boundary has been *demonstrated* — justified in an ADR, not by a
-  code-size or implementation-count threshold.
-- Directory names are short (`multi-tenant`); npm names are the published
-  identity (`dsh-multi-tenant`). They need not match.
+- One package = one independently composable/replaceable capability, one integration boundary, or one indivisible security invariant.
+- Prefer native DSH/Cordis Service, Context, Fiber, scope and typed protocol seams.
+- Contract and default implementation may co-locate early; split only when replacement/lifecycle/versioning value is real.
+- Do not scaffold speculative packages.
+- The future SaaS Framework should be an opinionated Distribution assembled from a Plugin Family, not a monolithic implementation package.
 
-## Dependency direction (non-negotiable)
+## Dependency direction
 
-```
-Kernel primitives ◀── capability contracts ◀── providers
+```text
+Runtime/kernel primitives <- capability contracts <- providers <- SaaS distribution
 ```
 
-The kernel owns only the minimal cross-suite tenant primitives (identity,
-ownership, authorization) and has zero transport/vendor dependencies — it never
-knows JWT / PostgreSQL / HTTP / MCP / Redis. Capability packages own their own
-contracts and may depend on the kernel's primitives. Providers depend on the
-package that owns their contract. Sibling capabilities do not reach through one
-another's implementations. A pull request that adds a transport/vendor
-dependency into the kernel is rejected.
+The runtime package keeps transport/vendor implementations out of core. Auth products, databases, HTTP/WebSocket transport, MCP product integration, audit/usage implementations and deployment profiles compose above the Runtime Contract.
 
 ## Tests: contract vs conformance
 
-Two test kinds prove different things:
-
-- **Contract Test Suite** — for a *provider seam* (e.g. `TenantSessionStore`).
-  Any implementation must pass the same suite as the default provider. This is
-  what makes "default ≠ only" hold: a replacement is proven by the contract,
-  not by fiat. The kernel ships this suite via the `dsh-multi-tenant/testing`
-  subpath (`assertTenantSessionStoreContract`).
-- **Conformance / Invariant Suite** — for a *security or integration
-  capability* (e.g. web enforcement). It asserts the tenant-isolation
-  invariants (A cannot list / history / mux / respond B; concurrent principals
-  never cross-talk), which no single provider's unit test can prove.
+- **Provider contract suites** prove a replaceable seam (for example `TenantSessionStore` or Runtime Capability Provider Contract).
+- **Conformance/invariant suites** prove cross-component properties such as tenant isolation, publication ordering and lifecycle ownership.
+- **Compatibility probes** prove assumptions about exact external DSH versions.
+- **Packed/registry smoke** proves the artifact users actually install, not only workspace source.
 
 ## Definition of done
 
-- Spec / ADR updated wherever behavior is decided.
-- The boundary classification is explicit when a change depends on an upstream
-  or otherwise uncontrolled surface.
-- Compatibility evidence names the DSH version it was actually validated on.
-- Contract and unit tests green (`pnpm test`).
-- `pnpm typecheck`, `pnpm build`, `pnpm verify`, and `pnpm smoke` green.
-- No transport/vendor dependency leaked into the kernel.
+- architecture/data/state/type implications reviewed globally;
+- current docs/ADR/spec updated where behavior is decided;
+- upstream/boundary ownership is explicit;
+- exact DSH compatibility evidence is green when relevant;
+- `pnpm release:check` is green;
+- no transport/vendor implementation leaks into the runtime kernel;
+- no compatibility shim is added solely to preserve an obsolete prerelease abstraction.

--- a/CONTRIBUTING.zh-CN.md
+++ b/CONTRIBUTING.zh-CN.md
@@ -1,67 +1,113 @@
 [English](./CONTRIBUTING.md) | 简体中文
 
-# 贡献指南
+# Contributing
 
-## 开发模型：规格驱动，然后测试驱动
+## 工程模型：先全局结构，再局部实现
 
-本仓库按 **先规格、次测试、后实现** 的顺序开发。
+本仓库优先长期结构正确性与快速迭代，不优先 prerelease 兼容。
 
-1. **规格** —— 一个能力先从一个书面规格开始：一张 *Seam Map*（surface + 缺口）、一份契约草图，或一份记录决策的 *ADR*。契约写下来之前不写实现。
-2. **测试** —— 在实现之前先写契约测试。一个提供方的契约测试是一套**共享套件**，该 seam 的任何实现都必须通过。
-3. **实现** —— 满足规格与测试的最小实现。
+改代码前先从全局建模：
 
-当前的规格产物：`docs/specs/web-seam-map.md`（web surface）与 `docs/adr/web-enforcement.md`（硬结论 + 上游 seam 提案）。
+1. **Ownership / Data Structure** —— canonical tree / graph 是什么？哪些非法状态应该从结构上不可表达？
+2. **State Transition** —— lifecycle state、publication boundary、cancel path、teardown order 分别是什么？
+3. **Semantic Types** —— identity / capability / lifecycle 的哪些语义应该由 TypeScript 类型系统表达，而不是散落成松散字段？
+4. **Native Framework Structure** —— Cordis / DSH 是否已经能表达 dependency、lifecycle 或 registration plane，而不需要新 registry / facade？
+5. **Executable Contract** —— 什么 test / conformance harness 能独立证明抽象，而不是只证明某个 implementation？
 
-## 边界优先的决策规则
+然后再实现最小但完整的结构。不要围绕一个弱模型不断叠加局部补丁。
 
-增加实现之前，先判断讨论中的 surface 属于哪一类：
+## Boundary-first Decision Rule
 
-1. **本仓库控制得住 → 严格强制。** 如果我们拥有可靠的 enforcement point，就默认拒绝，并用可执行测试证明安全不变量。
-2. **属于生态 → 制定标准。** 如果保证依赖 DSH 或第三方 seam，就定义最小、可复用的 contract / seam，发布一致性要求并优先向上游协作。本地 spike 是证据，不等于可以长期 fork 或重写上游子系统。
-3. **无法可靠强制 → 明确边界。** 直接说明 threat model / support boundary，把承诺限定在真正能证明的范围内。不要为了声称“已经覆盖”一个仍无法证明的 surface，而引入大范围工程复杂度。
+每个 guarantee 先分类：
 
-复杂度不是证据。一个 PR 如果主要效果是把上游或本仓库控制不了的责任强行吸收到本项目里，除非它证明了一个稳定、独立归属的边界，否则应该拒绝或延后。
+1. **仓库控制 -> 严格 enforce。** 我们拥有可靠 enforcement point，就让 invariant 可执行、必要时 fail closed。
+2. **生态控制 -> 制定标准。** 定义或消费最小可复用的 DSH / provider seam，并给出 executable conformance contract。
+3. **无法可靠 enforce -> 明确 boundary。** 不用平行 registry 或本地 fork 掩盖问题。
 
-## 快速跟进 prerelease 的纪律
+## Runtime Structural Rules
 
-DeepSeek Harness 仍在快速迭代，因此本项目优化的是**小而明确的兼容性增量**，而不是长期维护本地 fork。当前目标基线是 **DSH `0.1.0-rc.7`**。
+v0.2 Runtime 是 canonical ownership tree：
 
-- 显式 pin prerelease 版本；兼容性绝不依赖未限定的 `latest` tag。
-- 每个 probe 或架构结论都记录实际验证所对应的 DSH 精确版本 / commit。
-- 历史证据就是历史证据：一个 RC6 proof 在受影响 seam 为 RC7 重新验证之前，继续标记为 RC6。不能因为源码看起来类似就直接改标签。
-- DSH 升级时，先识别哪些 seam 真正发生变化，只重跑受影响的 probe / conformance check；未变化的层不要重新设计。
-- 在实际可行时，把兼容性升级与无关功能扩张拆开，让回归与上游变化更容易 review 和 revert。
-
-当前目标与证据政策见 `docs/reference/compatibility.md`。
-
-## 包约定
-
-- 一个包 = 一个**可独立组合 / 可替换的能力**，或一个**不可再分的安全边界**。绝不是代码量阈值，也绝不是一个安全不变量的碎片。
-- 优先使用**原生 DSH/Cordis seam**（Service、event/waterfall、带类型协议）。不要为了制造包边界而凭空发明一个 Service。
-- **契约与默认实现可以共置**（尤其在早期）。一个包可以是*纯提供方*或*纯集成*；仅当一个提供方获得独立的安装 / 替换 / 生命周期价值时，才拆出一个单独包。
-- **不要搭建投机性包。** 仅当一个独立的组合 / 替换 / 依赖 / 版本 / 生命周期 / 安全边界已被*证明*时才建包 —— 在 ADR 中论证，而非用代码量或实现数量阈值。
-- 目录名要短（`multi-tenant`）；npm 名是发布身份（`dsh-multi-tenant`）。二者不必一致。
-
-## 依赖方向（不可协商）
-
-```
-内核原语 ◀── 能力契约 ◀── 提供方
+```text
+Root -> Tenant -> Principal -> derived integration fibers -> DSH operations
 ```
 
-内核只拥有跨套件的最小租户原语（身份、所有权、授权），并且零 transport/vendor 依赖 —— 它永远不感知 JWT / PostgreSQL / HTTP / MCP / Redis。能力包拥有自己的契约，并且可以依赖内核的原语。提供方依赖拥有其契约的包。兄弟能力不会穿透彼此的实现。任何向内核引入 transport/vendor 依赖的 PR 都会被拒绝。
+所有贡献都应保持以下语义：
 
-## 测试：契约 vs 一致性
+- Tenant / Principal 共用 canonical registry 语义；
+- Principal identity 结构上嵌套在 Tenant 下；
+- asynchronous creation 在 setup / commit 成功前不可发布；
+- preparing creation 是可取消 lifecycle state，不只是一个 Promise；
+- registry teardown 先 close admission、cancel preparing transaction，再 drain published scope；
+- Principal Context 是 capability root；具体 operation 派生 fiber 并显式 inject dependency；
+- DSH Agent / Preset registration scope 与 Cordis Tenant / Principal service isolation 保持分离；
+- v0.1 ownership kernel 保持 shared，不被 Context metadata 替代。
 
-两种测试证明不同的事情：
+如果一个新功能需要大量例外才能塞进这些规则，应该先重审 abstraction，而不是继续加例外。
 
-- **契约测试套件** —— 针对一个*提供方 seam*（例如 `TenantSessionStore`）。任何实现都必须通过与默认提供方相同的套件。这正是「默认 ≠ 唯一」得以成立的原因：替换方由契约证明，而非由命令钦定。内核通过 `dsh-multi-tenant/testing` 子路径发布这套套件（`assertTenantSessionStoreContract`）。
-- **一致性 / 不变量套件** —— 针对一个*安全或集成能力*（例如 web 强制）。它断言租户隔离不变量（A 无法 list / history / mux / respond B；并发主体绝不串扰），这是任何单个提供方的单元测试都无法证明的。
+## Strong Types & Semantics
 
-## 完成定义
+优先让 TypeScript 类型 / 泛型携带语义：
 
-- 凡决定行为之处，规格 / ADR 均已更新。
-- 当一个变更依赖上游或其他本仓库控制不了的 surface 时，必须明确写出它属于哪一类边界。
-- 兼容性证据必须标出它实际验证所对应的 DSH 版本。
-- 契约与单元测试通过（`pnpm test`）。
-- `pnpm typecheck`、`pnpm build`、`pnpm verify`、`pnpm smoke` 通过。
-- 无 transport/vendor 依赖泄漏进内核。
+- identity / state / definition 使用清晰独立类型，不用 generic dictionary；
+- optional input 进入内部后 normalize 成明确数据结构；
+- 尽量用 parent-child structure 编码 invariant；
+- 只暴露 consumer 真正能观察的 lifecycle state；
+- 上层 API 不应被迫知道底层 creation recipe；
+- package version、DSH baseline 等 identity 保持唯一 source of truth。
+
+`exactOptionalPropertyTypes` 这类 compiler failure 是设计反馈；修正数据结构，不降低 compiler strictness。
+
+## DSH Compatibility Discipline
+
+当前精确 baseline：
+
+- version：`0.1.1-rc.2`
+- release commit：`b150a551b8d465e31e418e1b2eaf5e79bbb7d28e`
+
+`scripts/dsh-target.mjs` 是权威 source。Baseline 只手动推进，不 floating。
+
+一次 DSH refresh 必须：
+
+1. 选择明确 version + release commit；
+2. 所有 DSH-facing pin 一致更新；
+3. 从真实 registry 重新生成 lockfile；
+4. GitHub Actions 验证精确 upstream source identity；
+5. 重跑精确 npm 版本的 runtime probes；
+6. contract 失败时从结构上修，不削弱 evidence；
+7. 当前文档更新到新 baseline，同时历史 release evidence 不改写。
+
+参见 `docs/reference/compatibility.zh-CN.md`。
+
+## Package Conventions
+
+- 一个 package = 一个 independently composable / replaceable capability、integration boundary 或不可拆 security invariant；
+- 优先使用 DSH / Cordis 原生 Service、Context、Fiber、scope 与 typed protocol seam；
+- 早期 contract 与 default implementation 可以同 package；只有 replacement / lifecycle / versioning 价值真实出现时再拆；
+- 不创建 speculative package；
+- 未来 SaaS Framework 应该是由 Plugin Family 组装的 opinionated Distribution，而不是 monolithic implementation package。
+
+## Dependency Direction
+
+```text
+Runtime/kernel primitives <- capability contracts <- providers <- SaaS distribution
+```
+
+Runtime core 不引入 transport / vendor implementation。Auth 产品、数据库、HTTP/WebSocket transport、MCP 产品集成、audit/usage implementation 与 deployment profile 都在 Runtime Contract 之上组合。
+
+## Tests：Contract vs Conformance
+
+- **Provider contract suite** 证明可替换 seam，例如 `TenantSessionStore`、Runtime Capability Provider Contract；
+- **Conformance / invariant suite** 证明跨组件属性，例如 tenant isolation、publication ordering、lifecycle ownership；
+- **Compatibility probe** 证明对精确外部 DSH version 的假设；
+- **Packed / registry smoke** 证明用户真正安装到的 artifact，而不是只证明 workspace source。
+
+## Definition of Done
+
+- 从 architecture / data / state / type 维度完成全局审查；
+- 行为决策涉及的当前 docs / ADR / spec 已同步；
+- upstream / boundary ownership 明确；
+- 相关精确 DSH compatibility evidence 全绿；
+- `pnpm release:check` 全绿；
+- transport / vendor implementation 没有泄漏进 runtime kernel；
+- 不为了保留过时 prerelease abstraction 添加 compatibility shim。

--- a/README.md
+++ b/README.md
@@ -4,84 +4,134 @@
 
 Make [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) (DSH) a real **Multi-Tenant Runtime** while preserving a small, auditable security kernel.
 
-> **Current line: `0.2.0-rc.1`.** Published v0.1 tags are frozen historical contracts. v0.1 owns immutable session ownership and fail-closed authorization; v0.2 adds context-native Tenant/Principal capability scopes above that kernel. The executable DSH compatibility closure stays on the proven **`0.1.0-rc.7`** pin in this PR; current upstream `0.1.1-rc.2` scope behavior was reviewed separately.
+> **Current line: `0.2.0-rc.3`.** v0.1 is the frozen ownership/authorization kernel. v0.2 is the canonical Tenant/Principal Runtime Contract that the upcoming SaaS Framework will compose rather than rewrite.
+>
+> **Current DSH compatibility baseline:** `0.1.1-rc.2` at upstream release commit `b150a551b8d465e31e418e1b2eaf5e79bbb7d28e`. The version is explicitly pinned and manually advanced; CI never follows floating `latest` or `master`.
 
 ## Architecture
 
 ```text
-Deployment / Root Context
+Deployment / Root
 │
 ├── shared TenantSessionStore
-├── shared MultiTenantService        <- persistent authorization invariant
+├── shared MultiTenantService          persistent authorization invariant
 ├── shared TenantRuntimeService
 │
-├── Tenant A Cordis Context          <- capability graph
-│   ├── tenant-local auth / MCP / providers
-│   └── Principal A Context
-│       └── user-local credentials
+├── Tenant(acme)                       canonical runtime node
+│   ├── tenant capability graph
+│   ├── Principal(alice)               canonical runtime node
+│   │   └── principal capability graph
+│   └── Principal(bob)
 │
-└── Tenant B Cordis Context
-    ├── tenant-local auth / MCP / providers
-    └── Principal B Context
-        └── user-local credentials
+└── Tenant(globex)
 ```
 
-The project intentionally separates three isolation levels:
+The project separates four planes instead of overloading one tenant mechanism:
 
-1. **Ownership kernel** — durable `(tenantId, userId) -> session` authorization, fail closed.
-2. **Cordis context isolation** — tenant/principal service resolution and plugin lifecycle.
-3. **Deployment isolation** — process/filesystem/network/shell boundaries such as one tenant per container/Pod when stronger isolation is required.
+1. **Persistent authorization** — durable `(tenantId, userId) -> session` ownership; always fail closed.
+2. **Tenant/Principal capability graph** — Cordis Context service isolation and lifecycle.
+3. **Agent/Preset registration graph** — DSH `@deepseek-ai/dsh-scope`; tools, prompts, listeners and Agent-local visibility.
+4. **Strong deployment isolation** — process/filesystem/network/shell boundaries such as one tenant per container/Pod when required.
 
-DSH's own `@deepseek-ai/dsh-scope` remains the Agent/Preset registration-visibility plane. Tenant capability isolation uses Cordis service isolation instead of competing for the Agent scope parent chain.
+A canonical Principal Context is a capability/composition root. Operations that need additional services run in a Principal-derived integration fiber with explicit Cordis injection. For Agent creation the structural path is:
+
+```text
+Principal Runtime
+      ↓
+Principal-derived integration fiber
+  inject: agents
+      ↓
+ownerCtx.agents.create(...)
+      ↓
+DSH Agent setup / Agent scope
+```
+
+This preserves both planes instead of pretending `Agent.ctx` directly inherits the tenant service-isolation graph.
 
 ## v0.1 is frozen
 
-The published v0.1 tags remain unchanged and document the original kernel contract:
+The published v0.1 line remains the security kernel:
 
 - minimal authenticated `TenantPrincipal`;
 - claim-once immutable session ownership;
 - fail-closed access decisions;
 - replaceable `TenantSessionStore` provider seam.
 
-No new feature work is planned on the v0.1 line. Those guarantees are retained inside v0.2 as defense in depth.
+Those guarantees remain deployment-global inside v0.2 as defense in depth.
 
-## v0.2 runtime
+## v0.2 Runtime Contract
 
-`ctx.tenantRuntime` creates real Cordis tenant/principal child lifecycles. Selected service names receive independent isolation labels, so providers mounted below Tenant A and Tenant B resolve independently without a second application-level `tenantId -> service` container.
+Tenant and Principal share one structural vocabulary:
 
-The runtime is provider-neutral: auth, MCP, credential, storage, model, or other capability providers opt into tenancy by being mounted under the appropriate context and by avoiding deployment-global state that bypasses Cordis resolution.
+```ts
+const tenant = await ctx.tenantRuntime.tenants.ensure('acme', tenantDefinition)
+const alice = await tenant.principals.ensure('alice', principalDefinition)
+```
 
-Known upstream/provider gaps are documented rather than hidden. For example, in the reviewed current upstream the DSH MCP client reserves `serverName` against `ctx.root`, so equal server names across tenant-local instances are not yet automatically safe.
+Both levels are canonical runtime nodes with immutable identity, scoped Context, explicit lifecycle state, idempotent quiescent disposal, and canonical `ensure/get` registries.
 
-## Guiding principles
+Creation is transactional:
 
-- **Control → enforce** — strict fail-closed invariants where this repository owns the boundary.
-- **Ecosystem → standardize** — use Cordis/DSH native scope mechanisms and propose the smallest upstream seam when a provider is still global.
-- **Outside control → bound** — Context is not a process sandbox; say so explicitly.
-- **No second DI container** — tenant capability resolution belongs to Cordis Context.
-- **Defense in depth** — Context routing never replaces persistent session ownership checks.
+```text
+reserve canonical identity
+        ↓
+prepare unpublished Cordis subtree
+        ↓
+await setup(signal)
+        ↓
+optional synchronous commit()
+        ↓
+publish active node
+```
+
+Preparing transactions are first-class lifecycle resources. Registry teardown closes admission, cancels unpublished creations, then drains published scopes. Partial graphs are never visible; concurrent `ensure()` calls single-flight; setup failure rolls back; definition drift fails explicitly.
+
+## Provider ecosystem
+
+`dsh-multi-tenant/testing` exposes an executable Runtime Capability Provider Contract. Provider authors can prove same-name A/B isolation, root/parent non-leakage, descendant inheritance, sibling non-interference, disposal isolation, clean recreation, and unpublished setup ownership.
+
+That contract is the base of the future Plugin Family: the SaaS Framework may ship opinionated defaults while every capability slot remains replaceable.
+
+## Engineering principles
+
+- **Structure before patches** — design ownership, data structures and state transitions so correct behavior grows naturally.
+- **Strong semantic types** — use TypeScript types/generics to encode lifecycle and identity meaning rather than passing loosely related fields.
+- **Control -> enforce** — fail closed where this repository owns the boundary.
+- **Ecosystem -> standardize** — define executable provider/integration contracts instead of absorbing every implementation.
+- **Outside control -> bound** — Cordis Context is not a hostile-code or process sandbox.
+- **No prerelease compatibility debt** — break early APIs when a better long-term abstraction exists.
+- **No second DI container** — capability resolution belongs to Cordis Context.
+
+## Compatibility evidence
+
+CI proves the selected DSH baseline in two independent ways:
+
+- checks out the exact upstream DSH release commit and verifies its root package version;
+- runs executable session genesis, admission/publication and Agent owner/composition probes against the exact published npm packages.
+
+The baseline is explicit and manually refreshed when we choose to move DSH forward.
 
 ## Packages
 
 | Package | Distribution | Role |
 | --- | --- | --- |
-| [`packages/multi-tenant`](./packages/multi-tenant) | npm `dsh-multi-tenant@next` | v0.2 runtime + frozen v0.1 ownership kernel: `ctx.tenantRuntime`, `ctx.multiTenant`, `ctx.tenantSessionStore`. |
-| [`packages/multi-tenant-web`](./packages/multi-tenant-web) | private workspace | Experimental Web/API enforcement research; transport integration remains gated by real authenticated principal/context binding. |
+| [`packages/multi-tenant`](./packages/multi-tenant) | npm `dsh-multi-tenant` (`latest`) | v0.2 Runtime Contract + frozen v0.1 ownership kernel. |
+| [`packages/multi-tenant-web`](./packages/multi-tenant-web) | private workspace | Experimental Web/API enforcement research; production transport composition belongs to the SaaS Framework stage. |
 
-See [ROADMAP.md](./ROADMAP.md), [`docs/releases/v0.2.0-rc.1.md`](./docs/releases/v0.2.0-rc.1.md), and [CONTRIBUTING.md](./CONTRIBUTING.md).
+See [ROADMAP.md](./ROADMAP.md), [`docs/releases/v0.2.0-rc.3.md`](./docs/releases/v0.2.0-rc.3.md), and [CONTRIBUTING.md](./CONTRIBUTING.md).
+
+## Install
+
+```sh
+dsh plugin --profile <profile> add dsh-multi-tenant
+```
+
+`latest` always represents the newest version this project has intentionally published. We do not maintain a separate prerelease dist-tag during the current rapid-iteration phase.
 
 ## Development
 
 ```sh
-pnpm install
-pnpm typecheck
-pnpm test
-pnpm build
-```
-
-Full release gate:
-
-```sh
+pnpm install --frozen-lockfile
 pnpm release:check
 ```
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -2,86 +2,136 @@
 
 # dsh-multi-tenant
 
-目标：让 [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness)（DSH）真正成为 **Multi-Tenant Runtime**，同时保留一个小而可审计的安全 Kernel。
+让 [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness)（DSH）真正成为 **Multi-Tenant Runtime**，同时保留一个小而可审计的安全 Kernel。
 
-> **当前版本线：`0.2.0-rc.1`。** 已发布的 v0.1 tag 冻结为历史契约。v0.1 负责不可变 session ownership 与 fail-closed authorization；v0.2 在其上增加 Context-native Tenant / Principal capability scope。本 PR 的可执行 DSH compatibility closure 保持已经验证的 **`0.1.0-rc.7`**；设计阶段另外审阅了当前上游 `0.1.1-rc.2` 的 scope 行为。
+> **当前版本线：`0.2.0-rc.3`。** v0.1 是冻结的 ownership / authorization Kernel；v0.2 是 canonical Tenant / Principal Runtime Contract。后续 SaaS Framework 应该组合它，而不是重新发明 Runtime。
+>
+> **当前 DSH compatibility baseline：** `0.1.1-rc.2`，上游 release commit 为 `b150a551b8d465e31e418e1b2eaf5e79bbb7d28e`。版本与 commit 都显式固定，由我们手动推进；CI 永远不追 floating `latest` 或 `master`。
 
 ## 架构
 
 ```text
-Deployment / Root Context
+Deployment / Root
 │
 ├── shared TenantSessionStore
-├── shared MultiTenantService        <- 持久授权 invariant
+├── shared MultiTenantService          持久授权 invariant
 ├── shared TenantRuntimeService
 │
-├── Tenant A Cordis Context          <- capability graph
-│   ├── tenant-local auth / MCP / providers
-│   └── Principal A Context
-│       └── user-local credentials
+├── Tenant(acme)                       canonical runtime node
+│   ├── tenant capability graph
+│   ├── Principal(alice)               canonical runtime node
+│   │   └── principal capability graph
+│   └── Principal(bob)
 │
-└── Tenant B Cordis Context
-    ├── tenant-local auth / MCP / providers
-    └── Principal B Context
-        └── user-local credentials
+└── Tenant(globex)
 ```
 
-项目刻意区分三层隔离：
+项目刻意拆成四个 plane，而不是让一个“tenant 机制”承担所有职责：
 
-1. **Ownership Kernel** —— 持久 `(tenantId, userId) -> session` 授权，fail closed；
-2. **Cordis Context Isolation** —— Tenant / Principal service resolution 与 plugin lifecycle；
-3. **Deployment Isolation** —— process/filesystem/network/shell；需要强隔离时使用 one tenant per container / Pod。
+1. **Persistent authorization** —— durable `(tenantId, userId) -> session` ownership，始终 fail closed；
+2. **Tenant / Principal capability graph** —— Cordis Context service isolation 与 lifecycle；
+3. **Agent / Preset registration graph** —— DSH `@deepseek-ai/dsh-scope`，负责 tools、prompt、listener 和 Agent-local visibility；
+4. **Strong deployment isolation** —— process/filesystem/network/shell；需要时采用 one tenant per container / Pod。
 
-DSH 自己的 `@deepseek-ai/dsh-scope` 继续负责 Agent / Preset registration visibility。Tenant capability isolation 使用 Cordis service isolation，不去争抢 Agent scope 的 parent chain。
+Canonical Principal Context 是 capability / composition root。需要额外 service 的具体操作，应在 Principal 派生的 integration fiber 中显式 Cordis inject。Agent creation 的结构是：
+
+```text
+Principal Runtime
+      ↓
+Principal-derived integration fiber
+  inject: agents
+      ↓
+ownerCtx.agents.create(...)
+      ↓
+DSH Agent setup / Agent scope
+```
+
+这样不会把两套 scope plane 强行揉在一起，也不会假装 `Agent.ctx` 直接继承 Tenant service-isolation graph。
 
 ## v0.1 冻结
 
-已经发布的 v0.1 tag 保持不变，继续表示原来的 Kernel contract：
+已发布的 v0.1 继续表示安全 Kernel：
 
 - 最小 authenticated `TenantPrincipal`；
 - claim-once immutable session ownership；
 - fail-closed access decision；
 - 可替换 `TenantSessionStore` provider seam。
 
-v0.1 不再增加新功能；这些保证作为 defense in depth 被完整保留进 v0.2。
+这些保证在 v0.2 内保持 deployment-global，作为 defense in depth。
 
-## v0.2 Runtime
+## v0.2 Runtime Contract
 
-`ctx.tenantRuntime` 创建真实 Cordis Tenant / Principal child lifecycle。显式选择的 service name 获得独立 isolation label，因此 Tenant A / Tenant B 下挂载的 provider 由 Cordis 原生解析，不需要再造一套应用级 `tenantId -> service` 容器。
+Tenant 和 Principal 使用同一套结构语义：
 
-Runtime 保持 provider-neutral：auth、MCP、credential、storage、model 等 provider 通过挂载到正确 Context 下进入租户体系，同时 provider 自身不能绕开 Cordis resolution 使用 deployment-global state。
+```ts
+const tenant = await ctx.tenantRuntime.tenants.ensure('acme', tenantDefinition)
+const alice = await tenant.principals.ensure('alice', principalDefinition)
+```
 
-上游/provider 的 gap 会明确记录，不会被第二套 registry 掩盖。例如在已审阅的当前上游里，DSH MCP client 的 `serverName` reservation 仍按 `ctx.root` 全局管理，所以不同 Tenant 复用同一个 serverName 目前还不能自动视为安全。
+两级都是 canonical runtime node：拥有 immutable identity、scoped Context、显式 lifecycle state、幂等 quiescent disposal，以及 canonical `ensure/get` registry。
 
-## 原则
+创建过程是事务化的：
 
-- **控制得住 → 严格强制**：仓库拥有的边界做 fail-closed invariant；
-- **需要生态协作 → 制定标准**：优先使用 Cordis / DSH 原生 scope，缺 seam 时只推动最小上游 contract；
-- **控制不住 → 明确边界**：Context 不是 process sandbox；
-- **不再造 DI 容器**：Tenant capability resolution 属于 Cordis Context；
-- **Defense in depth**：Context routing 永远不能替代持久 session ownership 校验。
+```text
+reserve canonical identity
+        ↓
+prepare unpublished Cordis subtree
+        ↓
+await setup(signal)
+        ↓
+optional synchronous commit()
+        ↓
+publish active node
+```
+
+Preparing transaction 本身也是 first-class lifecycle resource。Registry teardown 先关闭 admission，再取消未发布 creation，最后 drain 已发布 scope。半初始化 graph 不可见；并发 `ensure()` single-flight；setup 失败完整 rollback；definition drift 明确失败。
+
+## Provider 生态
+
+`dsh-multi-tenant/testing` 提供可执行的 Runtime Capability Provider Contract。Provider 作者可以验证：同名 A/B isolation、root/parent 不泄漏、descendant inheritance、sibling 不干扰、dispose isolation、clean recreation、以及 unpublished setup ownership。
+
+这套 contract 是未来 Plugin Family 的地基：SaaS Framework 可以提供 opinionated defaults，但每个 capability slot 仍然可以被替换。
+
+## 工程原则
+
+- **Structure before patches** —— 先设计 ownership、数据结构、状态流转，让正确行为自然长出来；
+- **Strong semantic types** —— 用 TypeScript 类型系统 / 泛型表达 identity 与 lifecycle 语义，避免松散字段拼接；
+- **控制得住 -> 严格强制** —— 仓库拥有的边界 fail closed；
+- **需要生态协作 -> 制定标准** —— 用可执行 provider / integration contract，而不是把所有实现塞进 core；
+- **控制不住 -> 明确边界** —— Cordis Context 不是 hostile-code / process sandbox；
+- **Prerelease 不背兼容债** —— 更好的长期抽象出现时，直接破坏早期 API；
+- **不再造第二套 DI** —— capability resolution 属于 Cordis Context。
+
+## Compatibility Evidence
+
+CI 用两份独立证据证明选定的 DSH baseline：
+
+- checkout 精确的上游 DSH release commit，并验证 root package version；
+- 对精确 npm 版本运行 session genesis、admission/publication、Agent owner/composition executable probes。
+
+未来要升级 DSH 时，由我们显式更新 baseline，再重新跑整套证据。
 
 ## Packages
 
-| Package | Distribution | Role |
+| Package | Distribution | 作用 |
 | --- | --- | --- |
-| [`packages/multi-tenant`](./packages/multi-tenant) | npm `dsh-multi-tenant@next` | v0.2 runtime + 冻结的 v0.1 ownership kernel：`ctx.tenantRuntime`、`ctx.multiTenant`、`ctx.tenantSessionStore`。 |
-| [`packages/multi-tenant-web`](./packages/multi-tenant-web) | private workspace | Web/API enforcement 实验；production transport 仍需要真实 authenticated principal/context binding。 |
+| [`packages/multi-tenant`](./packages/multi-tenant) | npm `dsh-multi-tenant`（`latest`） | v0.2 Runtime Contract + 冻结的 v0.1 ownership kernel。 |
+| [`packages/multi-tenant-web`](./packages/multi-tenant-web) | private workspace | Web/API enforcement 实验；production transport composition 进入 SaaS Framework 阶段。 |
 
-参见 [ROADMAP.zh-CN.md](./ROADMAP.zh-CN.md)、[`docs/releases/v0.2.0-rc.1.md`](./docs/releases/v0.2.0-rc.1.md) 与 [CONTRIBUTING.zh-CN.md](./CONTRIBUTING.zh-CN.md)。
+参见 [ROADMAP.zh-CN.md](./ROADMAP.zh-CN.md)、[`docs/releases/v0.2.0-rc.3.md`](./docs/releases/v0.2.0-rc.3.md) 与 [CONTRIBUTING.zh-CN.md](./CONTRIBUTING.zh-CN.md)。
+
+## 安装
+
+```sh
+dsh plugin --profile <profile> add dsh-multi-tenant
+```
+
+当前快速迭代阶段只维护一个 npm channel：`latest` 永远表示我们明确选择发布的最新版本，不再维护额外 prerelease dist-tag。
 
 ## 开发
 
 ```sh
-pnpm install
-pnpm typecheck
-pnpm test
-pnpm build
-```
-
-完整 release gate：
-
-```sh
+pnpm install --frozen-lockfile
 pnpm release:check
 ```
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,142 +1,138 @@
 [简体中文](./ROADMAP.zh-CN.md) | English
 
-# Roadmap — v0.2 Multi-Tenant Runtime
+# Roadmap
 
-Status: ✅ done · 🚧 current · 🤝 ecosystem/upstream · 🧭 next · ⛔ boundary.
+The project is moving quickly and does not promise prerelease API compatibility. The governing rule is to optimize the architecture, data model, state transitions and semantic types for the long-term system rather than preserve early shapes.
 
-## Version-line policy
+## Version lines
 
-### v0.1 — frozen
+### v0.1 — frozen security kernel
 
-Published v0.1 tags are frozen. They define the authorization kernel only:
+v0.1 owns the durable authorization invariant:
 
-- minimal `TenantPrincipal`;
-- immutable session ownership;
+- minimal `{ tenantId, userId }` principal identity;
+- claim-once immutable session ownership;
 - fail-closed authorization;
 - replaceable `TenantSessionStore` contract.
 
-No new feature work belongs on v0.1. Security fixes may be documented/backported only when necessary; runtime expansion belongs on v0.2.
+This layer should remain small and boring.
 
-### v0.2 — current
+### v0.2 — Multi-Tenant Runtime Contract
 
-Goal: **make DeepSeek Harness a real Multi-Tenant Runtime**.
+v0.2 makes tenancy a first-class runtime structure rather than repeated `tenantId` plumbing.
 
-Current release candidate: `0.2.0-rc.1`.
-Executable DSH compatibility target for this PR: `0.1.0-rc.7` (the repository's proven lockfile closure). Current upstream `0.1.1-rc.2` scope behavior has been reviewed; dependency upgrade is a separate follow-up.
-
-## Architecture contract
-
-The runtime has distinct planes rather than one overloaded tenancy mechanism.
-
-| Plane | Owner | Purpose |
-| --- | --- | --- |
-| Persistent authorization | `ctx.multiTenant` + `TenantSessionStore` | Session ownership invariant; always fail closed. |
-| Tenant capability graph | Cordis Context service isolation | Tenant-local auth/MCP/credential/provider instances and lifecycle. |
-| Principal capability graph | Cordis Context service isolation | User-local OAuth/credential/policy providers below a tenant. |
-| Agent/Preset registration view | DSH `@deepseek-ai/dsh-scope` | Tools, prompts, listeners and model-facing registration visibility. |
-| Strong runtime isolation | Deployment/container/K8S | Process, filesystem, shell, network and memory boundaries. |
-
-The Tenant Runtime must not create a second DI/service registry keyed by tenant id. Cordis Context is the dependency scope.
-
-## ✅ R0 — v0.1 kernel retained
-
-The v0.1 security kernel remains intact inside v0.2. `multiTenant`, `tenantSessionStore`, `tenantRuntime`, and Cordis core services are reserved shared services and cannot be isolated out of a tenant graph.
-
-## 🚧 R1 — Context-native runtime (`0.2.0-rc.1`)
-
-Deliver the first executable runtime primitive:
-
-- `ctx.tenantRuntime`;
-- canonical live Tenant Context per tenant id;
-- Principal Context below Tenant Context;
-- explicit `isolateServices` capability selection;
-- contextual `tenantIdOf(ctx)` / `principalOf(ctx)` metadata;
-- structural Cordis lifecycle disposal;
-- duplicate tenant graph rejection;
-- cross-tenant principal binding rejection;
-- two-tenant adversarial tests;
-- packed external-consumer runtime smoke;
-- retain the proven RC7 executable compatibility closure while validating the architecture against current upstream scope behavior.
-
-Exit criteria: all repository release gates pass and the packed package proves independent same-name service resolution for two tenants while sharing the ownership kernel.
-
-## 🤝 R2 — Provider compatibility contracts
-
-A Context can isolate only capabilities whose providers respect Context/service scope. Inventory real DSH providers and classify them:
-
-1. **Context-safe** — may be instantiated below a Tenant/Principal Context as-is.
-2. **Needs scoped global-state fix** — provider uses `ctx.root`, module singleton, global Map/Set, env, or another deployment-global identity.
-3. **Host-global by design** — should not become tenant-local; expose a safe tenant-facing facade instead.
-
-First known gap in the reviewed current upstream: DSH MCP client reserves `serverName` per `ctx.root`. Propose the smallest upstream/provider change that makes namespace ownership scope-aware without forking MCP runtime.
-
-Target capability families:
-
-- Auth/session identity provider;
-- MCP connections and credentials;
-- credential/token store;
-- tenant configuration/secrets;
-- storage/workspace adapters where applicable;
-- model/provider policy where tenant-local instances are useful.
-
-## 🧭 R2.5 — DSH dependency refresh
-
-Upgrade the complete DSH package graph and `pnpm-lock.yaml` from the proven RC7 closure to a current release in a dedicated change. Do not couple that dependency-resolution churn to the v0.2 architecture PR.
-
-## 🤝 R3 — Authenticated transport → Context binding
-
-Define the production boundary as:
+This line is complete when the final convergence PR is green and merged. Its contract is:
 
 ```text
-HTTP request / WebSocket connection
-        ↓ authenticate
-TenantPrincipal
-        ↓ resolve/create
-Tenant Context / Principal Context
-        ↓
-DSH work driven from that context
+Deployment / Root
+  ├─ shared ownership kernel
+  └─ TenantRuntimeService
+       └─ Tenant                  canonical capability node
+            └─ Principal         canonical capability node
+                 └─ derived integration fibers
+                      └─ DSH Agent / transport / provider operations
 ```
 
-Do not spread `tenantId` parameters through every provider when Context can carry the dependency graph. Explicit identity remains mandatory at wire, durable, worker and authorization boundaries.
+#### Canonical runtime structure
 
-Required proof:
+- Tenant and Principal share one `ensure/get/state/dispose` vocabulary.
+- Principal is structurally nested under Tenant; invalid tenant/principal combinations are not representable.
+- Consumer code may join an existing canonical node by identity without knowing its creation recipe.
+- Explicit definitions are validated for capability-definition drift.
 
-- concurrent Tenant A/B requests do not cross-talk;
-- WebSocket lifetime keeps the correct Principal Context;
-- no client field can choose a trusted tenant/principal identity;
-- session publication/lookup still passes the ownership kernel.
+#### Publication and lifecycle
 
-## 🧭 R4 — Agent integration
+- creation reserves canonical identity before doing asynchronous work;
+- setup runs on an unpublished Cordis subtree;
+- optional synchronous `commit()` owns the exact publication boundary;
+- concurrent `ensure()` calls single-flight;
+- preparing transactions are first-class cancellable lifecycle resources;
+- registry shutdown closes admission, cancels unpublished creation, then drains published scopes;
+- failed setup rolls back completely;
+- Tenant teardown owns Principal teardown.
 
-Integrate Tenant/Principal Context with DSH agent creation without competing with the existing Agent/Preset scope-parent chain.
+#### Capability and Agent semantics
 
-Preferred direction:
+- Cordis service isolation owns Tenant/Principal capability authority and provider lifetime;
+- DSH `@deepseek-ai/dsh-scope` owns Agent/Preset registration visibility;
+- a Principal Context is a capability root, not a dependency-injection bypass;
+- operations derive an integration fiber and explicitly inject the services they need;
+- Agent creation uses the real DSH caller-bound `ownerCtx` seam rather than copying private Context state.
 
-- create/drive an Agent from a Tenant/Principal-derived Cordis context;
-- let DSH `agent.ctx` continue to own Agent-local registration lifecycle;
-- keep Preset standing-scope ancestry untouched;
-- define exactly which tenant-scoped services Agent creation inherits.
+#### Provider ecosystem contract
 
-## 🧭 R5 — Production providers
+`dsh-multi-tenant/testing` provides an executable Runtime Capability Provider Contract covering A/B isolation, leakage, inheritance, siblings, teardown, recreation and unpublished setup.
 
-Demand-driven, independently replaceable packages/providers:
+#### DSH baseline and evidence
 
-- durable ownership store (PostgreSQL/MySQL/Redis where justified);
-- reference auth/context binder;
-- tenant credential provider;
-- MCP tenant adapter after upstream namespace/global-state gaps are resolved;
-- audit/usage provider.
+Current explicit baseline:
 
-These should compose as a plugin family rather than make the core runtime depend on one SaaS stack.
+- DSH version: `0.1.1-rc.2`
+- release commit: `b150a551b8d465e31e418e1b2eaf5e79bbb7d28e`
 
-## ⛔ Explicit boundaries
+The baseline is manually advanced. Blocking CI never follows floating upstream state.
 
-Cordis Context is not a hostile-code sandbox. It does not isolate:
+CI proves both:
 
-- process memory/globals;
-- filesystem/shell;
-- network;
-- environment variables;
-- arbitrary malicious/trusted plugin code that deliberately escapes to `ctx.root` or process APIs.
+1. exact upstream source identity by checking out the pinned release commit;
+2. exact published runtime behavior through session genesis, admission/publication and Agent owner/composition probes.
 
-Deployments requiring strong tenant isolation should use a separate process/container/Pod boundary. Billing, organization UI, general RBAC and product-specific user management remain outside this repository's core contract.
+#### Release model
+
+The project currently keeps release mechanics deliberately simple:
+
+- package version lives in `packages/multi-tenant/package.json`;
+- manual GitHub release workflow derives that version automatically;
+- npm publishes to `latest` only;
+- registry smoke verifies that `latest` resolves to the just-published version;
+- prerelease/stable meaning belongs to the SemVer version itself, not a second npm channel.
+
+## v0.3 — SaaS Framework
+
+After v0.2 freezes, the main line becomes the SaaS Framework.
+
+The target is **an opinionated, out-of-the-box SaaS product experience built from a replaceable Plugin Family**, not a monolithic super-plugin.
+
+Conceptually:
+
+```text
+                         dsh-saas
+                 SaaS Distribution / Framework
+                            │
+        ┌───────────────────┼───────────────────┐
+        │                   │                   │
+      Auth              Credentials            MCP
+        │                   │                   │
+    Transport              Audit              Usage
+        │                   │                   │
+        └──────────── Provider Contracts ───────┘
+                            │
+                   dsh-multi-tenant
+                 Runtime Contract + Kernel
+```
+
+### v0.3 priorities
+
+1. **SaaS composition model** — define provider slots and a typed configuration/composition graph.
+2. **Authenticated transport binding** — authenticate at wire boundaries, resolve canonical Tenant/Principal runtime, then run work from a derived integration fiber.
+3. **Agent orchestration** — create/resume/drive DSH Agents through the Principal-owned integration boundary while preserving DSH Agent/Preset scope semantics.
+4. **Reference provider family** — Auth, credential/token storage, MCP tenancy, durable stores, audit/usage where justified.
+5. **Distribution defaults** — one recommended composition that works out of the box while allowing every provider slot to be replaced.
+6. **Diagnostics and compatibility** — startup validation, health, provider conformance, migrations and a clear compatibility matrix.
+
+Strong isolation remains a deployment profile, not a Context promise. A future K8S profile may map one Tenant to one Pod while preserving the same higher-level SaaS contracts.
+
+## Engineering rules
+
+- design globally before editing locally;
+- prefer structures that make invalid states unrepresentable;
+- model lifecycle/state transitions explicitly;
+- use TypeScript strong types and generics to carry semantics;
+- keep one source of truth for identities such as package version and DSH baseline;
+- do not preserve prerelease compatibility when it degrades the long-term model;
+- use Cordis/DSH native abstractions rather than parallel registries or local forks;
+- where this repository controls the boundary, enforce it; where the ecosystem owns it, standardize it; where neither applies, document the boundary.
+
+## Explicit security boundary
+
+Cordis Context is a trusted same-process composition/lifecycle boundary, not a hostile-code sandbox. It does not isolate process memory, filesystem, shell, network, environment variables or malicious plugins. Strong isolation belongs to process/container/Pod boundaries.

--- a/ROADMAP.zh-CN.md
+++ b/ROADMAP.zh-CN.md
@@ -1,142 +1,136 @@
 [English](./ROADMAP.md) | 简体中文
 
-# Roadmap —— v0.2 Multi-Tenant Runtime
+# Roadmap
 
-状态：✅ 已完成 · 🚧 当前 · 🤝 生态/上游协作 · 🧭 后续 · ⛔ 明确边界。
+项目当前处于快速推进阶段，不承诺 prerelease API 兼容。核心规则是：以长期系统的最佳工程结构、数据结构、状态流转与语义类型为目标，不为了保留早期形态制造兼容债。
 
-## 版本线策略
+## 版本线
 
-### v0.1 —— 冻结
+### v0.1 —— 冻结的 Security Kernel
 
-已经发布的 v0.1 tag 冻结，继续表示纯授权 Kernel：
+v0.1 负责 durable authorization invariant：
 
-- 最小 `TenantPrincipal`；
-- 不可变 session ownership；
+- 最小 `{ tenantId, userId }` principal identity；
+- claim-once immutable session ownership；
 - fail-closed authorization；
 - 可替换 `TenantSessionStore` contract。
 
-v0.1 不再做新功能；真正的 Runtime 扩展全部进入 v0.2。
+这一层应该保持小、稳定、无聊。
 
-### v0.2 —— 当前主线
+### v0.2 —— Multi-Tenant Runtime Contract
 
-目标：**让 DeepSeek Harness 真正成为 Multi-Tenant Runtime**。
+v0.2 把 tenancy 变成 first-class runtime structure，而不是到处传 `tenantId`。
 
-当前 candidate：`0.2.0-rc.1`。
-本 PR 的可执行 DSH compatibility target：`0.1.0-rc.7`（仓库已经验证的 lockfile 闭包）。当前上游 `0.1.1-rc.2` 的 scope 行为已审阅；依赖升级独立处理。
-
-## 架构契约
-
-Runtime 刻意拆成不同 plane，而不是让一个“tenant 机制”承担所有职责。
-
-| Plane | Owner | 作用 |
-| --- | --- | --- |
-| 持久授权 | `ctx.multiTenant` + `TenantSessionStore` | Session ownership invariant；永远 fail closed。 |
-| Tenant capability graph | Cordis Context service isolation | Tenant-local auth/MCP/credential/provider instance 与生命周期。 |
-| Principal capability graph | Cordis Context service isolation | Tenant 下的 user-local OAuth/credential/policy provider。 |
-| Agent/Preset registration view | DSH `@deepseek-ai/dsh-scope` | Tools、prompt、listener 与 model-facing registration visibility。 |
-| 强运行时隔离 | Deployment/container/K8S | Process、filesystem、shell、network、memory。 |
-
-Tenant Runtime **禁止**再造一套按 tenantId 索引的 DI/service registry。Cordis Context 就是 dependency scope。
-
-## ✅ R0 —— 保留 v0.1 Kernel
-
-v0.1 security kernel 完整保留进 v0.2。`multiTenant`、`tenantSessionStore`、`tenantRuntime` 以及 Cordis core service 都属于 reserved shared services，不能被 Tenant Context 隔离掉。
-
-## 🚧 R1 —— Context-native Runtime（`0.2.0-rc.1`）
-
-交付第一版可执行 runtime primitive：
-
-- `ctx.tenantRuntime`；
-- 每个 tenantId 一套 canonical live Tenant Context；
-- Tenant 下的 Principal Context；
-- 显式 `isolateServices` capability 选择；
-- `tenantIdOf(ctx)` / `principalOf(ctx)` contextual metadata；
-- Cordis Fiber structural disposal；
-- duplicate tenant graph 拒绝；
-- cross-tenant principal binding 拒绝；
-- two-tenant adversarial tests；
-- packed external-consumer runtime smoke；
-- 保留已经验证的 RC7 可执行兼容闭包，同时用当前上游 scope 行为校验架构方向。
-
-退出条件：仓库完整 release gate 通过，packed package 能证明两个 Tenant 对同名 service 得到独立 provider，同时 ownership kernel 仍然共享。
-
-## 🤝 R2 —— Provider Compatibility Contract
-
-Context 只能隔离真正尊重 Context/service scope 的 provider。对真实 DSH provider 做 inventory，并分类：
-
-1. **Context-safe** —— 可以直接实例化在 Tenant / Principal Context 下；
-2. **需要修 scoped global-state** —— provider 使用 `ctx.root`、module singleton、global Map/Set、env 或其他 deployment-global identity；
-3. **设计上就是 host-global** —— 不应该 tenant-local，应提供安全 tenant-facing facade。
-
-在已审阅的当前上游里，第一个明确 gap 是 DSH MCP client 的 `serverName` reservation 按 `ctx.root` 全局管理。应推动最小 upstream/provider 修复，让 namespace ownership scope-aware，而不是 fork MCP runtime。
-
-重点 capability family：
-
-- Auth/session identity provider；
-- MCP connection 与 credential；
-- credential/token store；
-- tenant config/secrets；
-- 合适场景下的 storage/workspace adapter；
-- 需要 tenant-local instance 的 model/provider policy。
-
-## 🧭 R2.5 —— DSH Dependency Refresh
-
-独立升级完整 DSH package graph 与 `pnpm-lock.yaml`，从当前已验证 RC7 闭包切到更新 release。不要把这类 dependency-resolution churn 混进 v0.2 架构 PR。
-
-## 🤝 R3 —— Authenticated Transport → Context Binding
-
-Production boundary 定义为：
+最终收口 MR 全绿并合并后，v0.2 即视为完成。其核心 contract 为：
 
 ```text
-HTTP request / WebSocket connection
-        ↓ authenticate
-TenantPrincipal
-        ↓ resolve/create
-Tenant Context / Principal Context
-        ↓
-从该 Context 驱动 DSH 工作
+Deployment / Root
+  ├─ shared ownership kernel
+  └─ TenantRuntimeService
+       └─ Tenant                  canonical capability node
+            └─ Principal         canonical capability node
+                 └─ derived integration fibers
+                      └─ DSH Agent / transport / provider operations
 ```
 
-能够由 Context 承载 dependency graph 的地方，不要再把 `tenantId` 参数扩散到每个 provider。Wire、durable、worker 与 authorization boundary 仍必须保留显式 identity。
+#### Canonical Runtime Structure
 
-需要证明：
+- Tenant / Principal 共用 `ensure / get / state / dispose` 语义；
+- Principal 结构上嵌套在 Tenant 下，错误 tenant/principal 组合不可表达；
+- 消费层可以只凭 identity 加入已有 canonical node，不需要知道 creation recipe；
+- 显式再次提供 definition 时才校验 capability-definition drift。
 
-- Tenant A/B 并发请求不 cross-talk；
-- WebSocket lifetime 始终绑定正确 Principal Context；
-- client field 不能选择可信 tenant/principal identity；
-- session publication/lookup 仍通过 ownership kernel。
+#### Publication 与 Lifecycle
 
-## 🧭 R4 —— Agent Integration
+- asynchronous work 之前先 reserve canonical identity；
+- setup 在 unpublished Cordis subtree 上运行；
+- 可选同步 `commit()` 拥有精确 publication boundary；
+- 并发 `ensure()` single-flight；
+- preparing transaction 是 first-class、可取消 lifecycle resource；
+- registry shutdown 先 close admission，再 cancel unpublished creation，最后 drain published scope；
+- setup 失败完整 rollback；
+- Tenant teardown 拥有 Principal teardown。
 
-将 Tenant / Principal Context 与 DSH Agent creation 集成，但不能破坏现有 Agent/Preset scope-parent chain。
+#### Capability 与 Agent 语义
 
-优先方向：
+- Cordis service isolation 负责 Tenant / Principal capability authority 与 provider lifetime；
+- DSH `@deepseek-ai/dsh-scope` 负责 Agent / Preset registration visibility；
+- Principal Context 是 capability root，不是 dependency-injection bypass；
+- 具体 operation 从 Principal 派生 integration fiber，并显式 inject 所需 service；
+- Agent creation 使用真实 DSH caller-bound `ownerCtx` seam，不复制 Context 私有状态。
 
-- 从 Tenant / Principal-derived Cordis Context 创建/驱动 Agent；
-- DSH `agent.ctx` 继续负责 Agent-local registration lifecycle；
-- Preset standing-scope ancestry 保持不变；
-- 明确定义 Agent creation 继承哪些 tenant-scoped services。
+#### Provider Ecosystem Contract
 
-## 🧭 R5 —— Production Providers
+`dsh-multi-tenant/testing` 提供可执行 Runtime Capability Provider Contract，覆盖 A/B isolation、leakage、inheritance、sibling、teardown、recreation 与 unpublished setup。
 
-按真实需求拆成可替换 Plugin Family：
+#### DSH Baseline 与 Evidence
 
-- durable ownership store（PostgreSQL/MySQL/Redis，按需求）；
-- reference auth/context binder；
-- tenant credential provider；
-- 上游 namespace/global-state gap 解决后的 MCP tenant adapter；
-- audit/usage provider。
+当前明确 baseline：
 
-不要让 core runtime 绑定某一套 SaaS 技术栈。
+- DSH version：`0.1.1-rc.2`
+- release commit：`b150a551b8d465e31e418e1b2eaf5e79bbb7d28e`
 
-## ⛔ 明确边界
+Baseline 由我们手动推进；blocking CI 永远不跟随 floating upstream state。
 
-Cordis Context 不是 hostile-code sandbox，它不隔离：
+CI 同时证明两件事：
 
-- process memory/global；
-- filesystem/shell；
-- network；
-- environment variable；
-- 故意访问 `ctx.root` 或 process API 的 arbitrary plugin code。
+1. checkout 精确 upstream release commit，验证源码身份；
+2. 对精确 npm package 运行 session genesis、admission/publication、Agent owner/composition executable probes。
 
-要求 strong tenant isolation 的部署继续使用独立 process/container/Pod。Billing、组织 UI、general RBAC 与产品特定用户管理不属于本仓库 core contract。
+#### Release Model
+
+当前 release mechanics 刻意保持简单：
+
+- package version 只存在于 `packages/multi-tenant/package.json`；
+- 手动 GitHub release workflow 自动读取这个版本；
+- npm 只发布到 `latest`；
+- registry smoke 验证 `latest` 指向刚发布的版本；
+- prerelease / stable 语义由 SemVer 本身表达，不再维护第二个 npm channel。
+
+## v0.3 —— SaaS Framework
+
+v0.2 冻结后，主线直接进入 SaaS Framework。
+
+目标是：**由可替换 Plugin Family 构成、但提供 opinionated 开箱即用体验的 SaaS Framework / Distribution**，而不是一个 monolithic super-plugin。
+
+```text
+                         dsh-saas
+                 SaaS Distribution / Framework
+                            │
+        ┌───────────────────┼───────────────────┐
+        │                   │                   │
+      Auth              Credentials            MCP
+        │                   │                   │
+    Transport              Audit              Usage
+        │                   │                   │
+        └──────────── Provider Contracts ───────┘
+                            │
+                   dsh-multi-tenant
+                 Runtime Contract + Kernel
+```
+
+### v0.3 优先级
+
+1. **SaaS composition model** —— 定义 provider slot 与强类型 configuration/composition graph；
+2. **Authenticated transport binding** —— wire boundary 完成认证，resolve canonical Tenant / Principal，再从 derived integration fiber 驱动工作；
+3. **Agent orchestration** —— 从 Principal-owned integration boundary create/resume/drive DSH Agent，同时保持 DSH Agent/Preset scope 语义；
+4. **Reference Provider Family** —— Auth、credential/token storage、MCP tenancy、durable store、audit/usage 等按需求实现；
+5. **Distribution defaults** —— 提供一套官方推荐的开箱即用组合，同时所有 provider slot 可替换；
+6. **Diagnostics & compatibility** —— startup validation、health、provider conformance、migration、清晰 compatibility matrix。
+
+Strong isolation 仍然是 deployment profile，不是 Context promise。未来 K8S profile 可以把一个 Tenant 映射到一个 Pod，同时保持同一套上层 SaaS contract。
+
+## 工程规则
+
+- 先全局设计，再局部修改；
+- 优先使用让非法状态不可表达的数据结构；
+- 显式建模 lifecycle / state transition；
+- 用 TypeScript 强类型与泛型携带语义；
+- package version、DSH baseline 等 identity 只保留一个 source of truth；
+- prerelease 阶段如果兼容性损害长期模型，直接破坏兼容；
+- 使用 Cordis / DSH 原生抽象，不另造平行 registry 或本地 fork；
+- 控制得住的边界严格 enforce，需要生态协作的定义标准，控制不住的明确 boundary。
+
+## Explicit Security Boundary
+
+Cordis Context 是 trusted same-process composition / lifecycle boundary，不是 process sandbox。它不隔离 process memory、filesystem、shell、network、environment variable 或任意同进程插件。Strong isolation 属于 process / container / Pod boundary。

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,9 +6,9 @@ Navigation hub for `dsh-multi-tenant` documentation.
 
 ## Guides
 
-- [README](../README.md) — project overview
-- [CONTRIBUTING](../CONTRIBUTING.md) — development policy
-- [ROADMAP](../ROADMAP.md) — current release/ecosystem direction
+- [README](../README.md) — project overview and current Runtime Contract
+- [CONTRIBUTING](../CONTRIBUTING.md) — engineering and compatibility policy
+- [ROADMAP](../ROADMAP.md) — v0.2 freeze and v0.3 SaaS Framework direction
 
 ## Decision records (ADR)
 
@@ -18,16 +18,19 @@ Navigation hub for `dsh-multi-tenant` documentation.
 ## Specs & analysis
 
 - [Architecture](./specs/architecture.md) — capability/layer ownership
-- [Session genesis map](./specs/session-genesis-map.md) — `prepare → setup → enter → announce`
+- [Session genesis map](./specs/session-genesis-map.md) — `prepare -> setup -> enter -> announce`
 - [Admission composition](./specs/admission-composition.md) — plugin admission composition
 - [Web seam map](./specs/web-seam-map.md) — authorization surfaces
 
 ## Reference
 
-- [Compatibility & versioning](./reference/compatibility.md) — Node / Cordis / DSH ranges + pinning
-- [Kernel prerelease contract](./reference/release.md) — current artifact, proof, OIDC publication, and boundaries
+- [Compatibility & versioning](./reference/compatibility.md) — exact DSH baseline and CI evidence
+- [Release contract](./reference/release.md) — package-version source of truth, npm latest, OIDC publication and registry proof
 
 ## Releases
 
+- [`v0.2.0-rc.3`](./releases/v0.2.0-rc.3.md) — final v0.2 convergence candidate
+- [`v0.2.0-rc.2`](./releases/v0.2.0-rc.2.md) — canonical Runtime Contract convergence
+- [`v0.2.0-rc.1`](./releases/v0.2.0-rc.1.md) — first context-native v0.2 runtime candidate
+- [`v0.1.0-rc.2`](./releases/v0.1.0-rc.2.md) — frozen kernel API convergence
 - [`v0.1.0-rc.1`](./releases/v0.1.0-rc.1.md) — first public kernel prerelease
-- [`v0.1.0-rc.2`](./releases/v0.1.0-rc.2.md) — API subtraction / OIDC-only convergence candidate

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -6,9 +6,9 @@
 
 ## 指南
 
-- [README](../README.zh-CN.md) — 项目概览
-- [CONTRIBUTING](../CONTRIBUTING.zh-CN.md) — 开发规范
-- [ROADMAP](../ROADMAP.zh-CN.md) — 当前 release / ecosystem 方向
+- [README](../README.zh-CN.md) — 项目概览与当前 Runtime Contract
+- [CONTRIBUTING](../CONTRIBUTING.zh-CN.md) — 工程与兼容性规范
+- [ROADMAP](../ROADMAP.zh-CN.md) — v0.2 收口与 v0.3 SaaS Framework 方向
 
 ## 决策记录（ADR）
 
@@ -18,16 +18,19 @@
 ## 规格与分析
 
 - [架构](./specs/architecture.zh-CN.md) — capability/layer 归属
-- [会话创生图](./specs/session-genesis-map.zh-CN.md) — `prepare → setup → enter → announce`
+- [会话创生图](./specs/session-genesis-map.zh-CN.md) — `prepare -> setup -> enter -> announce`
 - [准入组合](./specs/admission-composition.zh-CN.md) — plugin admission composition
 - [Web seam 图](./specs/web-seam-map.zh-CN.md) — authorization surfaces
 
 ## 参考
 
-- [兼容性与版本](./reference/compatibility.zh-CN.md) — Node / Cordis / DSH 范围 + pinning
-- [Kernel prerelease 发布契约](./reference/release.zh-CN.md) — 当前 artifact、proof、OIDC 发布与边界
+- [兼容性与版本](./reference/compatibility.zh-CN.md) — 精确 DSH baseline 与 CI evidence
+- [发布契约](./reference/release.zh-CN.md) — package version 单一事实源、npm latest、OIDC publication 与 registry proof
 
 ## Releases
 
+- [`v0.2.0-rc.3`](./releases/v0.2.0-rc.3.md) — v0.2 最终收口 candidate
+- [`v0.2.0-rc.2`](./releases/v0.2.0-rc.2.md) — canonical Runtime Contract 收敛
+- [`v0.2.0-rc.1`](./releases/v0.2.0-rc.1.md) — 第一个 context-native v0.2 runtime candidate
+- [`v0.1.0-rc.2`](./releases/v0.1.0-rc.2.md) — 冻结 kernel API 收敛
 - [`v0.1.0-rc.1`](./releases/v0.1.0-rc.1.md) — 第一次公开 kernel prerelease
-- [`v0.1.0-rc.2`](./releases/v0.1.0-rc.2.md) — API subtraction / OIDC-only 收敛 candidate

--- a/docs/adr/session-genesis.md
+++ b/docs/adr/session-genesis.md
@@ -1,82 +1,70 @@
 [简体中文](./session-genesis.zh-CN.md) | English
 
-# ADR — Session Genesis Ownership
+# ADR — Session / Agent publication boundary
 
-> Status: **proposed**. Based on the static `../specs/session-genesis-map.md` and the
-> `@deepseek-ai/dsh-session@0.1.0-rc.6` runtime probe (F1/F2). The Agent `setup`
-> semantics are statically confirmed; a full agent-stack runtime probe is
-> deferred (the `AgentLoop` injects `llm`/`tools`/`systemPrompt`, and the source
-> is unambiguous).
+> Status: **accepted finding; implementation guidance updated by v0.2 Runtime Contract**.
 
-## Finding
+## Decision
 
-DSH's Agent factory (`packages/core/agent-loop`, `setupAndPublish`) already runs
-an **async, before-visibility `setup` hook**:
+DSH Agent `setup` is the supported before-publication composition window for Agent create/resume flows.
 
+The relevant lifecycle is:
+
+```text
+prepare Session + Agent
+        ↓
+await setup(agentCtx)          unpublished
+        ↓
+setupCommit?.commit()
+        ↓
+sessions.enter / agents.enter
+        ↓
+announce / start
 ```
-sessions.prepare(id)        # Session constructed, NOT in store
-await setup(agent.ctx)      # ← async admission point. Rejection → dispose (rollback).
-sessions.enter(session)     # store entry — get/list now see it
-sessions.announce(session)  # session/created
+
+Tenant admission or product composition that must happen before an Agent becomes visible belongs in this setup transaction, not in `session/created` after the Session has already entered its registry.
+
+## Evidence
+
+The original static investigation is preserved in [`../specs/session-genesis-map.md`](../specs/session-genesis-map.md).
+
+Current blocking CI re-proves the contract against the exact DSH baseline `0.1.1-rc.2`:
+
+- `scripts/session-genesis-probe.mjs` proves SessionStore visibility/rollback semantics;
+- `scripts/admission-decorator-probe.mjs` proves setup-before-entry across create, fork, subagent and resume;
+- `scripts/agent-owner-context-probe.mjs` proves caller-bound Principal-derived Context reaches Agent creation as `ownerCtx`.
+
+## Updated composition guidance
+
+The earlier investigation suggested globally wrapping `ctx.agents` so every call received admission logic. That remains a valid compatibility technique and is useful as a probe, but it is **not the target SaaS architecture**.
+
+The v0.2/v0.3 structural path is:
+
+```text
+canonical Tenant
+   ↓
+canonical Principal
+   ↓
+derived integration fiber
+   ↓ explicit inject: agents
+ownerCtx.agents.create(...)
+   ↓
+Agent setup transaction
 ```
 
-`CreateAgentOptions.setup` / `ResumeAgentOptions.setup` are public and used by
-all four genesis paths (create / fork / subagent / resume).
+The SaaS Framework owns the authenticated product entry points, so Agent operations should naturally originate from the correct Principal-derived integration boundary rather than rely on ambient global middleware.
 
-## Decisions
+## Durable ownership interaction
 
-### 1. The admission mechanism exists; the gap is identity + composability
+The v0.1 `TenantSessionStore` ownership claim is persistent and independent from the in-process Agent lifecycle. If a caller reserves/claims a Session identity before final Agent publication and a later publication step fails, the durable claim may remain as an ownership reservation.
 
-`setup` is the correct admission point (before `sessions.enter`, async,
-rollback-on-reject). But it is a **per-call option**, not a global middleware.
-A plugin must **wrap `ctx.agents`** (Cordis service interception) to inject its
-admission into every `setup` — the same mechanism H3 needs to wrap the
-`ApiProxy`. The `setup` context (`agent.ctx`) exposes the session (hence the
-`sessionId` and `meta.parentSession`), so the plugin can derive:
+That behavior is safe from cross-tenant takeover because ownership is immutable and same-owner reclaim is idempotent, but product-level v0.3 composition should model reservation/finalization semantics explicitly if it needs reclamation or user-visible failed-session cleanup. Do not silently turn immutable ownership into rollbackable authorization state.
 
-| Path | Identity source | Needs H3? |
-| --- | --- | --- |
-| create | caller principal | **yes** (principal is not in `setup`) |
-| fork / subagent | parent owner via `getSessionOwner(parentSession)` | no |
-| resume | durable owner via the durable store | no |
+## Consequences
 
-### 2. H1 and H3 are distinct; only top-level create couples them
+- `session/created` is observation, not async admission.
+- DSH Agent setup and v0.2 Tenant/Principal setup intentionally share the same unpublished-setup -> optional commit -> publication vocabulary.
+- Principal identity/capability comes from the caller-owned Runtime boundary; `Agent.ctx` remains DSH-owned Agent/Preset scope.
+- Persistent ownership remains a separate defense-in-depth plane.
 
-- **fork / subagent / resume** are solvable today by wrapping `ctx.agents` and
-  reading the parent/durable owner — **no HTTP principal required**.
-- **top-level create** still needs the caller principal, which is lost at the
-  RPC boundary — that is H3, unchanged.
-
-### 3. Ghost ownership is a reservation tombstone (safe), pending a stricter rule
-
-If admission claims inside `setup` and `publish` then fails (e.g. a sync
-`session/created` throw), the session rolls back but the ownership claim
-remains. This is safe because:
-
-- the session id is a minted `session-<n>` or a client UUID — a failed
-  publication never grants access to anything, so the orphaned claim is a
-  **reservation tombstone**, not an authorization leak;
-- a same-owner retry is **idempotent**; a different-owner retry on the same id
-  is a conflict, which is correct (the id was reserved).
-
-This holds for the in-memory and durable stores alike. A stricter
-"reservation + commit" semantic is possible later (C) but is **not required**
-to close this spike.
-
-## Conclusion
-
-| Option | Verdict |
-| --- | --- |
-| **A** existing seam sufficient | **partially** — `setup` + wrap `ctx.agents` covers fork/subagent/resume today |
-| **B** upstream seam | **narrow** — only a request-scoped principal for top-level create (H3), not a new session lifecycle |
-| **C** core change | **not required** — inheritance/restore are already expressible; ghost ownership is a safe tombstone |
-
-The upstream proposal shrinks to **H3 only** (a request/connection-scoped
-principal reaching the create path). No new session-lifecycle seam is needed.
-
-## Next
-
-- M3 (web seam spike) proceeds on the **H3-only** upstream proposal.
-- Durable `TenantSessionStore` (M5) is still needed for cross-restart resume.
-- A full `ctx.agents.create` runtime probe can be added later if the AgentLoop's
-  dependencies (`llm`/`tools`/`systemPrompt`) become cheap to fixture.
+Current architecture authority: [`../specs/architecture.md`](../specs/architecture.md).

--- a/docs/adr/session-genesis.zh-CN.md
+++ b/docs/adr/session-genesis.zh-CN.md
@@ -1,62 +1,70 @@
 [English](./session-genesis.md) | 简体中文
 
-# ADR — 会话创生所有权
+# ADR —— Session / Agent Publication Boundary
 
-> 状态：**proposed（提案）**。基于静态的 `../specs/session-genesis-map.md` 与
-> `@deepseek-ai/dsh-session@0.1.0-rc.6` 运行时探针（F1/F2）。Agent `setup` 的语义已静态确认；完整 agent 栈运行时探针被延后（`AgentLoop` 注入 `llm`/`tools`/`systemPrompt`，且源码无歧义）。
+> Status：**事实已接受；实现指导已由 v0.2 Runtime Contract 更新**。
 
-## 发现
+## Decision
 
-DSH 的 Agent 工厂（`packages/core/agent-loop`、`setupAndPublish`）已经运行一个
-**异步、可见之前的 `setup` 钩子**：
+DSH Agent `setup` 是 Agent create / resume 流程中受支持的 before-publication composition window。
 
+关键生命周期：
+
+```text
+prepare Session + Agent
+        ↓
+await setup(agentCtx)          unpublished
+        ↓
+setupCommit?.commit()
+        ↓
+sessions.enter / agents.enter
+        ↓
+announce / start
 ```
-sessions.prepare(id)        # Session 已构造，但尚未入 store
-await setup(agent.ctx)      # ← 异步准入点。拒绝 → dispose（回滚）。
-sessions.enter(session)     # store 条目 —— get/list 现在可见
-sessions.announce(session)  # session/created
+
+必须在 Agent 对外可见前完成的 tenant admission 或 product composition 应进入 setup transaction，而不是依赖 Session 已进入 registry 之后的 `session/created`。
+
+## Evidence
+
+最初静态调查保留在 [`../specs/session-genesis-map.zh-CN.md`](../specs/session-genesis-map.zh-CN.md)。
+
+当前 blocking CI 会在精确 DSH baseline `0.1.1-rc.2` 上重新证明：
+
+- `scripts/session-genesis-probe.mjs`：SessionStore visibility / rollback 语义；
+- `scripts/admission-decorator-probe.mjs`：create / fork / subagent / resume 的 setup-before-entry；
+- `scripts/agent-owner-context-probe.mjs`：Principal-derived caller Context 作为 `ownerCtx` 进入 Agent creation。
+
+## 更新后的 Composition Guidance
+
+早期调查曾建议全局 wrap `ctx.agents`，让所有调用自动注入 admission logic。这个技术仍然可以作为兼容性手段和 probe，但它**不是目标 SaaS architecture**。
+
+v0.2 / v0.3 的结构路径是：
+
+```text
+canonical Tenant
+   ↓
+canonical Principal
+   ↓
+derived integration fiber
+   ↓ explicit inject: agents
+ownerCtx.agents.create(...)
+   ↓
+Agent setup transaction
 ```
 
-`CreateAgentOptions.setup` / `ResumeAgentOptions.setup` 是公开的，且被全部四条创生路径（create / fork / subagent / resume）使用。
+SaaS Framework 自己拥有 authenticated product entry point，因此 Agent operation 应自然从正确的 Principal-derived integration boundary 发起，而不是依赖 ambient global middleware。
 
-## 决策
+## Durable Ownership Interaction
 
-### 1. 准入机制已存在；缺口在身份与可组合性
+v0.1 `TenantSessionStore` ownership claim 是持久状态，与进程内 Agent lifecycle 独立。如果调用方在最终 Agent publication 前已经 reserve / claim Session identity，而之后 publication 失败，这个 durable claim 可能继续作为 ownership reservation 存在。
 
-`setup` 是正确的准入点（在 `sessions.enter` 之前、异步、拒绝即回滚）。但它是**逐调用选项**，而非全局中间件。插件必须**包装 `ctx.agents`**（Cordis service 拦截）以将其准入注入每一次 `setup` —— 与 H3 包装 `ApiProxy` 所需的机制相同。`setup` 上下文（`agent.ctx`）暴露了 session（因此暴露了 `sessionId` 与 `meta.parentSession`），所以插件可以推导出：
+它不会造成 cross-tenant takeover：ownership immutable，同 owner reclaim idempotent。但如果 v0.3 产品层需要回收、失败会话清理等语义，应显式建模 reservation / finalization，而不是偷偷把 immutable ownership 改成 rollbackable authorization state。
 
-| 路径 | 身份来源 | 需要 H3？ |
-| --- | --- | --- |
-| create | 调用方 principal | **是**（principal 不在 `setup` 中） |
-| fork / subagent | 通过 `getSessionOwner(parentSession)` 得到父所有者 | 否 |
-| resume | 通过持久 store 得到持久所有者 | 否 |
+## Consequences
 
-### 2. H1 与 H3 是不同的；只有顶层 create 将二者耦合
+- `session/created` 是 observation，不是 async admission；
+- DSH Agent setup 与 v0.2 Tenant / Principal setup 刻意共享 unpublished setup -> optional commit -> publication 语义；
+- Principal identity / capability 来自 caller-owned Runtime boundary；`Agent.ctx` 继续属于 DSH Agent / Preset scope；
+- persistent ownership 保持独立 defense-in-depth plane。
 
-- **fork / subagent / resume** 今天即可通过包装 `ctx.agents` 并读取父/持久所有者来解决 —— **无需 HTTP principal**。
-- **顶层 create** 仍需要调用方 principal，它在 RPC 边界被丢弃 —— 那正是 H3，不变。
-
-### 3. 幽灵所有权是一个保留墓碑（安全），等待更严格的规则
-
-若准入在 `setup` 内认领，而 `publish` 随后失败（例如同步 `session/created` 抛出），会话回滚但所有权认领保留。这是安全的，因为：
-
-- 会话 id 是铸造出来的 `session-<n>` 或客户端 UUID —— 一次失败的发布绝不会授予对任何东西的访问，因此孤儿认领是一个**保留墓碑**，而非授权泄漏；
-- 同所有者重试是**幂等**的；对同一 id 的不同所有者重试是冲突，这是正确的（该 id 已被保留）。
-
-这对内存 store 与持久 store 同样成立。更严格的「保留 + 提交」语义将来可以做（C），但**不是**收口本 spike 所必需的。
-
-## 结论
-
-| 选项 | 判定 |
-| --- | --- |
-| **A** 现有 seam 已足够 | **部分** —— `setup` + 包装 `ctx.agents` 今天即可覆盖 fork/subagent/resume |
-| **B** 上游 seam | **收窄** —— 仅为顶层 create 提供一个 request-scoped principal（H3），而非新的会话生命周期 |
-| **C** 内核改动 | **不需要** —— 继承/恢复已可表达；幽灵所有权是安全墓碑 |
-
-上游提案收窄为 **仅 H3**（一个抵达 create 路径的 request/connection-scoped principal）。不需要新的会话生命周期 seam。
-
-## 下一步
-
-- M3（web seam spike）在 **H3-only** 上游提案上推进。
-- 持久 `TenantSessionStore`（M5）对跨重启 resume 仍然需要。
-- 若 AgentLoop 的依赖（`llm`/`tools`/`systemPrompt`）变得容易构造 fixture，之后可以加一个完整的 `ctx.agents.create` 运行时探针。
+当前架构权威：[`../specs/architecture.zh-CN.md`](../specs/architecture.zh-CN.md)。

--- a/docs/adr/web-enforcement.md
+++ b/docs/adr/web-enforcement.md
@@ -1,92 +1,68 @@
 [简体中文](./web-enforcement.zh-CN.md) | English
 
-# ADR — DSH Web Multi-Tenant Enforcement (release-converged)
+# ADR — Web/API tenant enforcement research
 
-> Status: **proposed**. Converges the session-genesis, admission-composition,
-> real-`ApiProxy`, and RC7 transport evidence. This ADR now follows the project
-> boundary rule: owned enforcement is implemented here; missing DSH transport
-> scope is an ecosystem seam, not a reason to fork the carrier.
+> Status: **historical enforcement findings accepted; old transport architecture superseded by v0.2 Runtime Contract / v0.3 SaaS composition**.
 
-## Context
+## Accepted findings
 
-The core (`dsh-multi-tenant`) owns session ownership and fail-closed
-authorization. The Web question is narrower: what is the smallest DSH seam
-needed to carry an authenticated request/connection identity into that owned
-enforcement without shared ambient state?
+The earlier Web spike established several durable rules that remain useful regardless of transport implementation:
 
-## Converged findings
+1. session-keyed point operations require ownership guard before dispatch;
+2. collection filtering is valid only when post-filter semantics remain correct;
+3. create/resume ownership or admission must happen before publication, not after `session/created`;
+4. unmodelled deployment-global surfaces remain denied until a tenant resource model exists;
+5. exhaustive API classification is valuable because new DSH methods should not silently bypass policy.
 
-| Concern | Status |
-| --- | --- |
-| **H1 — session genesis** | **Resolved.** Agent `setup` is the before-visibility async admission point; no kernel change is required. |
-| **Admission composability** | **Runtime-proven on RC6; RC7 refresh is release compatibility work.** A decorator joins `ctx.agents.create/resume` and runs admission before `sessions.enter`. |
-| **Unary enforcement** | **Implemented as the real shape.** `bindTenant` wraps the real `ApiProxy`; every `RpcMethodMap` member is exhaustively classified and the policy fails closed. |
-| **H3 — request/connection principal scope** | **RC7 ecosystem gap.** Public `ConnectionRpcHandler` receives only decoded `(endpoint, payload, signal)`, while the DSH Web carrier owns the real HTTP/WS boundary and documents that it has no authentication layer. |
-| **Streams / respond** | **Deferred behind H3.** They remain denied in the spike. Implement them only when a real principal-scoped transport path exists. |
-| **Ghost ownership** | **v0 security-safe tombstone.** Session ids must not be reused; cleanup semantics are independent later work. |
+`packages/multi-tenant-web` preserves the real `ApiProxy` experiments and compile-time exhaustive unary classification as private research evidence.
 
-## H3 under RC7 — ecosystem deliverable
+## What is superseded
 
-The facade needs a `TenantPrincipal`, but RC7's public Connection RPC seam no
-longer has the transport request when the decoded handler runs. The real HTTP
-request / WS upgrade is held inside the DSH Web carrier, and the shipped carrier
-explicitly describes its host fence as reachability policy rather than
-authentication.
+The old ADR framed production progress around adding a request/connection principal seam directly to the Web spike and then growing the spike into a production enforcement plane.
 
-That evidence is sufficient to classify H3 as **ecosystem-owned**. The project
-should not build and maintain a production replacement for DSH's Web transport
-just to make the local checklist complete.
+That is no longer the architectural direction.
 
-The deliverable is a **minimal tenant-agnostic upstream seam** that lets a
-consumer derive or install request/connection-scoped API/security context from
-the actual HTTP request / WS upgrade. The proposal should preserve DSH's carrier
-ownership and be useful beyond this plugin.
+v0.2 introduced a canonical Tenant/Principal Runtime, so v0.3 authenticated transport should be designed from the runtime structure outward:
 
-A small local probe may still be used to sharpen an API proposal, but a full
-HTTP/WS transport clone is no longer a prerequisite for the kernel release or
-for filing the upstream proposal.
+```text
+wire request / connection
+        ↓ authenticate explicit identity
+TenantPrincipal
+        ↓ resolve canonical runtime
+Tenant -> Principal
+        ↓ derive operation fiber
+explicit Cordis inject
+        ↓
+DSH API / Agent operation
+```
 
-## v0 Web spike security policy
+Transport is therefore an integration/provider layer over the Runtime Contract, not a second tenant runtime.
 
-`RpcMethodMap` coverage is exhaustive, but exhaustive coverage does not make
-host-global capabilities tenant-safe. Until real resource semantics and H3
-exist, the spike stays fail-closed:
+## Boundary ownership
 
-- session-keyed point operations → **GUARD**;
-- `session.list` → **FILTER** only while post-filtering preserves semantics;
-- `session.create` → **ADMIT**, denied until principal-scoped admission can be
-  installed before publication;
-- `session.search` → **DENY** for now; tenant-scoped ranking/visibility belongs
-  to a later search contract;
-- deployment/host management (`settings.*`, `credentials.*`, host/workspace,
-  preset authoring, host-scoped LLM configuration/discovery) → **DENY**;
-- explicitly tenant-neutral read-only discovery may be **ALLOW**.
-- streams, `respond`, and downloads stay **DENY** until their supported security
-  semantics are implemented.
+The transport/security boundary must explicitly authenticate identity; client-supplied tenant/user fields are not trusted merely because they exist in a payload.
 
-## Explicitly not required
+After identity is established, the canonical Principal Runtime owns same-process capability/lifecycle context. The operation fiber injects only the services needed for that request/connection/Agent action.
 
-Current evidence does **not** require:
+Persistent session ownership still goes through `ctx.multiTenant`; contextual identity never replaces durable authorization.
 
-- a kernel change;
-- a global setup-contribution registry;
-- a permanent fork or reimplementation of DSH Web transport;
-- JWT/OIDC/API-key logic inside the kernel;
-- making host-global DSH resources tenant-owned as part of v0.1.
+## Reuse of Web spike code
 
-`respond` may require correlation state once a principal-scoped connection path
-exists. That is an enforcement detail to prove then, not a reason to expand the
-upstream proposal preemptively.
+Existing Web code may be reused when it naturally fits the v0.3 structure:
 
-## Next
+- `ApiProxy` exhaustive method classification;
+- guard/filter/deny policy mechanics;
+- fail-closed handling of unknown/global surfaces;
+- tests that prove cross-tenant visibility restrictions.
 
-1. **Release track:** refresh the affected admission/ApiProxy evidence on RC7;
-   this is enough for the kernel compatibility baseline.
-2. **Ecosystem track:** file the small request/connection-scope upstream
-   proposal, with concurrency and HTTP/WS lifetime conformance expectations.
-3. **After an adequate seam exists:** turn `dsh-multi-tenant-web` into a
-   production plugin and prove mux/host/respond plus unary/admission in a
-   two-tenant E2E suite.
+Do not preserve old code by adding compatibility shims, global ambient principal state or a parallel tenant registry. If a clean v0.3 transport adapter is simpler and semantically stronger, replace the spike.
 
-Production Web enforcement no longer blocks the first `dsh-multi-tenant`
-kernel prerelease.
+## Current evidence
+
+- Agent/session publication seam: [`../specs/session-genesis-map.md`](../specs/session-genesis-map.md)
+- Agent setup composition: [`../specs/admission-composition.md`](../specs/admission-composition.md)
+- historical Web seam map: [`../specs/web-seam-map.md`](../specs/web-seam-map.md)
+- current Runtime architecture: [`../specs/architecture.md`](../specs/architecture.md)
+- current product direction: [`../../ROADMAP.md`](../../ROADMAP.md)
+
+Exact current DSH baseline and executable probes are defined in [`../reference/compatibility.md`](../reference/compatibility.md).

--- a/docs/adr/web-enforcement.zh-CN.md
+++ b/docs/adr/web-enforcement.zh-CN.md
@@ -1,62 +1,68 @@
 [English](./web-enforcement.md) | 简体中文
 
-# ADR — DSH Web 多租户强制（发布收敛版）
+# ADR —— Web/API Tenant Enforcement Research
 
-> 状态：**proposed（提案）**。收敛 session genesis、admission composition、真实 `ApiProxy` 以及 RC7 transport 证据。本文档现在明确遵循项目边界原则：本仓库控制得住的 enforcement 自己实现；DSH transport 缺少的 scope 作为生态 seam 处理，而不是 fork carrier。
+> Status：**历史 enforcement 结论继续接受；旧 transport architecture 已被 v0.2 Runtime Contract / v0.3 SaaS composition 取代**。
 
-## 背景
+## 继续成立的结论
 
-内核（`dsh-multi-tenant`）拥有 session ownership 和 fail-closed authorization。Web 问题更窄：需要 DSH 提供什么最小 seam，才能把一个已认证的 request/connection identity 带入本仓库拥有的 enforcement，同时不依赖共享 ambient state。
+早期 Web spike 确认了几条不依赖具体 transport implementation 的长期规则：
 
-## 收敛后的结论
+1. session-keyed point operation 在 dispatch 前必须做 ownership guard；
+2. collection 只有在 post-filter 后语义仍正确时才可以 filter；
+3. create / resume ownership 或 admission 必须发生在 publication 前，而不是 `session/created` 之后；
+4. 没有 tenant resource model 的 deployment-global surface 继续 deny；
+5. exhaustive API classification 很有价值，新 DSH method 不应该静默绕过 policy。
 
-| 关注点 | 状态 |
-| --- | --- |
-| **H1 — session genesis** | **已解决。** Agent `setup` 是 visibility 前的异步准入点；不需要 kernel 改动。 |
-| **Admission composability** | **RC6 runtime 已证明；RC7 refresh 属于发布兼容性工作。** decorator 可以加入 `ctx.agents.create/resume`，且 admission 在 `sessions.enter` 前执行。 |
-| **Unary enforcement** | **真实形态已实现。** `bindTenant` 包装真实 `ApiProxy`；`RpcMethodMap` 每个成员都被穷举分类，策略默认拒绝。 |
-| **H3 — request/connection principal scope** | **RC7 生态缺口。** 公开的 `ConnectionRpcHandler` 只有解码后的 `(endpoint, payload, signal)`；真实 HTTP/WS boundary 由 DSH Web carrier 持有，而且官方文档明确说明目前没有 authentication layer。 |
-| **Streams / respond** | **在 H3 之后处理。** spike 中继续拒绝。只有真实 principal-scoped transport path 存在后才实现。 |
-| **Ghost ownership** | **v0 在安全上可接受的 tombstone。** Session id 不可复用；cleanup semantics 是独立后续工作。 |
+`packages/multi-tenant-web` 继续以 private research evidence 的形式保留真实 `ApiProxy` 实验与 compile-time exhaustive unary classification。
 
-## RC7 下的 H3 —— 生态交付物
+## 已被取代的部分
 
-facade 需要一个 `TenantPrincipal`，但 RC7 的公开 Connection RPC seam 在 decoded handler 执行时已经拿不到 transport request。真实 HTTP request / WS upgrade 保留在 DSH Web carrier 内部；官方 carrier 也明确把现有 host fence 定义为 reachability policy，而不是 authentication。
+旧 ADR 把 production 推进路径理解为：先给 Web spike 增加 request/connection principal seam，再把 spike 扩成 production enforcement plane。
 
-这些证据已经足够把 H3 归类为**生态拥有**。本项目不应该为了让本地 checklist 看起来完整，就长期构建并维护一套 DSH Web transport 替代实现。
+这已经不是当前架构方向。
 
-真正应该交付的是一个**最小、tenant-agnostic 的 upstream seam**：让 consumer 可以基于真实 HTTP request / WS upgrade 建立或安装 request/connection-scoped API/security context。proposal 应保留 DSH 对 carrier 的所有权，并尽量让这个 seam 对其他插件也有价值。
+v0.2 已经建立 canonical Tenant / Principal Runtime，因此 v0.3 authenticated transport 应从 Runtime structure 向外设计：
 
-为了打磨 API proposal，可以继续写一个很小的 local probe；但完整 HTTP/WS transport clone 不再是 kernel release 的前置条件，也不再是提交 upstream proposal 的前置条件。
+```text
+wire request / connection
+        ↓ authenticate explicit identity
+TenantPrincipal
+        ↓ resolve canonical runtime
+Tenant -> Principal
+        ↓ derive operation fiber
+explicit Cordis inject
+        ↓
+DSH API / Agent operation
+```
 
-## v0 Web spike 的安全策略
+Transport 是 Runtime Contract 上方的 integration / provider layer，而不是第二套 tenant runtime。
 
-`RpcMethodMap` 已经穷举，但穷举并不等于 host-global capability 就具备 tenant-safe 语义。真实 resource semantics 和 H3 存在之前，spike 继续 fail-closed：
+## Boundary Ownership
 
-- session-keyed point 操作 → **GUARD**；
-- `session.list` → 只有在 post-filter 保持语义正确时才 **FILTER**；
-- `session.create` → **ADMIT**，在 principal-scoped admission 能够 publication 前安装之前继续拒绝；
-- `session.search` → 当前 **DENY**；tenant-scoped ranking/visibility 属于后续 search contract；
-- deployment/host 管理面（`settings.*`、`credentials.*`、host/workspace、preset authoring、host-scoped LLM 配置/发现）→ **DENY**；
-- 明确 tenant-neutral 的只读 discovery 可以 **ALLOW**；
-- streams、`respond`、downloads 在支持的安全语义真正实现前继续 **DENY**。
+Transport / security boundary 必须显式认证 identity；payload 中出现 tenant/user 字段并不意味着它们天然可信。
 
-## 明确不需要的东西
+Identity 建立之后，canonical Principal Runtime 负责同进程 capability / lifecycle context；operation fiber 只 inject 该 request / connection / Agent action 真正需要的 service。
 
-当前证据**不**要求：
+Persistent session ownership 仍然通过 `ctx.multiTenant`；contextual identity 永远不替代 durable authorization。
 
-- kernel 改动；
-- 新的全局 setup contribution registry；
-- 永久 fork 或重写 DSH Web transport；
-- 把 JWT/OIDC/API-key 逻辑塞进 kernel；
-- 在 v0.1 中把 DSH host-global resource 强行变成 tenant-owned。
+## Web Spike Code 的复用原则
 
-principal-scoped connection path 存在以后，`respond` 可能需要 correlation state。那是届时要验证的 enforcement detail，不是现在提前扩大 upstream proposal 的理由。
+以下已有能力可以在自然适配 v0.3 结构时复用：
 
-## 下一步
+- `ApiProxy` exhaustive method classification；
+- guard / filter / deny policy mechanics；
+- unknown / global surface 的 fail-closed 处理；
+- 证明 cross-tenant visibility restriction 的测试。
 
-1. **发布主线：** 对 RC7 刷新受影响的 admission/ApiProxy evidence；这已经足够形成 kernel compatibility baseline。
-2. **生态主线：** 提交小型 request/connection-scope upstream proposal，并附带并发隔离与 HTTP/WS lifetime 的 conformance expectation。
-3. **足够 seam 存在以后：** 再把 `dsh-multi-tenant-web` 变成 production plugin，并通过 two-tenant E2E 一起证明 unary/admission/mux/host/respond。
+不要为了保留旧代码增加 compatibility shim、global ambient principal state 或 parallel tenant registry。如果一个新的 v0.3 transport adapter 更简单、语义更强，就直接替换 spike。
 
-Production Web enforcement 不再阻塞第一次 `dsh-multi-tenant` kernel prerelease。
+## 当前 Evidence
+
+- Agent / Session publication seam：[`../specs/session-genesis-map.zh-CN.md`](../specs/session-genesis-map.zh-CN.md)
+- Agent setup composition：[`../specs/admission-composition.zh-CN.md`](../specs/admission-composition.zh-CN.md)
+- 历史 Web seam map：[`../specs/web-seam-map.zh-CN.md`](../specs/web-seam-map.zh-CN.md)
+- 当前 Runtime architecture：[`../specs/architecture.zh-CN.md`](../specs/architecture.zh-CN.md)
+- 当前产品方向：[`../../ROADMAP.zh-CN.md`](../../ROADMAP.zh-CN.md)
+
+当前精确 DSH baseline 与 executable probes 见 [`../reference/compatibility.zh-CN.md`](../reference/compatibility.zh-CN.md)。

--- a/docs/reference/compatibility.md
+++ b/docs/reference/compatibility.md
@@ -2,101 +2,89 @@
 
 # Compatibility & versioning policy
 
-## Runtime
+## Runtime baseline
 
-- **Node** `^22.19.0 || >=24.0.0` — aligned with the current DeepSeek Harness RC7 engine policy.
-- **Cordis** `@deepseek-ai/cordis` `>= 4.0.1 < 5` (peer).
+- **Node:** `^22.19.0 || >=24.0.0`
+- **Cordis peer:** `@deepseek-ai/cordis >=4.0.1 <5`
+- **DSH:** explicit baseline only; never a floating dependency
 
-CI exercises both the minimum supported Node 22 line (`22.19.0`) and Node 24.
+CI exercises Node `22.19.0` and Node `24.x`.
 
-## Current DSH target
+## Current DSH baseline
 
-The executable compatibility target is centralized in `scripts/dsh-target.mjs`:
+`scripts/dsh-target.mjs` is the single source of truth:
 
-- **DeepSeek Harness:** `0.1.0-rc.7`
-- **RC7 release commit:** `99f6f02fecdb7dff40c3fbc9470f5907c29f74ca`
+```js
+DSH_TARGET = {
+  repository: 'deepseek-ai/deepseek-harness',
+  version: '0.1.1-rc.2',
+  commit: 'b150a551b8d465e31e418e1b2eaf5e79bbb7d28e',
+}
+```
 
-DSH-facing package pins and runtime probes must use that target. `pnpm verify`
-checks the Web proof package pin so a future prerelease bump cannot update only
-one place and silently leave stale evidence behind.
+This was the current DeepSeek Harness release when the v0.2 convergence baseline was selected. Future upgrades are manual and explicit; blocking CI does not auto-follow npm `latest` or upstream `master`.
 
-## RC7 evidence refresh (R1)
+## Evidence model
 
-R1 selectively revalidated the DSH seams used by this repository instead of
-redesigning unaffected layers.
+Compatibility is proven from two independent directions.
 
-Static RC6 → RC7 review:
+### Exact upstream source identity
 
-| Evidence surface | RC7 source blob | Result |
-| --- | --- | --- |
-| `RpcMethodMap` (`packages/host/apiproxy/src/api/rpc-map.ts`) | `80dede179913fc3f96bc32e71e77c75ee8460cf9` | unchanged from RC6 |
-| AgentLoop entry (`packages/core/agent-loop/src/index.ts`) | `371154a7c9e849a444a4806268e4b2d861b8f22b` | unchanged from RC6 |
-| Session service entry (`packages/core/session/src/index.ts`) | `2d82a88623cf8b8d381f9ba905ba2e7088cbfe12` | unchanged from RC6 |
+GitHub Actions checks out the pinned upstream repository at the exact release commit and verifies:
 
-Executable RC7 evidence:
+- checkout HEAD equals `DSH_TARGET.commit`;
+- upstream root `package.json.version` equals `DSH_TARGET.version`.
 
-- `scripts/session-genesis-probe.mjs` installs the target `dsh-session` in a
-  clean temporary consumer and asserts the publication/rollback behavior used by
-  the genesis analysis.
-- `scripts/admission-decorator-probe.mjs` installs the target Agent/AgentLoop/
-  Session packages and asserts admission-before-`sessions.enter` for create,
-  fork, subagent, and resume.
-- the real `RpcMethodMap` remains compile-time exhaustive through
-  `Record<keyof RpcMethodMap, Category>` in `dsh-multi-tenant-web`; normal CI
-  typechecking therefore fails if the DSH unary surface changes without a new
-  classification.
+This establishes which source tree our architectural conclusions refer to.
 
-These runtime probes are first-class CI gates via `pnpm probe:dsh`, not manual
-release notes.
+### Exact published-package behavior
 
-## Target vs historical evidence
+`pnpm probe:dsh` installs the exact published DSH npm versions into clean temporary consumers and executes:
 
-"Target" is not permission to rewrite historical evidence. An RC6 proof remains
-labelled RC6 in the document that recorded it; R1 adds new RC7 evidence on top.
-When DSH moves again, identify the changed seams, rerun only the affected probes
-or conformance checks, and update the centralized target explicitly.
+- **session genesis proof** — publication visibility and rollback semantics;
+- **admission/publication proof** — create/fork/subagent/resume setup before session entry;
+- **Agent owner/composition proof** — a Principal-derived integration fiber reaches DSH Agent creation as caller-bound `ownerCtx` while preserving tenant/principal identity and capability resolution.
 
-A version bump is a compatibility exercise, not a reason to absorb upstream
-responsibilities into this repository. If the new version exposes a needed
-seam, use it. If a seam is ecosystem-owned but still missing, define the
-smallest reusable standard / upstream proposal. If no reliable enforcement
-point exists, document the boundary rather than inventing a brittle local fork.
+The Web proof package also pins `@deepseek-ai/dsh-host-apiproxy` to the same target version, enforced by `pnpm verify`.
 
-## DSH prerelease pinning
+## Manual baseline refresh
 
-**Never depend on an unqualified `latest` tag for DSH prereleases.** Pin an
-explicit prerelease version and record the DSH commit SHA / release used by any
-package types, runtime probe, or architectural conclusion.
+When we intentionally move DSH forward:
 
-When DSH moves to a new prerelease:
+1. select the explicit DSH version and release commit;
+2. update `scripts/dsh-target.mjs`;
+3. update DSH-facing package pins to the same version;
+4. regenerate `pnpm-lock.yaml` from the real npm registry;
+5. rerun source-identity verification and all executable compatibility probes;
+6. fix contract failures structurally rather than weakening evidence;
+7. update current docs to describe the selected baseline.
 
-1. update `scripts/dsh-target.mjs`;
-2. identify which DSH-facing seams changed;
-3. refresh the lockfile from the explicit prerelease pin;
-4. rerun only the probes / conformance checks that cover those seams; and
-5. leave unrelated layers alone.
+Historical release notes keep the versions they actually proved.
 
-## CI compatibility gates
+## Compatibility philosophy
 
-Pull requests and `main` run:
+This project is in rapid prerelease development. We do not preserve early API shapes when they conflict with a better ownership model, stronger semantic types or clearer lifecycle/state transitions.
 
+Compatibility work follows three rules:
+
+- where this repository owns a boundary, enforce it;
+- where DSH/provider ecosystems own the seam, define or consume a reusable contract;
+- where neither provides a reliable boundary, document the limitation instead of hiding it behind a local fork or parallel registry.
+
+## CI gates
+
+Pull requests and `main` require:
+
+- exact upstream DSH source baseline verification;
 - frozen-lockfile installation;
-- architecture/package verification (`pnpm verify`), including DSH pin drift;
-- typecheck, unit/contract tests, build, and packed external-consumer smoke;
-- real DSH runtime proofs (`pnpm probe:dsh`);
-- the supported Node 22.19 and Node 24 lines.
-
-The packed smoke installs the produced kernel tarball into a clean temporary
-consumer and exercises its public subpaths, so CI checks the distributable rather
-than only workspace source.
-
-## Toolchain
-
-- **pnpm** `>= 11` (CI currently uses pnpm 11).
-- **TypeScript** `>= 6.0` (build baseline; `tsconfig.base.json`).
+- package/architecture invariants (`pnpm verify`);
+- release manifest preflight;
+- TypeScript typecheck;
+- unit and contract tests;
+- build;
+- packed external-consumer smoke;
+- exact-version DSH runtime probes on Node 22.19 and Node 24.
 
 ## Kernel invariant
 
-The kernel depends on Cordis only — no transport/vendor runtime dependencies
-(JWT / PostgreSQL / HTTP / MCP / Redis). Enforced by
-`scripts/verify-packages.mjs` (CI gate), not by convention.
+The public runtime package depends on Cordis only. Transport/vendor implementations such as JWT, databases, HTTP, MCP or Redis do not belong in the core Runtime Contract. Provider families and SaaS composition are layered above it.

--- a/docs/reference/compatibility.zh-CN.md
+++ b/docs/reference/compatibility.zh-CN.md
@@ -1,79 +1,90 @@
 [English](./compatibility.md) | 简体中文
 
-# 兼容性与版本政策
+# Compatibility & Versioning Policy
 
-## 运行时
+## Runtime Baseline
 
-- **Node** `^22.19.0 || >=24.0.0` —— 与当前 DeepSeek Harness RC7 的 engine policy 对齐。
-- **Cordis** `@deepseek-ai/cordis` `>= 4.0.1 < 5`（peer）。
+- **Node：** `^22.19.0 || >=24.0.0`
+- **Cordis peer：** `@deepseek-ai/cordis >=4.0.1 <5`
+- **DSH：** 只使用显式 baseline，不依赖 floating version
 
-CI 同时覆盖最低支持的 Node 22 版本（`22.19.0`）与 Node 24。
+CI 同时覆盖 Node `22.19.0` 与 Node `24.x`。
 
-## 当前 DSH 目标
+## 当前 DSH Baseline
 
-可执行的兼容性目标统一定义在 `scripts/dsh-target.mjs`：
+`scripts/dsh-target.mjs` 是唯一 source of truth：
 
-- **DeepSeek Harness：** `0.1.0-rc.7`
-- **RC7 release commit：** `99f6f02fecdb7dff40c3fbc9470f5907c29f74ca`
+```js
+DSH_TARGET = {
+  repository: 'deepseek-ai/deepseek-harness',
+  version: '0.1.1-rc.2',
+  commit: 'b150a551b8d465e31e418e1b2eaf5e79bbb7d28e',
+}
+```
 
-所有面向 DSH 的 package pin 与 runtime probe 都必须使用这个目标。`pnpm verify`
-会检查 Web proof package 的版本 pin，避免下一次 prerelease 只更新一处、却把旧 evidence 静默留下。
+这是 v0.2 收口时选定的 DeepSeek Harness 当前 release。未来升级由我们手动、显式推进；blocking CI 不会自动跟随 npm `latest` 或 upstream `master`。
 
-## RC7 evidence refresh（R1）
+## Evidence Model
 
-R1 按受影响 seam 定向复验，而不是重新设计没有变化的层。
+Compatibility 从两个独立方向证明。
 
-RC6 → RC7 静态核对：
+### 精确 Upstream Source Identity
 
-| Evidence surface | RC7 source blob | 结果 |
-| --- | --- | --- |
-| `RpcMethodMap`（`packages/host/apiproxy/src/api/rpc-map.ts`） | `80dede179913fc3f96bc32e71e77c75ee8460cf9` | 与 RC6 相同 |
-| AgentLoop 入口（`packages/core/agent-loop/src/index.ts`） | `371154a7c9e849a444a4806268e4b2d861b8f22b` | 与 RC6 相同 |
-| Session service 入口（`packages/core/session/src/index.ts`） | `2d82a88623cf8b8d381f9ba905ba2e7088cbfe12` | 与 RC6 相同 |
+GitHub Actions checkout 精确 upstream release commit，并验证：
 
-RC7 可执行证据：
+- checkout HEAD 等于 `DSH_TARGET.commit`；
+- upstream root `package.json.version` 等于 `DSH_TARGET.version`。
 
-- `scripts/session-genesis-probe.mjs` 在干净临时 consumer 中安装目标 `dsh-session`，并断言 genesis 分析依赖的 publication / rollback 行为。
-- `scripts/admission-decorator-probe.mjs` 安装目标 Agent / AgentLoop / Session 包，并断言 create、fork、subagent、resume 四条路径都在 `sessions.enter` 前完成 admission。
-- `dsh-multi-tenant-web` 继续通过 `Record<keyof RpcMethodMap, Category>` 对真实 `RpcMethodMap` 做编译期穷举；因此 DSH unary surface 新增或变化而没有分类时，正常 CI typecheck 会直接失败。
+这明确了我们的架构结论究竟对应哪一份源码。
 
-这些 runtime probe 现在通过 `pnpm probe:dsh` 成为正式 CI gate，而不是依赖人工 release note。
+### 精确 Published-Package Behavior
 
-## 目标版本与历史证据
+`pnpm probe:dsh` 在干净的临时 consumer 中安装精确 DSH npm 版本并执行：
 
-“当前 target”不意味着可以改写历史。记录 RC6 proof 的文档继续标记 RC6；R1 是在其上增加 RC7 evidence。下一次 DSH 再升级时，先识别真正变化的 seam，只重新运行受影响的 probe / conformance check，并显式更新统一 target。
+- **session genesis proof** —— publication visibility 与 rollback 语义；
+- **admission/publication proof** —— create/fork/subagent/resume 的 setup 必须先于 session entry；
+- **Agent owner/composition proof** —— Principal-derived integration fiber 通过 caller-bound `ownerCtx` 进入真实 DSH Agent creation，同时保持 tenant/principal identity 与 capability resolution。
 
-版本升级是兼容性工作，不是把上游责任吸收到本仓库里的理由。如果新版本暴露了需要的 seam，就直接使用；如果 seam 属于生态但仍缺失，就定义最小、可复用的标准 / 上游提案；如果没有可靠 enforcement point，就明确边界，而不是制造脆弱的本地 fork。
+Web proof package 也把 `@deepseek-ai/dsh-host-apiproxy` 固定到同一个 target version，并由 `pnpm verify` 强制一致。
 
-## DSH prerelease pinning
+## 手动 Baseline Refresh
 
-**DSH prerelease 绝不依赖未限定的 `latest` tag。** 显式 pin prerelease 版本，并为 package type、runtime probe 或架构结论记录实际对应的 DSH commit SHA / release。
+当我们明确决定升级 DSH 时：
 
-当 DSH 推进到新的 prerelease 时：
+1. 选择明确的 DSH version 与 release commit；
+2. 更新 `scripts/dsh-target.mjs`；
+3. 所有 DSH-facing package pin 同步到该 version；
+4. 使用真实 npm registry 重新生成 `pnpm-lock.yaml`；
+5. 重跑 source identity verification 与全部 executable probes；
+6. 如果 contract 失败，从工程结构 / 数据结构 / 状态流转上修正，不削弱 evidence；
+7. 当前文档统一更新到新 baseline。
 
-1. 更新 `scripts/dsh-target.mjs`；
-2. 识别哪些面向 DSH 的 seam 真正变化；
-3. 从显式 prerelease pin 刷新 lockfile；
-4. 只重跑覆盖这些 seam 的 probe / conformance check；
-5. 与此次变化无关的层保持不动。
+历史 release note 保留当时真正验证过的版本。
 
-## CI 兼容性门
+## Compatibility Philosophy
 
-Pull request 与 `main` 都运行：
+项目处于快速 prerelease 开发期。如果早期 API 与更好的 ownership model、semantic type、lifecycle/state transition 冲突，我们不会为了兼容保留旧形态。
 
-- frozen-lockfile 安装；
-- 架构/package 验证（`pnpm verify`），其中包含 DSH pin 漂移检查；
-- typecheck、unit/contract test、build、真实 packed external-consumer smoke；
-- 真实 DSH runtime proof（`pnpm probe:dsh`）；
-- Node 22.19 与 Node 24 两条支持线。
+Compatibility 工作遵循三条原则：
 
-packed smoke 会把生成的 kernel tarball 安装到一个干净临时 consumer，并实际调用公开 subpath，因此 CI 检查的是可发布产物，而不仅是 workspace 源码。
+- 仓库自己拥有的边界，严格 enforce；
+- DSH / provider 生态拥有的 seam，定义或消费可复用 contract；
+- 没有可靠 enforcement point 的地方，明确记录 boundary，不用本地 fork 或平行 registry 掩盖问题。
 
-## 工具链
+## CI Gates
 
-- **pnpm** `>= 11`（CI 当前使用 pnpm 11）。
-- **TypeScript** `>= 6.0`（构建基线；`tsconfig.base.json`）。
+PR 与 `main` 必须通过：
 
-## 内核不变量
+- 精确 upstream DSH source baseline verification；
+- frozen-lockfile install；
+- package / architecture invariant（`pnpm verify`）；
+- release manifest preflight；
+- TypeScript typecheck；
+- unit / contract tests；
+- build；
+- packed external-consumer smoke；
+- Node 22.19 / Node 24 上的精确版本 DSH runtime probes。
 
-内核只依赖 Cordis —— 无 transport/vendor 运行时依赖（JWT / PostgreSQL / HTTP / MCP / Redis）。由 `scripts/verify-packages.mjs`（CI 门）强制，而非靠约定。
+## Kernel Invariant
+
+公开 runtime package 的运行时依赖只允许 Cordis。JWT、数据库、HTTP、MCP、Redis 等 vendor / transport implementation 不进入 core Runtime Contract；Provider Family 与 SaaS composition 在其上层组合。

--- a/docs/reference/release.md
+++ b/docs/reference/release.md
@@ -1,59 +1,46 @@
 [简体中文](./release.zh-CN.md) | English
 
-# Kernel prerelease contract
+# Release contract
 
-The kernel has a real published prerelease line. This reference defines the
-current release artifact and the mechanical proof required before publication.
+The project is in rapid prerelease development. Release mechanics are intentionally simple and deterministic.
 
 ## Current artifact
 
 - **Package:** `dsh-multi-tenant`
-- **Candidate:** `0.1.0-rc.2`
-- **npm dist-tag:** `next`
-- **DSH compatibility target:** `0.1.0-rc.7`
-- **Node:** `^22.19.0 || >=24.0.0`
-- **Publishing:** npm Trusted Publishing / GitHub Actions OIDC
+- **Current version:** read from `packages/multi-tenant/package.json`
+- **Current candidate:** `0.2.0-rc.3`
+- **npm dist-tag:** `latest`
+- **DSH baseline:** `0.1.1-rc.2` @ `b150a551b8d465e31e418e1b2eaf5e79bbb7d28e`
+- **Publishing:** npm Trusted Publishing through GitHub Actions OIDC
 - **Provenance:** enabled
 
-`dsh-multi-tenant-web` remains private and is not part of this release.
+`dsh-multi-tenant-web` remains private.
 
-## Why rc.2 exists
+## Single source of truth
 
-`0.1.0-rc.1` successfully established the first public artifact, registry smoke,
-provenance, tag, and GitHub prerelease. Before freezing a stable 0.1 contract,
-rc.2 removes one speculative public field: `TenantPrincipal.roles`.
+The package manifest owns release identity:
 
-The ownership kernel never consumed roles. Keeping the required field would have
-made every caller carry RBAC vocabulary that this package explicitly does not
-own. The principal is therefore reduced to the identity the kernel actually
-enforces:
-
-```ts
-interface TenantPrincipal {
-  tenantId: string
-  userId: string
-}
+```text
+packages/multi-tenant/package.json
+  ├─ version
+  └─ publishConfig.tag = latest
 ```
 
-Roles/permissions/admin policy belong to a separate policy plane if a real use
-case later requires them.
+The release workflow does not ask the operator to retype a version. Manual dispatch from `main` reads the manifest, verifies the repository, runs the complete release proof and publishes exactly that version.
 
-## Release guarantee
+## One npm channel
 
-The artifact guarantees only the kernel-owned contract: opaque tenant/user
-identity, claim-once immutable session ownership, unconditional cross-tenant
-denial, v0.1 same-user ownership, fail-closed unknown/foreign-session
-authorization, non-enumerating public denial, and the replaceable async
-`TenantSessionStore` contract plus shared provider test suite.
+During the current rapid-iteration phase, the project maintains a single npm channel:
 
-The bundled `InMemoryTenantSessionStore` is a reference/bootstrap provider, not
-production durability.
+> `latest` = the newest version the project has intentionally published.
 
-## Explicit boundary
+Prerelease/stable meaning is expressed by SemVer itself (`0.2.0-rc.3`, later `0.2.0`, etc.), not by maintaining a second `next` channel.
 
-The prerelease does not claim authentication, production DSH Web multi-user
-isolation, durable storage, MCP credential/context isolation, audit persistence,
-team ACLs, general RBAC, or shell/filesystem/process/container/network isolation.
+Install the current release with:
+
+```sh
+dsh plugin --profile <profile> add dsh-multi-tenant
+```
 
 ## Pre-publication proof
 
@@ -64,39 +51,38 @@ pnpm install --frozen-lockfile
 pnpm release:check
 ```
 
-The release workflow reruns this proof from `main` before touching npm.
+The proof includes package/architecture invariants, release preflight, TypeScript typecheck, unit/contract tests, build, packed external-consumer smoke and exact-version DSH compatibility probes.
 
-## OIDC-only publication
+CI separately checks out the exact upstream DSH release commit and verifies its source version.
 
-Publication is implemented by `.github/workflows/release.yml` and is manual
-(`workflow_dispatch`). The operator types the exact package version and dispatches
-from `main`. The job runs in the `npm-release` GitHub Environment with
-`id-token: write` and no npm publish token fallback.
+## Publication flow
 
-The workflow:
+`.github/workflows/release.yml` is manually dispatched from `main` and:
 
-1. validates branch/version and npm trusted-publishing capability;
-2. runs `release:check`;
-3. checks npm package ownership and exact-version state;
-4. publishes through npm Trusted Publishing/OIDC only when the version is absent;
-5. verifies `next`, repository metadata, integrity, and a clean external consumer;
-6. creates the matching Git tag and GitHub prerelease only after registry smoke succeeds.
+1. reads `packages/multi-tenant/package.json.version` into one release identity;
+2. validates npm Trusted Publishing capability;
+3. performs frozen install and `pnpm release:check`;
+4. checks npm repository ownership and whether the exact version already exists;
+5. publishes with npm OIDC/provenance when needed;
+6. verifies the exact registry artifact and that `latest` resolves to it;
+7. creates the matching Git tag and GitHub release.
 
-It is safe to rerun: an existing matching npm version skips duplicate publish and
-continues verification/tag/release recovery.
+The workflow is idempotent for an already-published exact version: publication is skipped, while verification/tag/release recovery can continue.
 
-The first-publication bootstrap token used for rc.1 is no longer part of the
-workflow. Maintainers should remove/revoke any remaining bootstrap credential.
+## Registry proof
 
-## Post-publication verification
+`scripts/registry-smoke.mjs` installs the exact published artifact into a clean consumer and exercises the current Runtime Contract, including:
 
-The workflow runs `scripts/registry-smoke.mjs` against the exact version. A human
-can additionally verify DSH installation with:
+- store + ownership kernel;
+- `ctx.tenantRuntime`;
+- canonical Tenant/Principal creation;
+- tenant capability inheritance;
+- durable session ownership from a Principal Context;
+- provider store contract;
+- npm `latest` pointing to the released version.
 
-```sh
-dsh plugin --profile <profile> add dsh-multi-tenant@next
-```
+## Release philosophy
 
-After rc.2, the project should prefer observation and real feedback over adding
-more speculative kernel API. Barring a real bug or upstream compatibility change,
-the next release decision is whether the contract is ready for `0.1.0` stable.
+Release automation should protect correctness without creating process ceremony. Current development prefers frequent, explicit releases over maintaining multiple channels or compatibility promises that slow structural improvement.
+
+If a better ownership model, data structure, lifecycle state machine or semantic type requires a breaking prerelease change, change the model and release the new version.

--- a/docs/reference/release.zh-CN.md
+++ b/docs/reference/release.zh-CN.md
@@ -1,78 +1,88 @@
 [English](./release.md) | 简体中文
 
-# Kernel prerelease 发布契约
+# Release Contract
 
-Kernel 已经拥有真实公开的 prerelease 版本线。本文档定义当前 release artifact，以及发布前必须通过的机械化证明。
+项目处于快速 prerelease 开发期，发布机制刻意保持简单、确定、可复现。
 
-## 当前 artifact
+## 当前 Artifact
 
 - **Package：** `dsh-multi-tenant`
-- **Candidate：** `0.1.0-rc.2`
-- **npm dist-tag：** `next`
-- **DSH compatibility target：** `0.1.0-rc.7`
-- **Node：** `^22.19.0 || >=24.0.0`
-- **Publishing：** npm Trusted Publishing / GitHub Actions OIDC
+- **当前 version：** 从 `packages/multi-tenant/package.json` 读取
+- **当前 candidate：** `0.2.0-rc.3`
+- **npm dist-tag：** `latest`
+- **DSH baseline：** `0.1.1-rc.2` @ `b150a551b8d465e31e418e1b2eaf5e79bbb7d28e`
+- **Publishing：** GitHub Actions OIDC + npm Trusted Publishing
 - **Provenance：** enabled
 
-`dsh-multi-tenant-web` 继续保持 private，不属于本次 release。
+`dsh-multi-tenant-web` 继续保持 private。
 
-## 为什么需要 rc.2
+## Single Source of Truth
 
-`0.1.0-rc.1` 已经成功建立第一个公开 artifact，并完成 registry smoke、provenance、Git tag 与 GitHub prerelease。进入 stable 0.1 以前，rc.2 做最后一次主动 API subtraction：删除 `TenantPrincipal.roles`。
+Package manifest 拥有 release identity：
 
-Ownership kernel 从未读取 roles。继续把它作为 required public field，会迫使每个调用方携带一个本 package 明确不拥有的 RBAC vocabulary。因此 principal 收敛到 kernel 真正强制的 identity：
-
-```ts
-interface TenantPrincipal {
-  tenantId: string
-  userId: string
-}
+```text
+packages/multi-tenant/package.json
+  ├─ version
+  └─ publishConfig.tag = latest
 ```
 
-未来如果真实需求需要 roles / permissions / admin policy，应进入独立 policy plane。
+Release workflow 不再让操作者重复输入 version。只需要从 `main` 手动 dispatch，workflow 自动读取 manifest、执行完整验证并发布该版本。
 
-## Release guarantee
+## 单一 npm Channel
 
-Artifact 只承诺 kernel 自己拥有的 contract：opaque tenant/user identity、claim-once 不可变 session ownership、无条件 cross-tenant denial、v0.1 same-user ownership、fail-closed unknown/foreign-session authorization、不可枚举公开 denial，以及可替换 async `TenantSessionStore` contract 与共享 provider test suite。
+当前快速迭代阶段只维护一个 npm channel：
 
-内置 `InMemoryTenantSessionStore` 是 reference/bootstrap provider，不提供 production durability。
+> `latest` = 项目明确选择发布的最新版本。
 
-## 明确边界
+Prerelease / stable 语义由 SemVer 本身表达（例如 `0.2.0-rc.3`，以后可能是 `0.2.0`），不再额外维护 `next`。
 
-本 prerelease 不声称提供 authentication、production DSH Web 多用户隔离、durable storage、MCP credential/context isolation、audit persistence、team ACL、general RBAC，也不提供 shell/filesystem/process/container/network isolation。
+安装当前版本：
 
-## 发布前验证
+```sh
+dsh plugin --profile <profile> add dsh-multi-tenant
+```
+
+## Pre-publication Proof
+
+干净 checkout 上执行：
 
 ```sh
 pnpm install --frozen-lockfile
 pnpm release:check
 ```
 
-真正 publish 前，release workflow 会从 `main` 再完整执行一次。
+完整 proof 包括 package / architecture invariant、release preflight、TypeScript typecheck、unit / contract tests、build、packed external-consumer smoke 与精确版本 DSH compatibility probes。
 
-## OIDC-only 发布
+CI 还会独立 checkout 精确 upstream DSH release commit 并验证源码 version。
 
-发布由 `.github/workflows/release.yml` 完成，并刻意保持手工 `workflow_dispatch`。操作者必须输入精确 package version，并从 `main` 触发。Job 运行在 `npm-release` GitHub Environment 中，具备 `id-token: write`，**不再存在 npm publish token fallback**。
+## Publication Flow
 
-Workflow 会：
+`.github/workflows/release.yml` 从 `main` 手动 dispatch，并依次：
 
-1. 核对 branch/version 与 npm trusted-publishing capability；
-2. 跑完整 `release:check`；
-3. 核对 npm package ownership 与精确 version 状态；
-4. version 不存在时，仅通过 npm Trusted Publishing/OIDC publish；
-5. 验证 `next`、repository metadata、integrity，并在干净 external consumer 中安装调用；
-6. registry smoke 成功以后才创建匹配的 Git tag 与 GitHub prerelease。
+1. 从 `packages/multi-tenant/package.json.version` 得到唯一 release identity；
+2. 验证 npm Trusted Publishing capability；
+3. frozen install + `pnpm release:check`；
+4. 检查 npm repository ownership 与 exact version 是否已存在；
+5. 需要时通过 OIDC / provenance 发布；
+6. 验证 exact registry artifact，并确认 `latest` 指向该版本；
+7. 创建 matching Git tag 与 GitHub release。
 
-Workflow 可安全重跑：如果匹配版本已经存在，会跳过重复 publish，继续完成 verification/tag/release recovery。
+如果 exact version 已发布，workflow 会跳过重复 publish，但仍可继续 verification / tag / release recovery。
 
-rc.1 首次发布使用过的 bootstrap token 已经不再属于 workflow。维护者应删除/revoke 任何仍然存在的 bootstrap credential。
+## Registry Proof
 
-## 发布后验证
+`scripts/registry-smoke.mjs` 会把精确发布 artifact 安装到干净 consumer，并验证当前 Runtime Contract：
 
-Workflow 会对精确版本运行 `scripts/registry-smoke.mjs`。还可以人工使用 DSH 验证：
+- store + ownership kernel；
+- `ctx.tenantRuntime`；
+- canonical Tenant / Principal creation；
+- tenant capability inheritance；
+- 从 Principal Context 执行 durable session ownership；
+- provider store contract；
+- npm `latest` 指向当前 release。
 
-```sh
-dsh plugin --profile <profile> add dsh-multi-tenant@next
-```
+## Release Philosophy
 
-rc.2 以后，项目应该优先观察真实使用反馈，不再给 kernel 增加推测性 API。除非出现真实 bug 或 upstream compatibility change，否则下一次 release decision 应该是判断是否进入 `0.1.0` stable。
+Release automation 的目标是保护 correctness，而不是制造流程负担。当前阶段优先 frequent explicit release，不维护多个 channel，也不为了兼容承诺阻碍结构优化。
+
+如果更好的 ownership model、数据结构、lifecycle state machine 或 semantic type 需要 prerelease breaking change，就直接改模型并发布新版本。

--- a/docs/releases/v0.2.0-rc.2.md
+++ b/docs/releases/v0.2.0-rc.2.md
@@ -1,0 +1,111 @@
+# dsh-multi-tenant v0.2.0-rc.2
+
+`0.2.0-rc.2` converges the v0.2 runtime contract around one canonical ownership tree and one publication/lifecycle vocabulary.
+
+## Why this release exists
+
+`0.2.0-rc.1` proved the architecture: Tenant/Principal Cordis capability scopes can coexist with the frozen v0.1 ownership kernel and with DSH's separate Agent/Preset scope plane.
+
+`0.2.0-rc.2` makes that architecture safe to depend on from the future SaaS Framework. The prerelease API is intentionally broken where necessary; no compatibility shim is carried forward.
+
+## Canonical runtime tree
+
+```text
+Root -> Tenant -> Principal -> DSH Agent
+```
+
+Tenant and Principal nodes now share the same structural contract:
+
+- immutable `identity`;
+- `kind`;
+- scoped `ctx`;
+- `state` (`active | disposing | disposed`);
+- idempotent quiescent `dispose()`;
+- canonical registry with `ensure()` and `get()`.
+
+Principal identity is structurally nested below its Tenant: callers key the Principal registry by `userId`, so a mismatched tenant id is no longer representable at that boundary.
+
+## Atomic publication
+
+A new scope is not visible while it is being prepared.
+
+Creation follows:
+
+```text
+reserve canonical key
+        ↓
+private Cordis subtree
+        ↓
+setup (awaitable)
+        ↓
+optional synchronous commit()
+        ↓
+publish active node
+```
+
+Guarantees:
+
+- `get()` never returns a preparing node;
+- concurrent `ensure()` calls for one key single-flight;
+- setup failure disposes the unpublished subtree and clears the canonical reservation;
+- a clean retry can recreate the same key;
+- an already-active node rejects a different isolated-service definition;
+- Tenant teardown owns/drains Principal teardown before its own quiescence.
+
+The optional synchronous publication commit mirrors the same semantic boundary used by DSH Agent setup: asynchronous preparation happens privately, then mutable external state may be revalidated/flipped immediately before visibility.
+
+## DSH Agent composition boundary
+
+This release deliberately does **not** claim that `Agent.ctx` directly inherits the Principal Cordis service graph.
+
+Current DSH Agent creation carries the `ctx.agents.create()` caller Context to the Agent factory as `ownerCtx`, while AgentLoop owns a separate Agent runtime/registration scope. v0.2 follows that real architecture:
+
+- Principal Context is the Agent creation owner/composition boundary;
+- Tenant/Principal capabilities remain on the Cordis capability plane;
+- Agent `setup` explicitly projects/composes the capabilities needed by Agent-local tools, prompts and listeners;
+- Agent/Preset `dsh-scope` ancestry remains untouched.
+
+A new compatibility probe executes the real `@deepseek-ai/dsh-agent` registry API at the pinned DSH target and proves A/B Principal owner contexts and capability separation through `ctx.agents.create()`.
+
+## Executable Tenant-Safe Provider Contract
+
+`dsh-multi-tenant/testing` now exports `assertRuntimeCapabilityProviderContract()`.
+
+Provider authors can declare tenant- or principal-level capability scope and automatically verify:
+
+- same-name A/B isolation;
+- root/parent non-leakage;
+- descendant inheritance;
+- sibling non-interference;
+- disposal isolation;
+- clean recreation without stale state;
+- provider mounting inside the unpublished setup transaction.
+
+This is the foundation for the future Plugin Family: the Framework can choose opinionated default providers while every slot remains replaceable by implementations that pass the same contract.
+
+## Kept from v0.1 / rc.1
+
+- immutable session ownership;
+- fail-closed `ctx.multiTenant` authorization;
+- replaceable `TenantSessionStore` contract;
+- reserved shared security/kernel services;
+- Cordis Tenant/Principal service isolation;
+- explicit strong-isolation boundary at process/container/Pod level.
+
+## Intentionally not added
+
+This release does not add product-level Auth, HTTP/WebSocket binding, billing, organization UI, production MCP SaaS integration, or a second DI container. Those belong to the future SaaS Framework / Plugin Family after the runtime contract is closed.
+
+## Verification
+
+The release gate includes:
+
+- canonical publication and rollback tests;
+- concurrent `ensure()` single-flight tests;
+- canonical Principal lifecycle tests;
+- disposal/recreation tests;
+- provider conformance tests at Tenant and Principal levels;
+- real Cordis Loader integration;
+- packed external-consumer smoke;
+- DSH session/admission compatibility probes;
+- DSH Agent owner-context compatibility proof.

--- a/docs/releases/v0.2.0-rc.3.md
+++ b/docs/releases/v0.2.0-rc.3.md
@@ -1,0 +1,65 @@
+# dsh-multi-tenant 0.2.0-rc.3
+
+`0.2.0-rc.3` is the v0.2 convergence candidate: it brings the final canonical Runtime Contract onto the main release path, refreshes the DeepSeek Harness baseline, and simplifies publication for rapid iteration.
+
+## Runtime Contract
+
+The runtime is a canonical ownership tree:
+
+```text
+Root -> Tenant -> Principal -> derived integration fibers -> DSH operations
+```
+
+Tenant and Principal share one `ensure/get/state/dispose` vocabulary. Principal identity is structurally nested under Tenant. Creation is transactionally unpublished until setup/optional commit succeeds.
+
+Preparing creations are first-class cancellable lifecycle resources. Registry shutdown closes admission, cancels unpublished transactions, then drains published scopes. This avoids teardown waiting on work that only teardown itself can cancel.
+
+## Agent composition
+
+Principal Contexts remain capability roots. Operations needing extra services derive a Cordis integration fiber and explicitly inject those services. Agent creation therefore uses a Principal-derived fiber injecting `agents`; DSH carries the caller-bound Context into the Agent factory as `ownerCtx`.
+
+The project does not fake direct Tenant service inheritance into `Agent.ctx` or copy private Cordis isolation maps.
+
+## Provider contract
+
+`dsh-multi-tenant/testing` includes an executable Runtime Capability Provider Contract covering tenant/principal A/B isolation, parent/root leakage, inheritance, siblings, disposal, recreation and unpublished setup ownership.
+
+## DeepSeek Harness baseline
+
+The explicit compatibility baseline is refreshed to:
+
+- version: `0.1.1-rc.2`
+- release commit: `b150a551b8d465e31e418e1b2eaf5e79bbb7d28e`
+
+CI proves both the exact upstream source identity and behavior of the exact published npm packages. The baseline remains manually advanced; CI does not follow floating upstream state.
+
+## Release model
+
+The project now maintains one npm channel during rapid iteration:
+
+- package version is the single release identity;
+- npm dist-tag is `latest`;
+- the manual GitHub release workflow reads the version from `package.json` instead of asking for duplicate input;
+- registry smoke verifies `latest` resolves to the published version;
+- SemVer itself expresses prerelease/stable status.
+
+## Verification
+
+Before publication the release requires:
+
+- frozen dependency install;
+- package/architecture verification;
+- release manifest preflight;
+- TypeScript typecheck;
+- unit + contract tests;
+- build;
+- packed external-consumer smoke;
+- DSH source-baseline verification;
+- session genesis proof;
+- Agent admission/publication proof;
+- Agent owner/composition proof;
+- registry smoke after publication.
+
+## Next
+
+Once this candidate is merged and published, v0.2 is treated as the Runtime Contract foundation and the main development line moves to v0.3: an opinionated SaaS Framework assembled from a replaceable Plugin Family.

--- a/docs/specs/admission-composition.md
+++ b/docs/specs/admission-composition.md
@@ -1,116 +1,60 @@
 [简体中文](./admission-composition.zh-CN.md) | English
 
-# M3.0 — Agent Setup Admission Composition
+# Agent Setup Admission — historical investigation and current proof
 
-> Static proof of how a third-party Cordis plugin can reliably join every Agent
-> `setup`. Source read at `deepseek-ai/deepseek-harness` @
-> `47f943859bef60e4160492346772ded9b24f765a`. Runtime proof of the chosen
-> candidate landed in M4 (②-A) — see §5 and `scripts/admission-decorator-probe.mjs`.
+This document records the investigation that established DSH Agent `setup` as a usable before-publication composition window. It is historical evidence; current Runtime architecture lives in [`architecture.md`](./architecture.md).
 
-## 1. The composition mechanism
+## Historical finding
 
-The Web surface composes the agent's `setup` in `composeAgent`
-(`packages/host/apiproxy/src/api-proxy.ts`), a **private closure**:
+The original source investigation was performed against DeepSeek Harness commit:
 
-```ts
-async function composeAgent(presetId) {
-  const presets = ctx.get('agentPresets')
-  if (presets === undefined) {
-    return { setup: (agentCtx) => { installSelection(agentCtx) } }
-  }
-  const resolvedId = (await presets.resolve(presetId)).id
-  return { setup: async (agentCtx) => {
-    installSelection(agentCtx)          // model selection (hardcoded)
-    await presets.mount(agentCtx, resolvedId)  // preset composition
-  } }
-}
+`47f943859bef60e4160492346772ded9b24f765a`
+
+The important finding was not a particular private helper. It was the structural contract:
+
+```text
+Agent create/resume
+      ↓
+caller supplies setup
+      ↓
+Agent factory awaits setup while unpublished
+      ↓
+publication / registry entry
 ```
 
-`presets.mount` → `mountPreset(agentCtx, preset)`
-(`packages/preset/agent-presets/src/mount.ts`) mounts the preset's `cordis.yml`
-plugins into `agentCtx` via `agentCtx.plugin(PresetTree, config)`. The preset
-service is `AgentPresets extends Service` (`static inject = ['loader']`).
+That means tenant admission or other composition logic can participate before the Agent/Session becomes visible, provided it composes through the public Agent creation API rather than patching a private transport or SessionStore event.
 
-So the setup is a **composition window**, but its contents are fixed:
-`installSelection` + one preset's mount. There is **no global
-setup-contribution registry** a plugin can self-register into.
+## Current executable evidence
 
-## 2. Candidate evaluation
+`scripts/admission-decorator-probe.mjs` installs the exact current DSH baseline (`0.1.1-rc.2`) and proves setup-before-entry for all genesis shapes relevant to this repository:
 
-| Candidate | Mechanism | Unfailing (automatic)? | Verdict |
-| --- | --- | --- | --- |
-| **A** native preset composition | add the plugin to a preset's `cordis.yml` | ❌ user-config, not automatic | not unfailing |
-| **B** setup contribution registry | a registry plugins register into | — | **does not exist** |
-| **C** `ctx.agents` decorator | wrap the AgentService, prepend admission to `setup` | ✅ (if the wrap is installed) | **feasible** |
-| **D** upstream global setup middleware | DSH adds a contribution registry | ✅ | cleaner alternative |
+- create;
+- fork (`parentSession`);
+- subagent (`origin: 'subagent'` + parent);
+- resume.
 
-## 3. Candidate C in detail (feasible)
+The proof asserts the target Session is absent from the Session registry while the setup callback runs and present after successful publication.
 
-A plugin wraps `ctx.agents` (`AgentService`). `create`/`resume` receive
-`CreateAgentOptions` / `ResumeAgentOptions`, which carry the identity:
+## v0.2 interpretation
 
-- `options.sessionId` — the session id.
-- `options.meta.parentSession` — the parent for fork / subagent.
-- `options.resumeSessionId` — the resumed session.
+v0.2 no longer treats admission as a Web-specific decorator architecture. The broader structural model is:
 
-So the wrapped `create` prepends admission to the caller's `setup`:
-
-```ts
-create(options) {
-  const original = options.setup
-  options.setup = async (agentCtx) => {
-    await admission(options.sessionId, options.meta?.parentSession)  // claim/inherit
-    return original?.(agentCtx)
-  }
-  return originalAgents.create(options)
-}
+```text
+canonical Principal Runtime
+        ↓
+derived integration fiber
+        ↓ explicit inject
+DSH operation / Agent create
+        ↓
+DSH setup publication window
 ```
 
-Identity for each path:
+The Principal-derived operation Context supplies identity/capabilities; DSH owns Agent-local setup and registration scope.
 
-| Path | Identity source in `options` | Needs H3? |
-| --- | --- | --- |
-| create | caller principal | **yes** (not in `options`) |
-| fork / subagent | `meta.parentSession` → `getSessionOwner(parent)` | no |
-| resume | `resumeSessionId` → durable owner | no |
+This avoids both global `tenantId` plumbing and a second Agent-specific tenancy registry.
 
-This matches the M2 ADR: **only top-level create needs H3**.
+## Current authority
 
-## 4. Conclusion
-
-- The setup is a composition window, but **not a public seam**: `composeAgent`
-  is a private closure with a fixed `installSelection` + `mountPreset` body.
-- **C** (`ctx.agents` decorator) is the only plugin-side mechanism that is
-  *unfailing* and carries the identity via `options`; **A** is user-config, **B**
-  does not exist.
-- **D** (an upstream global setup-contribution middleware) is the cleaner
-  alternative if wrapping `ctx.agents` proves too invasive in M3.1. **M4 (②-A)
-  shows it is not required** — C holds at runtime.
-
-## 5. Runtime proof (M4 · ②-A)
-
-`scripts/admission-decorator-probe.mjs` wraps the **real** `AgentRegistry`
-(`ctx.agents`, `@deepseek-ai/dsh-agent`) and runs admission against the **real**
-`AgentLoop` (`@deepseek-ai/dsh-agent-loop@0.1.0-rc.6`) + `SessionStore`
-(`@deepseek-ai/dsh-session@0.1.0-rc.6`). The `llm` / `tools` / `systemPrompt`
-services are structurally injected but not exercised by the create → setup →
-enter path, so they are no-op stubs; `sessionPersistence` is a minimal stub for
-the resume path.
-
-Result — for all four genesis paths the admission ran inside `setup`, and the
-session was **not yet in the store** at admission time (i.e. before
-`sessions.enter`), then was present after create/resume resolved:
-
-| Path | Identity available in `options` | Admission before `sessions.enter` |
-| --- | --- | --- |
-| create | `sessionId` | ✅ |
-| fork | `meta.parentSession` | ✅ |
-| subagent | `meta.origin === 'subagent'` + `meta.parentSession` | ✅ |
-| resume | `resumeSessionId` | ✅ |
-
-This proves **C is composable** (a plugin can wrap `ctx.agents` and prepend to
-`setup`) and that the admission point is **before visibility** for every path.
-What it does *not* yet prove (②-C) is that a plugin installs the wrap
-*unfailingly before the host's own `create` calls* in a live deployment — that is
-the transport prototype's job. The upstream gap therefore remains **H3 only**
-(identity for top-level `create`), not a new admission seam.
+- Runtime ownership/lifecycle: [`architecture.md`](./architecture.md)
+- exact DSH baseline and probes: [`../reference/compatibility.md`](../reference/compatibility.md)
+- historical Session publication investigation: [`session-genesis-map.md`](./session-genesis-map.md)

--- a/docs/specs/admission-composition.zh-CN.md
+++ b/docs/specs/admission-composition.zh-CN.md
@@ -1,88 +1,60 @@
 [English](./admission-composition.md) | 简体中文
 
-# M3.0 — Agent Setup 准入组合
+# Agent Setup Admission —— 历史调查与当前可执行证据
 
-> 关于第三方 Cordis 插件如何可靠地加入每一次 Agent `setup` 的静态证明。源码阅读于 `deepseek-ai/deepseek-harness` @ `47f943859bef60e4160492346772ded9b24f765a`。所选候选的运行时证明已在 M4（②-A）完成 —— 见 §5 与 `scripts/admission-decorator-probe.mjs`。
+本文档记录最初用于确认 DSH Agent `setup` 可以作为 before-publication composition window 的调查。它属于 historical evidence；当前 Runtime 架构权威见 [`architecture.zh-CN.md`](./architecture.zh-CN.md)。
 
-## 1. 组合机制
+## 历史结论
 
-Web surface 在 `composeAgent`（`packages/host/apiproxy/src/api-proxy.ts`）中组合 agent 的 `setup`，这是一个**私有闭包**：
+最初 source investigation 基于 DeepSeek Harness commit：
 
-```ts
-async function composeAgent(presetId) {
-  const presets = ctx.get('agentPresets')
-  if (presets === undefined) {
-    return { setup: (agentCtx) => { installSelection(agentCtx) } }
-  }
-  const resolvedId = (await presets.resolve(presetId)).id
-  return { setup: async (agentCtx) => {
-    installSelection(agentCtx)          // 模型选择（硬编码）
-    await presets.mount(agentCtx, resolvedId)  // preset 组合
-  } }
-}
+`47f943859bef60e4160492346772ded9b24f765a`
+
+真正重要的不是某个 private helper，而是结构 contract：
+
+```text
+Agent create / resume
+      ↓
+caller supplies setup
+      ↓
+Agent factory awaits setup while unpublished
+      ↓
+publication / registry entry
 ```
 
-`presets.mount` → `mountPreset(agentCtx, preset)`（`packages/preset/agent-presets/src/mount.ts`）通过 `agentCtx.plugin(PresetTree, config)` 将 preset 的 `cordis.yml` 插件挂载进 `agentCtx`。preset service 是 `AgentPresets extends Service`（`static inject = ['loader']`）。
+因此 tenant admission 或其他 composition logic 可以在 Agent / Session 对外可见前参与，只要它通过 public Agent creation API 组合，而不是 patch private transport 或依赖 SessionStore 事后事件。
 
-因此 setup 是一个**组合窗口**，但其内容固定：`installSelection` + 一个 preset 的挂载。**不存在**插件可自注册的全局 setup 贡献注册表。
+## 当前 Executable Evidence
 
-## 2. 候选评估
+`scripts/admission-decorator-probe.mjs` 安装当前精确 DSH baseline `0.1.1-rc.2`，并证明本项目关心的所有 genesis shape 都满足 setup-before-entry：
 
-| 候选 | 机制 | 无条件（自动）？ | 判定 |
-| --- | --- | --- | --- |
-| **A** 原生 preset 组合 | 将插件加入某个 preset 的 `cordis.yml` | ❌ 用户配置，非自动 | 非无条件 |
-| **B** setup 贡献注册表 | 插件注册进某个注册表 | — | **不存在** |
-| **C** `ctx.agents` 装饰器 | 包装 AgentService，在 `setup` 前追加准入 | ✅（若包装已安装） | **可行** |
-| **D** 上游全局 setup 中间件 | DSH 增加一个贡献注册表 | ✅ | 更干净的备选 |
+- create；
+- fork（`parentSession`）；
+- subagent（`origin: 'subagent'` + parent）；
+- resume。
 
-## 3. 候选 C 详解（可行）
+Probe 断言 setup callback 执行时目标 Session 尚未进入 registry，成功 publication 后才可见。
 
-插件包装 `ctx.agents`（`AgentService`）。`create`/`resume` 接收 `CreateAgentOptions` / `ResumeAgentOptions`，它们携带身份：
+## v0.2 解释
 
-- `options.sessionId` —— 会话 id。
-- `options.meta.parentSession` —— fork / subagent 的父级。
-- `options.resumeSessionId` —— 被恢复的会话。
+v0.2 不再把 admission 理解成某个 Web-specific decorator 架构。更通用的结构是：
 
-因此被包装的 `create` 在调用方 `setup` 前追加准入：
-
-```ts
-create(options) {
-  const original = options.setup
-  options.setup = async (agentCtx) => {
-    await admission(options.sessionId, options.meta?.parentSession)  // 认领/继承
-    return original?.(agentCtx)
-  }
-  return originalAgents.create(options)
-}
+```text
+canonical Principal Runtime
+        ↓
+derived integration fiber
+        ↓ explicit inject
+DSH operation / Agent create
+        ↓
+DSH setup publication window
 ```
 
-各路径的身份：
+Principal-derived operation Context 提供 identity / capability；DSH 继续拥有 Agent-local setup 与 registration scope。
 
-| 路径 | `options` 中的身份来源 | 需要 H3？ |
-| --- | --- | --- |
-| create | 调用方 principal | **是**（不在 `options` 中） |
-| fork / subagent | `meta.parentSession` → `getSessionOwner(parent)` | 否 |
-| resume | `resumeSessionId` → 持久所有者 | 否 |
+这样既不需要全局 `tenantId` plumbing，也不需要第二套 Agent-specific tenancy registry。
 
-这与 M2 ADR 一致：**只有顶层 create 需要 H3**。
+## 当前权威
 
-## 4. 结论
-
-- setup 是一个组合窗口，但**不是一个公开 seam**：`composeAgent` 是一个私有闭包，其函数体固定为 `installSelection` + `mountPreset`。
-- **C**（`ctx.agents` 装饰器）是唯一*无条件*且通过 `options` 携带身份的插件侧机制；**A** 是用户配置，**B** 不存在。
-- **D**（上游全局 setup 贡献中间件）是若 M3.1 中包装 `ctx.agents` 被证明过于侵入时更干净的备选。**M4（②-A）表明它并非必需** —— C 在运行时成立。
-
-## 5. 运行时证明（M4 · ②-A）
-
-`scripts/admission-decorator-probe.mjs` 包装**真实**的 `AgentRegistry`（`ctx.agents`、`@deepseek-ai/dsh-agent`），并针对**真实**的 `AgentLoop`（`@deepseek-ai/dsh-agent-loop@0.1.0-rc.6`）+ `SessionStore`（`@deepseek-ai/dsh-session@0.1.0-rc.6`）运行准入。`llm` / `tools` / `systemPrompt` 服务在结构上被注入，但 create → setup → enter 路径并不会触及它们，因此用空操作 stub；`sessionPersistence` 是 resume 路径的最小 stub。
-
-结果 —— 四条创生路径的准入都在 `setup` 内运行，且在准入时刻会话**尚未入 store**（即在 `sessions.enter` 之前），随后在 create/resume 完成时已存在：
-
-| 路径 | `options` 中可得的身份 | 准入先于 `sessions.enter` |
-| --- | --- | --- |
-| create | `sessionId` | ✅ |
-| fork | `meta.parentSession` | ✅ |
-| subagent | `meta.origin === 'subagent'` + `meta.parentSession` | ✅ |
-| resume | `resumeSessionId` | ✅ |
-
-这证明 **C 是可组合的**（插件可以包装 `ctx.agents` 并在 `setup` 前追加准入），且准入点在每条路径上都是**可见之前**的。它尚未证明的（②-C）是：在真实部署中插件能否*在宿主的 `create` 调用之前无条件地安装*该包装 —— 那是 transport 原型的职责。因此上游缺口仍是**仅 H3**（顶层 `create` 的身份），而非新的准入 seam。
+- Runtime ownership / lifecycle：[`architecture.zh-CN.md`](./architecture.zh-CN.md)
+- 精确 DSH baseline 与 probes：[`../reference/compatibility.zh-CN.md`](../reference/compatibility.zh-CN.md)
+- 历史 Session publication 调查：[`session-genesis-map.zh-CN.md`](./session-genesis-map.zh-CN.md)

--- a/docs/specs/architecture.md
+++ b/docs/specs/architecture.md
@@ -1,142 +1,272 @@
 [简体中文](./architecture.zh-CN.md) | English
 
-# Architecture — six layers, explicit ownership
+# Architecture — canonical runtime, explicit planes
 
-The project is **one composable plugin family**, organized into six conceptual
-layers. The layers describe where a multi-tenant guarantee must connect; they do
-**not** mean this repository must implement every layer. The boundary rule is
-part of the architecture:
+This document is the current architecture authority for `dsh-multi-tenant` v0.2 and the foundation that v0.3 SaaS Framework composes.
 
-- owned enforcement points are implemented and tested here;
-- ecosystem-owned seams are specified and upstreamed;
-- capabilities outside the supported threat model stay explicit boundaries.
+The design goal is not to spread tenant checks across APIs. It is to make tenancy a structural property of the runtime so identity, capability resolution and lifecycle ownership follow one coherent model.
 
-## The six layers
-
-| # | Layer | Artifact | Responsibility | Ownership / status |
-| --- | --- | --- | --- | --- |
-| ① | **Kernel** | `dsh-multi-tenant` | `TenantPrincipal` / `SessionOwner`, claim-once ownership, fail-closed authorization, the `TenantSessionStore` contract. | **Owned here.** ✅ test-pinned, prerelease contract. |
-| ② | **Ownership provider** | `TenantSessionStore` impls | Persist ownership. Providers prove conformance with the shared contract suite. | **Contract owned here; providers replaceable.** ✅ in-memory reference; durable providers demand-gated. |
-| ③ | **Genesis admission** | `ctx.agents` decorator | Join Agent `setup`; establish / inherit / restore ownership before `sessions.enter`. | **Owned here where DSH exposes the hook.** ✅ RC6 runtime proof; RC7 evidence refresh is release work. |
-| ④ | **Identity bridge** | DSH transport scope + auth resolver/provider | Carry authenticated request/connection identity to a scoped `TenantPrincipal`. | **Split ownership.** 🤝 transport scope is a DSH ecosystem seam; auth providers are optional integrations after that seam exists. |
-| ⑤ | **Enforcement plane** | `dsh-multi-tenant-web` | Principal-bound `ApiProxy`: guard/filter/admit/deny; later streams/respond under the same scope. | **Owned here after Layer ④ exists.** 🚧 unary spike exists; production Web contract is ecosystem-gated. |
-| ⑥ | **Distribution / integration** | optional bundles / recipes | Compose whichever kernel, provider, auth, Web, MCP, audit, or deployment components a product needs. | **Not a mandatory full-stack deliverable.** 🧭 recipes may be added when useful. |
-
-## Diagram
-
-```mermaid
-flowchart TD
-    subgraph L4["④ Identity Bridge"]
-        direction TB
-        HTTP["HTTP / WebSocket"] --> SCOPE["DSH request / connection scope<br/>(ecosystem seam)"]
-        SCOPE --> AUTH["replaceable auth resolver/provider"]
-        AUTH --> PRINCIPAL["scoped TenantPrincipal"]
-    end
-
-    PRINCIPAL -->|"create / fork / subagent / resume"| GENESIS
-    PRINCIPAL -->|"guard / filter / admit"| ENFORCE
-
-    subgraph L3["③ Genesis Admission"]
-        GENESIS["Agent setup decorator<br/>establish / inherit / restore"]
-    end
-
-    subgraph L5["⑤ Enforcement Plane"]
-        ENFORCE["tenant-bound ApiProxy<br/>guard / filter / admit / deny"]
-    end
-
-    GENESIS --> KERNEL
-    ENFORCE --> KERNEL
-
-    subgraph L1["① Kernel"]
-        KERNEL["dsh-multi-tenant<br/>TenantPrincipal · SessionOwner<br/>ownership + fail-closed authorization"]
-    end
-
-    KERNEL --> STORE
-
-    subgraph L2["② Ownership Provider"]
-        STORE["TenantSessionStore contract"]
-        STORE --> MEM["Memory reference"]
-        STORE --> DURABLE["optional durable providers"]
-        STORE --> THIRD["third-party providers"]
-    end
-
-    subgraph L6["⑥ Distribution / Integration"]
-        RECIPE["optional bundles / deployment recipes"]
-    end
-
-    RECIPE -.-> L1
-    RECIPE -.-> L2
-    RECIPE -.-> L3
-    RECIPE -.-> L4
-    RECIPE -.-> L5
-```
-
-## Request flow
-
-1. **④ Identity bridge** — a deployment authenticates an HTTP request or WS
-   upgrade and resolves a `TenantPrincipal`. For production Web isolation this
-   requires a DSH request/connection scope that can carry or install the scoped
-   API/security context. The kernel never sees JWT/OIDC/API-key mechanics.
-2. **③ Genesis** — on `create` / `fork` / `subagent` / `resume`, the admission
-   decorator joins Agent `setup` and establishes, inherits, or restores ownership
-   before `sessions.enter`.
-3. **⑤ Enforcement** — a tenant-bound `ApiProxy` guards session-keyed methods,
-   filters only collections whose semantics remain correct, and denies
-   unmodelled/global surfaces. Streams/respond remain denied in the spike until
-   Layer ④ provides a real principal scope.
-4. **① Kernel** — `MultiTenantService` authorizes against the
-   `TenantSessionStore` contract. Tenant and user ownership is immutable in the
-   0.1 line.
-5. **② Provider** — ownership is stored by the selected provider. Provider
-   choice does not change the kernel contract.
-
-## Dependency direction (one-way)
+## 1. Canonical runtime tree
 
 ```text
-Kernel primitives  ◀──  capability contracts  ◀──  providers / integrations
+Deployment / Root
+│
+├── TenantSessionStore                 shared durable ownership seam
+├── MultiTenantService                 shared fail-closed authorization kernel
+├── TenantRuntimeService               canonical runtime root
+│
+├── Tenant(acme)                       canonical capability node
+│   ├── tenant-local providers
+│   ├── Principal(alice)               canonical capability node
+│   │   ├── principal-local providers
+│   │   └── derived integration fibers
+│   │       └── Agent / transport / provider operations
+│   └── Principal(bob)
+│
+└── Tenant(globex)
 ```
 
-- The **kernel** has zero transport/vendor dependencies — it never knows JWT,
-  PostgreSQL, HTTP, MCP, Redis, or a particular deployment runtime.
-- Capability packages own only the contracts they can enforce.
-- Provider and integration packages depend on the contract they implement; a
-  sibling capability does not reach through another sibling's implementation.
-- A missing upstream seam is not solved by importing or copying the entire
-  upstream subsystem into the kernel.
+Tenant and Principal are not request DTOs. They are live runtime nodes with identity, Context, lifecycle and canonical registry semantics.
 
-## H3 under DSH RC7 — ecosystem seam, not kernel blocker
+Principal is structurally nested under Tenant. A Principal registry is keyed by `userId`; its `tenantId` is derived from its parent. Cross-tenant Principal binding is therefore not merely rejected by an `if` statement — the public data model does not represent it.
 
-RC7's public `ConnectionRpcHandler` receives decoded
-`(endpoint, payload, signal)`, while the DSH Web carrier owns the real HTTP/WS
-boundary and documents that it currently has no authentication layer. That is
-enough evidence to classify request/connection principal scope as an
-**ecosystem-owned seam**.
+## 2. One runtime-node vocabulary
 
-The project therefore does not need a production-like local Web transport fork
-to release the kernel. The deliverable is a minimal, tenant-agnostic upstream
-proposal that lets a deployment derive/install a request/connection-scoped API
-or security context from the real HTTP request / WS upgrade. When such a seam
-exists, Layer ⑤ can turn its current fail-closed spike into production Web
-enforcement.
+Tenant and Principal share the same semantic base shape:
 
-## Explicit architecture boundary: execution isolation
+```ts
+interface RuntimeScope<K, I> {
+  readonly kind: K
+  readonly identity: Readonly<I>
+  readonly ctx: Context
+  readonly state: 'active' | 'disposing' | 'disposed'
+  dispose(): Promise<void>
+}
 
-This architecture protects the application/session control surfaces it covers.
-It does **not** claim process, filesystem, shell, container, credential,
-network/egress, or host isolation for an Agent that the surrounding DSH
-deployment has already allowed to run. Strong execution isolation belongs to
-the deployment/runtime layer and is intentionally outside this plugin family's
-0.1 guarantee.
+interface RuntimeScopeRegistry<Key, Scope, Definition> {
+  get(key: Key): Scope | undefined
+  ensure(key: Key, definition?: Definition): Promise<Scope>
+}
+```
 
-## Layer → roadmap ownership
+The nesting adds only the capability that structurally belongs to the parent:
 
-| Layer | Roadmap treatment |
-| --- | --- |
-| ① Kernel | first-release blocker; owned and enforced here |
-| ② Provider | contract is release blocker; durable providers are independent follow-ups |
-| ③ Genesis admission | RC7 compatibility evidence is release blocker |
-| ④ Identity bridge | ecosystem track; does not block kernel release |
-| ⑤ Web enforcement | production work waits for Layer ④; not a kernel blocker |
-| ⑥ Distribution / integration | optional recipes, never a required "complete SaaS stack" milestone |
+```ts
+interface TenantRuntimeScope extends RuntimeScope<'tenant', TenantIdentity> {
+  readonly principals: RuntimeScopeRegistry<
+    string,
+    PrincipalRuntimeScope,
+    PrincipalScopeDefinition
+  >
+}
+```
 
-See `../../ROADMAP.md` for the release and ecosystem tracks.
+This is deliberate: avoid unrelated special-purpose verbs such as `createTenantForRequest`, `createPrincipalForAgent`, or provider-specific runtime managers. New features should compose from this tree rather than widen the core API surface.
+
+## 3. Creation recipe vs runtime identity
+
+A node has two different concerns:
+
+- **identity** — what canonical node the caller wants;
+- **definition** — how a missing node should be constructed.
+
+Consumers may join an existing node without knowing its creation recipe:
+
+```ts
+const tenant = await ctx.tenantRuntime.tenants.ensure('acme')
+```
+
+Configuration/bootstrap code may explicitly define creation:
+
+```ts
+const tenant = await ctx.tenantRuntime.tenants.ensure('acme', {
+  isolateServices: ['tenantAuth', 'tenantMcp'],
+  setup: async ({ ctx, signal }) => {
+    await ctx.plugin(authProvider)
+    await ctx.plugin(mcpProvider)
+  },
+})
+```
+
+When an explicit definition targets an already active canonical identity, incompatible capability shape is rejected. Upper layers are not forced to duplicate lower-layer configuration merely to resolve identity.
+
+## 4. Publication transaction
+
+Async configuration must not make a half-built Tenant/Principal visible.
+
+The creation state machine is:
+
+```text
+ABSENT
+  │ ensure(identity, definition)
+  ▼
+RESERVED / PREPARING              not visible through get()
+  │
+  ├─ prepare isolated Cordis subtree
+  ├─ await setup(signal)
+  ├─ optional synchronous commit()
+  │
+  ├──────── success ───────────────► ACTIVE / published
+  │
+  └──────── failure/cancel ────────► rollback -> ABSENT
+```
+
+The optional synchronous `commit()` owns the exact publication boundary for external mutable state that must be revalidated or flipped immediately before visibility. This intentionally mirrors DSH Agent unpublished-setup/publication semantics.
+
+Concurrent `ensure()` calls for one key single-flight into one creation transaction.
+
+## 5. Preparing transaction is a lifecycle resource
+
+A preparing scope is not modeled as only `Promise<Scope>`. That would lose the capability to cancel creation during parent teardown and can create a self-waiting lifecycle:
+
+```text
+Tenant.dispose()
+    waits pending Principal promise
+        waits forever
+            only Tenant teardown could cancel it
+```
+
+The registry therefore owns a cancellable creation transaction conceptually equivalent to:
+
+```ts
+interface RuntimeCreation<Scope> {
+  readonly ready: Promise<Scope>
+  cancel(reason: unknown): Promise<void>
+}
+```
+
+Registry teardown is ordered:
+
+```text
+OPEN
+  ↓ close admission
+CLOSING
+  ↓ cancel all preparing creations
+  ↓ dispose/drain all published scopes
+CLOSED
+```
+
+Tenant disposal first closes/drains its Principal registry and then unwinds the Tenant Cordis fiber. Replacement of the same canonical identity cannot overlap a still-draining old graph.
+
+## 6. Four independent planes
+
+Tenancy is not one overloaded mechanism.
+
+| Plane | Owner | Responsibility |
+| --- | --- | --- |
+| Persistent authorization | `MultiTenantService` + `TenantSessionStore` | Durable session ownership; fail closed. |
+| Tenant/Principal capability graph | Cordis Context service isolation | Auth/MCP/credential/provider resolution and lifecycle. |
+| Agent/Preset registration graph | DSH `@deepseek-ai/dsh-scope` | Agent-local tools, prompts, listeners and model-facing visibility. |
+| Strong isolation | Deployment/container/K8S | Process, filesystem, shell, network, memory boundary. |
+
+The first two are defense-in-depth, not alternatives. Context identity is trusted same-process composition metadata; it never replaces persistent ownership authorization.
+
+## 7. Principal Context and integration fibers
+
+A Principal Context is a canonical capability root. It is not a bypass around Cordis dependency injection.
+
+An operation that needs a service derives a child integration fiber and explicitly injects the dependency:
+
+```ts
+const alice = await tenant.principals.ensure('alice')
+
+const operation = alice.ctx.inject(['agents'], async (ownerCtx) => {
+  return ownerCtx.agents.create({
+    sessionId,
+    setup(agentCtx) {
+      const credentials = ownerCtx.get('userCredentials')
+      // Compose Agent-local DSH registrations into agentCtx.
+    },
+  })
+})
+
+await operation
+```
+
+This provides a natural place for future HTTP/WebSocket request scope, Agent orchestration, tracing and operation-local cancellation without polluting the canonical Principal node with ephemeral state.
+
+## 8. Agent boundary
+
+Current DSH Agent creation carries the `ctx.agents.create()` caller Context into the factory as `ownerCtx`. The runtime relies on that public seam.
+
+It deliberately does **not**:
+
+- copy Cordis private isolation maps into `Agent.ctx`;
+- make Tenant a second parent in DSH's Agent/Preset scope ancestry;
+- provide an Agent-specific tenant service registry.
+
+Instead:
+
+```text
+Principal capability root
+       ↓ derived fiber (inject agents)
+DSH ownerCtx boundary
+       ↓ setup composition
+DSH Agent/Preset scope
+```
+
+The two graphs preserve different semantics and remain composable.
+
+## 9. Provider contract
+
+A provider being mountable below a Context does not automatically make it tenant-safe. Providers can bypass scope through root state, module globals, process environment or other deployment-wide mutable state.
+
+`dsh-multi-tenant/testing` therefore exposes an executable Runtime Capability Provider Contract. It verifies:
+
+- same-name Tenant A/B isolation;
+- root/parent non-leakage;
+- expected descendant inheritance;
+- Principal sibling isolation;
+- disposing one scope does not affect another;
+- recreation has no stale state;
+- mounting works during unpublished setup.
+
+Provider compatibility is a contract, not an assumption.
+
+## 10. Dependency direction
+
+The architecture grows upward:
+
+```text
+v0.1 ownership kernel
+        ↑
+v0.2 Runtime Contract
+        ↑
+capability contracts
+        ↑
+replaceable providers / integrations
+        ↑
+v0.3 SaaS Distribution / Framework
+```
+
+The runtime package keeps transport/vendor implementations out of core. A future SaaS distribution may install opinionated Auth, credentials, MCP, storage, audit and transport defaults, but those providers remain independently replaceable.
+
+## 11. v0.3 composition target
+
+```text
+                         dsh-saas
+                 SaaS Distribution / Framework
+                            │
+        ┌───────────────────┼───────────────────┐
+        │                   │                   │
+      Auth              Credentials            MCP
+        │                   │                   │
+    Transport              Audit              Usage
+        │                   │                   │
+        └──────────── Provider Contracts ───────┘
+                            │
+                   dsh-multi-tenant
+                 Runtime Contract + Kernel
+```
+
+The Framework provides the product experience and opinionated defaults. The Plugin Family provides the replaceable architecture.
+
+## 12. Explicit boundary
+
+Cordis Context is a trusted same-process capability/lifecycle structure, not a hostile-code sandbox. It does not isolate arbitrary process memory, filesystem, shell, network, environment variables or code deliberately escaping to root/process APIs.
+
+Strong isolation belongs to deployment profiles such as one Tenant per process/container/Pod.
+
+## 13. Compatibility baseline
+
+Current exact DSH baseline and executable evidence policy are defined in [`../reference/compatibility.md`](../reference/compatibility.md). Architecture code must not depend on floating upstream state.

--- a/docs/specs/architecture.zh-CN.md
+++ b/docs/specs/architecture.zh-CN.md
@@ -1,112 +1,253 @@
 [English](./architecture.md) | 简体中文
 
-# 架构 —— 六层，但明确归属
+# 架构 —— Canonical Runtime，职责 Plane 明确分离
 
-本项目是**一个可组合的插件家族**，概念上组织为六层。这些层说明多租户保证需要在哪些位置连接，并**不**意味着本仓库必须把每一层都自己实现。边界原则本身就是架构的一部分：
+本文档是 `dsh-multi-tenant` v0.2 的当前架构权威，也是 v0.3 SaaS Framework 应该直接组合的基础。
 
-- 本仓库拥有的 enforcement point，由本仓库实现并测试；
-- 属于生态的 seam，由本仓库定义标准并向上游协作；
-- 超出支持 threat model 的能力，继续作为明确边界。
+设计目标不是把 tenant check 扩散到每个 API，而是让 tenancy 成为 Runtime 的结构属性，使 identity、capability resolution 与 lifecycle ownership 遵循同一模型。
 
-## 六层
-
-| # | 层 | 产物 | 职责 | 归属 / 状态 |
-| --- | --- | --- | --- | --- |
-| ① | **内核** | `dsh-multi-tenant` | `TenantPrincipal` / `SessionOwner`、一次性认领所有权、默认拒绝式授权、`TenantSessionStore` 契约。 | **本仓库拥有。** ✅ 已由测试锁定，契约仍是 prerelease。 |
-| ② | **所有权 provider** | `TenantSessionStore` 实现 | 持久化 ownership。Provider 通过共享 contract suite 证明一致性。 | **契约由本仓库拥有；provider 可替换。** ✅ 内存参考实现；durable provider 按需求触发。 |
-| ③ | **创生准入** | `ctx.agents` decorator | 加入 Agent `setup`；在 `sessions.enter` 前建立 / 继承 / 恢复 ownership。 | **DSH 已暴露 hook 的地方由我们强制。** ✅ 有 RC6 runtime proof；RC7 evidence refresh 属于发布工作。 |
-| ④ | **身份桥接** | DSH transport scope + auth resolver/provider | 把已认证 request/connection identity 传递成 scoped `TenantPrincipal`。 | **归属拆分。** 🤝 transport scope 是 DSH 生态 seam；auth provider 在 seam 存在后作为可选 integration。 |
-| ⑤ | **强制平面** | `dsh-multi-tenant-web` | Principal-bound `ApiProxy`：guard/filter/admit/deny；未来在同一 scope 下处理 stream/respond。 | **Layer ④ 存在以后由我们拥有。** 🚧 unary spike 已有；production Web contract 受生态 seam 门控。 |
-| ⑥ | **分发 / integration** | 可选 bundle / recipe | 根据产品需要组合 kernel、provider、auth、Web、MCP、audit 或 deployment 组件。 | **不是必须交付的完整全栈。** 🧭 有价值时再增加 recipe。 |
-
-## 图示
-
-```mermaid
-flowchart TD
-    subgraph L4["④ Identity Bridge"]
-        direction TB
-        HTTP["HTTP / WebSocket"] --> SCOPE["DSH request / connection scope<br/>(ecosystem seam)"]
-        SCOPE --> AUTH["replaceable auth resolver/provider"]
-        AUTH --> PRINCIPAL["scoped TenantPrincipal"]
-    end
-
-    PRINCIPAL -->|"create / fork / subagent / resume"| GENESIS
-    PRINCIPAL -->|"guard / filter / admit"| ENFORCE
-
-    subgraph L3["③ Genesis Admission"]
-        GENESIS["Agent setup decorator<br/>establish / inherit / restore"]
-    end
-
-    subgraph L5["⑤ Enforcement Plane"]
-        ENFORCE["tenant-bound ApiProxy<br/>guard / filter / admit / deny"]
-    end
-
-    GENESIS --> KERNEL
-    ENFORCE --> KERNEL
-
-    subgraph L1["① Kernel"]
-        KERNEL["dsh-multi-tenant<br/>TenantPrincipal · SessionOwner<br/>ownership + fail-closed authorization"]
-    end
-
-    KERNEL --> STORE
-
-    subgraph L2["② Ownership Provider"]
-        STORE["TenantSessionStore contract"]
-        STORE --> MEM["Memory reference"]
-        STORE --> DURABLE["optional durable providers"]
-        STORE --> THIRD["third-party providers"]
-    end
-
-    subgraph L6["⑥ Distribution / Integration"]
-        RECIPE["optional bundles / deployment recipes"]
-    end
-
-    RECIPE -.-> L1
-    RECIPE -.-> L2
-    RECIPE -.-> L3
-    RECIPE -.-> L4
-    RECIPE -.-> L5
-```
-
-## 请求流
-
-1. **④ 身份桥接** —— deployment 对 HTTP request 或 WS upgrade 做认证，并解析出 `TenantPrincipal`。要实现 production Web isolation，需要 DSH 提供 request/connection scope，使 scoped API/security context 能在真实 transport 边界安装。Kernel 永远不知道 JWT/OIDC/API-key 的具体机制。
-2. **③ 创生** —— 在 `create` / `fork` / `subagent` / `resume` 上，admission decorator 加入 Agent `setup`，并在 `sessions.enter` 之前建立、继承或恢复 ownership。
-3. **⑤ 强制** —— tenant-bound `ApiProxy` 守卫 session-keyed method，只过滤 post-filter 后语义仍正确的 collection，并拒绝未建模/global surface。Layer ④ 提供真实 principal scope 之前，spike 中的 stream/respond 继续默认拒绝。
-4. **① 内核** —— `MultiTenantService` 通过 `TenantSessionStore` contract 做授权。0.1 版本线保持 tenant+user ownership 不可变。
-5. **② Provider** —— ownership 由选定 provider 存储。Provider 选择不会改变 kernel contract。
-
-## 依赖方向（单向）
+## 1. Canonical Runtime Tree
 
 ```text
-内核原语  ◀──  能力契约  ◀──  provider / integration
+Deployment / Root
+│
+├── TenantSessionStore                 shared durable ownership seam
+├── MultiTenantService                 shared fail-closed authorization kernel
+├── TenantRuntimeService               canonical runtime root
+│
+├── Tenant(acme)                       canonical capability node
+│   ├── tenant-local providers
+│   ├── Principal(alice)               canonical capability node
+│   │   ├── principal-local providers
+│   │   └── derived integration fibers
+│   │       └── Agent / transport / provider operations
+│   └── Principal(bob)
+│
+└── Tenant(globex)
 ```
 
-- **内核**没有 transport/vendor 依赖 —— 不感知 JWT、PostgreSQL、HTTP、MCP、Redis 或具体 deployment runtime。
-- capability package 只拥有它真正能强制的 contract。
-- provider / integration package 依赖自己实现的 contract；兄弟能力不穿透彼此实现。
-- 缺少 upstream seam 时，不通过把整个 upstream subsystem 导入或复制进 kernel 来“解决”。
+Tenant / Principal 不是 request DTO，而是拥有 identity、Context、lifecycle 与 canonical registry 语义的真实 Runtime Node。
 
-## DSH RC7 下的 H3 —— 生态 seam，不是 kernel 发布阻塞项
+Principal 结构上嵌套在 Tenant 下。Principal registry 只以 `userId` 为 key，`tenantId` 来自父 Tenant，因此错误的 cross-tenant Principal 组合不是靠一个 `if` 拦截，而是 public data model 本身无法表达。
 
-RC7 公开的 `ConnectionRpcHandler` 接收解码后的
-`(endpoint, payload, signal)`；真实 HTTP/WS boundary 由 DSH Web carrier 自己持有，而且官方文档明确说明目前没有 authentication layer。这些证据已经足够把 request/connection principal scope 归类为**生态拥有的 seam**。
+## 2. 统一 Runtime Node 语义
 
-因此，发布 kernel 不需要先做一套 production-like 的本地 Web transport fork。本项目应该交付一个最小、tenant-agnostic 的 upstream proposal，让 deployment 可以基于真实 HTTP request / WS upgrade 建立或安装 request/connection-scoped API/security context。这个 seam 存在以后，Layer ⑤ 才把当前 fail-closed spike 变成 production Web enforcement。
+Tenant / Principal 共用一个基础抽象：
 
-## 明确架构边界：执行隔离
+```ts
+interface RuntimeScope<K, I> {
+  readonly kind: K
+  readonly identity: Readonly<I>
+  readonly ctx: Context
+  readonly state: 'active' | 'disposing' | 'disposed'
+  dispose(): Promise<void>
+}
 
-本架构保护的是它实际覆盖的 application/session control surface。对于 surrounding DSH deployment 已经允许执行的 Agent，本项目**不**声称提供 process、filesystem、shell、container、credential、network/egress 或 host isolation。强执行隔离属于 deployment/runtime 层，并明确不在本插件家族 0.1 guarantee 中。
+interface RuntimeScopeRegistry<Key, Scope, Definition> {
+  get(key: Key): Scope | undefined
+  ensure(key: Key, definition?: Definition): Promise<Scope>
+}
+```
 
-## Layer → Roadmap 归属
+Tenant 只增加结构上真正属于它的 Principal Registry。
 
-| Layer | Roadmap 处理方式 |
-| --- | --- |
-| ① Kernel | 第一次发布阻塞项；本仓库拥有并强制 |
-| ② Provider | contract 阻塞发布；durable provider 是独立 follow-up |
-| ③ Genesis admission | RC7 compatibility evidence 阻塞发布 |
-| ④ Identity bridge | ecosystem track；不阻塞 kernel release |
-| ⑤ Web enforcement | production 工作等待 Layer ④；不阻塞 kernel |
-| ⑥ Distribution / integration | 可选 recipe，不再是“完整 SaaS 栈”必做 milestone |
+新功能应该从这棵树自然组合，而不是继续增加 `createTenantForRequest`、`createPrincipalForAgent` 之类特殊方法。
 
-发布主线与生态主线见 `../../ROADMAP.md`。
+## 3. Runtime Identity 与 Creation Recipe 分离
+
+一个 Runtime Node 有两个不同问题：
+
+- **identity** —— 调用方要加入哪个 canonical node；
+- **definition** —— 这个 node 不存在时应该如何创建。
+
+消费层可以只凭 identity 获取已有 node：
+
+```ts
+const tenant = await ctx.tenantRuntime.tenants.ensure('acme')
+```
+
+Bootstrap / configuration 层才负责 creation recipe：
+
+```ts
+const tenant = await ctx.tenantRuntime.tenants.ensure('acme', {
+  isolateServices: ['tenantAuth', 'tenantMcp'],
+  setup: async ({ ctx, signal }) => {
+    await ctx.plugin(authProvider)
+    await ctx.plugin(mcpProvider)
+  },
+})
+```
+
+这样 Transport / Agent 等上层 consumer 不需要知道底层 provider 配方。只有显式再次提供 definition 时才做 definition-drift 校验。
+
+## 4. Publication Transaction
+
+异步配置不能让半初始化 Tenant / Principal 对外可见。
+
+```text
+ABSENT
+  │ ensure(identity, definition)
+  ▼
+RESERVED / PREPARING              get() 不可见
+  │
+  ├─ prepare isolated Cordis subtree
+  ├─ await setup(signal)
+  ├─ optional synchronous commit()
+  │
+  ├──────── success ───────────────► ACTIVE / published
+  │
+  └──────── failure/cancel ────────► rollback -> ABSENT
+```
+
+可选同步 `commit()` 拥有精确 publication boundary，用于必须在 visibility 前最终确认的外部 mutable state。这个语义刻意与 DSH Agent 的 unpublished setup / publication 模型保持同构。
+
+同一个 key 的并发 `ensure()` single-flight 到同一个 creation transaction。
+
+## 5. Preparing Transaction 是 Lifecycle Resource
+
+Preparing scope 不能只表示成 `Promise<Scope>`。否则 parent teardown 可能等待一个只有自己才能取消的 pending child，形成自等待。
+
+Registry 内部因此需要类似下面的 first-class creation resource：
+
+```ts
+interface RuntimeCreation<Scope> {
+  readonly ready: Promise<Scope>
+  cancel(reason: unknown): Promise<void>
+}
+```
+
+Registry teardown 顺序统一为：
+
+```text
+OPEN
+  ↓ close admission
+CLOSING
+  ↓ cancel all preparing creations
+  ↓ dispose/drain all published scopes
+CLOSED
+```
+
+Tenant dispose 先关闭并 drain Principal registry，再回收 Tenant Cordis fiber。相同 canonical identity 的 replacement 不允许与旧 graph 的 draining 生命周期重叠。
+
+## 6. 四个独立 Plane
+
+Tenancy 不是一个机制包办所有职责。
+
+| Plane | Owner | 作用 |
+| --- | --- | --- |
+| Persistent authorization | `MultiTenantService` + `TenantSessionStore` | Durable session ownership；fail closed。 |
+| Tenant / Principal capability graph | Cordis Context service isolation | Auth / MCP / credential / provider resolution 与 lifecycle。 |
+| Agent / Preset registration graph | DSH `@deepseek-ai/dsh-scope` | Agent-local tools、prompt、listener 与 model-facing visibility。 |
+| Strong isolation | Deployment / container / K8S | Process、filesystem、shell、network、memory boundary。 |
+
+前两层是 defense in depth，不是互相替代。Context identity 只属于 trusted same-process composition metadata，绝不替代 persistent ownership authorization。
+
+## 7. Principal Context 与 Integration Fiber
+
+Principal Context 是 canonical capability root，不是绕过 Cordis dependency injection 的万能 Context。
+
+需要额外 service 的具体 operation 从 Principal 派生 integration fiber，并显式 inject：
+
+```ts
+const alice = await tenant.principals.ensure('alice')
+
+const operation = alice.ctx.inject(['agents'], async (ownerCtx) => {
+  return ownerCtx.agents.create({
+    sessionId,
+    setup(agentCtx) {
+      const credentials = ownerCtx.get('userCredentials')
+      // 把 Agent-local DSH registration 组合到 agentCtx。
+    },
+  })
+})
+
+await operation
+```
+
+未来 HTTP / WebSocket request scope、Agent orchestration、tracing、operation-local cancellation 都可以自然落在这一层，而不用把 ephemeral state 塞进 canonical Principal Node。
+
+## 8. Agent Boundary
+
+当前 DSH Agent creation 会把 `ctx.agents.create()` 的 caller Context 作为 `ownerCtx` 传入 factory。Runtime 直接使用这个 public seam。
+
+明确不做：
+
+- 复制 Cordis 私有 isolation map 到 `Agent.ctx`；
+- 把 Tenant 强塞成 DSH Agent / Preset scope ancestry 的第二个 parent；
+- 再造 Agent-specific tenant service registry。
+
+正确结构是：
+
+```text
+Principal capability root
+       ↓ derived fiber (inject agents)
+DSH ownerCtx boundary
+       ↓ setup composition
+DSH Agent / Preset scope
+```
+
+两张 graph 负责不同语义，因此可以稳定组合。
+
+## 9. Provider Contract
+
+Provider 能挂载到 Context 下，并不代表它天然 tenant-safe。它仍可能通过 root state、module global、process env 等方式绕过 scope。
+
+`dsh-multi-tenant/testing` 提供 executable Runtime Capability Provider Contract，验证：
+
+- 同名 Tenant A/B isolation；
+- root / parent 不泄漏；
+- 正确 descendant inheritance；
+- Principal sibling isolation；
+- dispose 一个 scope 不影响另一个；
+- recreate 不残留 stale state；
+- provider 能在 unpublished setup 中正确挂载。
+
+Provider compatibility 是 contract，不是默认假设。
+
+## 10. Dependency Direction
+
+架构只向上生长：
+
+```text
+v0.1 ownership kernel
+        ↑
+v0.2 Runtime Contract
+        ↑
+capability contracts
+        ↑
+replaceable providers / integrations
+        ↑
+v0.3 SaaS Distribution / Framework
+```
+
+Runtime package 不引入 transport / vendor implementation。未来 SaaS Distribution 可以提供 Auth、credentials、MCP、storage、audit、transport 的官方默认实现，但 provider slot 必须保持可替换。
+
+## 11. v0.3 Composition Target
+
+```text
+                         dsh-saas
+                 SaaS Distribution / Framework
+                            │
+        ┌───────────────────┼───────────────────┐
+        │                   │                   │
+      Auth              Credentials            MCP
+        │                   │                   │
+    Transport              Audit              Usage
+        │                   │                   │
+        └──────────── Provider Contracts ───────┘
+                            │
+                   dsh-multi-tenant
+                 Runtime Contract + Kernel
+```
+
+Framework 提供开箱即用的产品体验与 opinionated defaults；Plugin Family 提供可替换、可组合的工程架构。
+
+## 12. Explicit Boundary
+
+Cordis Context 是 trusted same-process capability / lifecycle structure，不是 hostile-code sandbox。它不隔离任意 process memory、filesystem、shell、network、environment variable，也不能约束故意访问 root / process API 的代码。
+
+Strong isolation 属于 one Tenant per process / container / Pod 等 deployment profile。
+
+## 13. Compatibility Baseline
+
+当前精确 DSH baseline 与 executable evidence policy 见 [`../reference/compatibility.zh-CN.md`](../reference/compatibility.zh-CN.md)。Architecture code 不依赖 floating upstream state。

--- a/docs/specs/session-genesis-map.md
+++ b/docs/specs/session-genesis-map.md
@@ -1,99 +1,74 @@
 [简体中文](./session-genesis-map.zh-CN.md) | English
 
-# Session Genesis Map
+# Session Genesis — historical investigation and current proof
 
-> Static analysis of DSH's session + agent lifecycle. Source read at
-> `deepseek-ai/deepseek-harness` @ `47f943859bef60e4160492346772ded9b24f765a`
-> (whose `@deepseek-ai/dsh-session` manifest is `0.1.0-rc.5`). The runtime probe
-> pins the npm-published `@deepseek-ai/dsh-session@0.1.0-rc.6`; F1/F2 behavior
-> is consistent across both.
+This document records the investigation that established the DSH session/Agent publication seam used by this project. It is evidence, not the current multi-tenant architecture authority; see [`architecture.md`](./architecture.md) for the Runtime Contract.
 
-## 1. Two layers: SessionStore publication vs. Agent genesis
+## Historical source investigation
 
-The low-level session store (`SessionStore`, `packages/core/session`) has a
-three-step publication transaction:
+The original static analysis was performed against DeepSeek Harness commit:
 
+`47f943859bef60e4160492346772ded9b24f765a`
+
+It identified two distinct publication layers.
+
+### Low-level SessionStore
+
+```text
+prepare(session)     unpublished
+      ↓
+enter(session)       registry-visible
+      ↓
+announce(session)    session/created dispatch
 ```
-prepare(id?, options)   # construct Session. NOT in store.
-enter(session)          # store.set(id, entry). → get/list/history see it.
-announce(session)       # emit `session/created` (synchronous dispatch).
-```
 
-The **real** genesis path is the agent factory (`packages/core/agent-loop`,
-`setupAndPublish`), which wraps that transaction with an **async,
-before-visibility `setup` hook**:
+`session/created` is therefore not a before-visibility admission point.
 
-```
-prepare Session           (sessions.prepare)
-prepare Agent             (agent-loop prepare)
-await setup(agent.ctx)    # ← ASYNC, before any store entry. Rejection → rollback.
+### Agent factory genesis
+
+The Agent factory adds an async setup window before publication:
+
+```text
+prepare Session
+prepare Agent
+      ↓
+await setup(agentCtx)       unpublished
+      ↓
 setupCommit?.commit()
-publish():
-    sessions.enter(session)   # store entry — get/list/history now see it
-    agents.enter(agent)
-    sessions.announce(session)  # `session/created` (sync dispatch)
-    agents.announce(agent)
+      ↓
+sessions.enter(session)
+agents.enter(agent)
+announce / start
 ```
 
-`CreateAgentOptions.setup` / `ResumeAgentOptions.setup` are **public** and are
-passed by **all four** genesis paths (create / fork / subagent / resume). DSH
-therefore **does** have an existing async, before-visibility admission point —
-the `setup` hook.
+This is the useful composition boundary: setup failure can abort before the Session/Agent becomes externally visible.
 
-The open question is **composability, not existence**: `setup` is a per-call
-option supplied by the caller (`composition.setup`), not a global middleware.
-Whether a third-party plugin can participate in *every* setup unfailingly is
-what M2.1 must answer.
+## Current executable evidence
 
-## 2. Genesis paths
+The repository no longer treats the historical source read as sufficient evidence. `scripts/session-genesis-probe.mjs` installs the exact current DSH baseline from `scripts/dsh-target.mjs` (`0.1.1-rc.2`) into a clean temporary consumer and asserts:
 
-| Path | Entry (RPC) | Owner source | Goes through | First visible | Rollback |
-| --- | --- | --- | --- | --- | --- |
-| **create** | `session.create` | caller principal — **not carried** | `ctx.agents.create({sessionId, meta, setup})` → `setupAndPublish` | `sessions.enter` → `list`/`get`; `announce` → `mux`/`host` | `setup` reject or sync `session/created` throw → `dispose()` |
-| **fork** | `session.fork` | **inherit parent** | `ctx.agents.create({parentSession, seed, setup})` | same | same |
-| **subagent** | `subagent.*` | **inherit parent** | `ctx.agents.create({origin:'subagent', parentSession, setup})` | same | same |
-| **resume** | `session.create`(preallocated)/`history`/`prompt` | **restore persisted** | `ctx.agents.resume({resumeSessionId, setup})` | same | same |
+1. `session/created` observes the Session already in the store;
+2. a synchronous `session/created` throw rolls publication back;
+3. an async listener rejection cannot veto already-completed synchronous publication.
 
-## 3. Hook candidates
+`scripts/admission-decorator-probe.mjs` separately proves Agent setup runs before `sessions.enter` across create, fork, subagent and resume paths.
 
-| Candidate | async | before store entry | composable | Verdict |
-| --- | --- | --- | --- | --- |
-| `setup` (`CreateAgentOptions.setup`) | ✅ | ✅ (before `sessions.enter`) | ❌ per-call, not global | the right point; **composability is the gap** |
-| `session/created` listener | ❌ sync-veto only | ❌ after `enter` | n/a | too late + no async veto |
-| wrap `ctx.agents` | ✅ (interpose) | ✅ | ⚠️ needs principal (create) / parent owner (fork/subagent) | possible but coupled to H3 |
+These probes are blocking CI on Node 22.19 and Node 24.
 
-## 4. Key findings
+## Architectural consequence
 
-- **F1** — `session/created` fires **after** `enter`; the session is already
-  store-visible when the event fires. (runtime-confirmed)
-- **F2** — `session/created` is **sync-veto-only**: a synchronous throw rolls
-  back `enter`, an async listener's rejection is logged, not vetoed. An async
-  ownership claim cannot ride it. (runtime-confirmed)
-- **F3** — the principal is dropped at the RPC boundary; only **top-level
-  create** needs it. fork/subagent need the parent owner, resume needs the
-  durable owner — neither needs the HTTP principal.
-- **F4** — fork/subagent inherit via `meta.parentSession`. The **store contract**
-  (`store.claim(childId, SessionOwner)`) already expresses inheritance; only the
-  `MultiTenantService.claimSession()` helper is Principal-oriented. This is an
-  **ergonomics** gap, not a capability gap.
-- **F5** — resume restores the durable owner. A same-owner claim is
-  **idempotent, not a conflict**; resume must read the durable ownership, not
-  re-claim.
+v0.2 applies the same publication principle to Tenant/Principal Runtime nodes:
 
-## 5. Invariant assessment
+```text
+prepare unpublished subtree
+      ↓
+await setup(signal)
+      ↓
+optional synchronous commit()
+      ↓
+publish canonical node
+```
 
-| Invariant | Status |
-| --- | --- |
-| 1. No ownership window | ✅ `setup` runs before `sessions.enter` — an admission in `setup` has no window |
-| 2. Child inheritance explicit | ⚠️ store contract can express it (F4), but the admission needs the parent owner at the hook |
-| 3. No ghost ownership on failure | ✅ reservation tombstone — no access grant; same-owner retry idempotent; different-owner retry conflicts (correct) |
-| 4. Resume doesn't steal | ✅ idempotent same-owner claim; restore, don't re-claim |
-| 5. Concurrent genesis unique | ✅ `sessionCreations` dedup + `enter` collision check |
+This is intentional semantic alignment with DSH rather than a parallel lifecycle model.
 
-## 6. Conclusion (see `../adr/session-genesis.md`)
-
-The `setup` hook is the before-visibility async admission point. Composability
-is via wrapping `ctx.agents` (the same mechanism H3 needs to wrap `ApiProxy`).
-Fork / subagent / resume are solvable today from the parent / durable owner;
-only top-level create needs the H3 request-scoped principal. Ghost ownership is
-a safe reservation tombstone. The upstream proposal shrinks to **H3 only**.
+Current DSH baseline/evidence policy lives in [`../reference/compatibility.md`](../reference/compatibility.md).

--- a/docs/specs/session-genesis-map.zh-CN.md
+++ b/docs/specs/session-genesis-map.zh-CN.md
@@ -1,74 +1,74 @@
 [English](./session-genesis-map.md) | 简体中文
 
-# 会话创生图（Session Genesis Map）
+# Session Genesis —— 历史调查与当前可执行证据
 
-> 对 DSH session + agent 生命周期的静态分析。源码阅读于
-> `deepseek-ai/deepseek-harness` @ `47f943859bef60e4160492346772ded9b24f765a`
-> （其 `@deepseek-ai/dsh-session` manifest 为 `0.1.0-rc.5`）。运行时探针钉住 npm 发布的 `@deepseek-ai/dsh-session@0.1.0-rc.6`；F1/F2 行为在二者间一致。
+本文档记录最初用于确认 DSH Session / Agent publication seam 的调查过程。它属于 evidence，不是当前 Multi-Tenant Runtime 的架构权威；当前 Runtime Contract 见 [`architecture.zh-CN.md`](./architecture.zh-CN.md)。
 
-## 1. 两层：SessionStore 发布 vs. Agent 创生
+## 历史 Source Investigation
 
-底层 session store（`SessionStore`、`packages/core/session`）有一个三步发布事务：
+最初静态分析基于 DeepSeek Harness commit：
 
+`47f943859bef60e4160492346772ded9b24f765a`
+
+当时确认了两个不同的 publication layer。
+
+### Low-level SessionStore
+
+```text
+prepare(session)     unpublished
+      ↓
+enter(session)       registry-visible
+      ↓
+announce(session)    session/created dispatch
 ```
-prepare(id?, options)   # 构造 Session。尚未入 store。
-enter(session)          # store.set(id, entry)。→ get/list/history 可见。
-announce(session)       # 发出 `session/created`（同步派发）。
-```
 
-**真正的**创生路径是 agent 工厂（`packages/core/agent-loop`、`setupAndPublish`），它用一个**异步、可见之前的 `setup` 钩子**包裹该事务：
+因此 `session/created` 不是 before-visibility admission point。
 
-```
-prepare Session           (sessions.prepare)
-prepare Agent             (agent-loop prepare)
-await setup(agent.ctx)    # ← 异步，先于任何 store 条目。拒绝 → 回滚。
+### Agent Factory Genesis
+
+Agent factory 在 publication 前增加了 async setup window：
+
+```text
+prepare Session
+prepare Agent
+      ↓
+await setup(agentCtx)       unpublished
+      ↓
 setupCommit?.commit()
-publish():
-    sessions.enter(session)   # store 条目 —— get/list/history 现在可见
-    agents.enter(agent)
-    sessions.announce(session)  # `session/created`（同步派发）
-    agents.announce(agent)
+      ↓
+sessions.enter(session)
+agents.enter(agent)
+announce / start
 ```
 
-`CreateAgentOptions.setup` / `ResumeAgentOptions.setup` 是**公开**的，且被**全部四条**创生路径（create / fork / subagent / resume）传入。因此 DSH **确实**有一个现有的异步、可见之前的准入点 —— `setup` 钩子。
+真正有价值的是这个 setup composition boundary：setup 失败时 Session / Agent 仍未对外可见，可以完整 rollback。
 
-悬而未决的问题是**可组合性，而非存在性**：`setup` 是一个由调用方（`composition.setup`）提供的逐调用选项，而非全局中间件。第三方插件能否无条件地参与*每一次* setup，正是 M2.1 必须回答的。
+## 当前 Executable Evidence
 
-## 2. 创生路径
+仓库不再把历史 source read 当成当前兼容性证明。`scripts/session-genesis-probe.mjs` 会在干净临时 consumer 中安装 `scripts/dsh-target.mjs` 指定的精确 DSH baseline（当前 `0.1.1-rc.2`），并断言：
 
-| 路径 | 入口（RPC） | 所有者来源 | 经过 | 首次可见 | 回滚 |
-| --- | --- | --- | --- | --- | --- |
-| **create** | `session.create` | 调用方 principal —— **未被携带** | `ctx.agents.create({sessionId, meta, setup})` → `setupAndPublish` | `sessions.enter` → `list`/`get`；`announce` → `mux`/`host` | `setup` 拒绝或同步 `session/created` 抛出 → `dispose()` |
-| **fork** | `session.fork` | **继承父级** | `ctx.agents.create({parentSession, seed, setup})` | 同上 | 同上 |
-| **subagent** | `subagent.*` | **继承父级** | `ctx.agents.create({origin:'subagent', parentSession, setup})` | 同上 | 同上 |
-| **resume** | `session.create`(预分配)/`history`/`prompt` | **恢复持久化** | `ctx.agents.resume({resumeSessionId, setup})` | 同上 | 同上 |
+1. `session/created` 执行时 Session 已经进入 store；
+2. 同步 `session/created` throw 会 rollback publication；
+3. async listener rejection 无法否决已经完成的同步 publication boundary。
 
-## 3. 钩子候选
+`scripts/admission-decorator-probe.mjs` 另行证明 create / fork / subagent / resume 四条路径的 Agent setup 都发生在 `sessions.enter` 之前。
 
-| 候选 | 异步 | 先于 store 条目 | 可组合 | 判定 |
-| --- | --- | --- | --- | --- |
-| `setup`（`CreateAgentOptions.setup`） | ✅ | ✅（先于 `sessions.enter`） | ❌ 逐调用，非全局 | 正确的点；**可组合性是缺口** |
-| `session/created` 监听器 | ❌ 仅同步否决 | ❌ 在 `enter` 之后 | 不适用 | 太晚 + 无异步否决 |
-| 包装 `ctx.agents` | ✅（介入） | ✅ | ⚠️ 需要 principal（create）/ 父所有者（fork/subagent） | 可行但与 H3 耦合 |
+这些 probe 在 Node 22.19 与 Node 24 上都是 blocking CI。
 
-## 4. 关键发现
+## 对当前架构的影响
 
-- **F1** —— `session/created` 在 `enter` **之后**触发；事件触发时会话已对 store 可见。（运行时确认）
-- **F2** —— `session/created` 是**仅同步否决**：同步抛出会回滚 `enter`，异步监听器的拒绝会被记录，而非否决。异步所有权认领无法搭它。（运行时确认）
-- **F3** —— principal 在 RPC 边界被丢弃；只有**顶层 create** 需要它。fork/subagent 需要父所有者，resume 需要持久所有者 —— 二者都不需要 HTTP principal。
-- **F4** —— fork/subagent 通过 `meta.parentSession` 继承。**store 契约**（`store.claim(childId, SessionOwner)`）已经表达继承；只有 `MultiTenantService.claimSession()` 辅助函数是 Principal 导向的。这是**易用性**缺口，而非能力缺口。
-- **F5** —— resume 恢复持久所有者。同所有者认领是**幂等、而非冲突**；resume 必须读取持久所有权，而非重新认领。
+v0.2 对 Tenant / Principal Runtime node 使用相同 publication 原则：
 
-## 5. 不变量评估
+```text
+prepare unpublished subtree
+      ↓
+await setup(signal)
+      ↓
+optional synchronous commit()
+      ↓
+publish canonical node
+```
 
-| 不变量 | 状态 |
-| --- | --- |
-| 1. 无所有权窗口 | ✅ `setup` 先于 `sessions.enter` 运行 —— `setup` 中的准入无窗口 |
-| 2. 子级继承显式 | ⚠️ store 契约可表达（F4），但准入在钩子处需要父所有者 |
-| 3. 失败时无幽灵所有权 | ✅ 保留墓碑 —— 无访问授予；同所有者重试幂等；不同所有者重试冲突（正确） |
-| 4. resume 不窃取 | ✅ 同所有者幂等认领；恢复，而非重新认领 |
-| 5. 并发创生唯一 | ✅ `sessionCreations` 去重 + `enter` 冲突检查 |
+这是刻意与 DSH 生命周期语义保持一致，而不是另造一套平行 transaction model。
 
-## 6. 结论（见 `../adr/session-genesis.md`）
-
-`setup` 钩子是可见之前的异步准入点。可组合性通过包装 `ctx.agents`（与 H3 包装 `ApiProxy` 相同的机制）实现。Fork / subagent / resume 今天即可从父/持久所有者解决；只有顶层 create 需要 H3 的 request-scoped principal。幽灵所有权是一个安全的保留墓碑。上游提案收窄为**仅 H3**。
+当前 DSH baseline 与 evidence policy 见 [`../reference/compatibility.zh-CN.md`](../reference/compatibility.zh-CN.md)。

--- a/docs/specs/web-seam-map.md
+++ b/docs/specs/web-seam-map.md
@@ -1,148 +1,61 @@
 [简体中文](./web-seam-map.zh-CN.md) | English
 
-# DSH Web Multi-Tenant Seam Map
+# DSH Web Multi-Tenant Seam Map — historical research
 
-> Based on `deepseek-ai/deepseek-harness` @ `47f943859bef60e4160492346772ded9b24f765a`
-> (master, 2026-08-15). Preliminary verdicts are refined by executable proof;
-> current policy lives in `../adr/web-enforcement.md`.
->
-> **Converged since this map was first written**: **H1** (create→claim atomicity)
-> is resolved by the Agent `setup` hook — admission runs before `sessions.enter`
-> (runtime-proven M4 ②-A). **H3** (principal propagation) remains the transport
-> hypothesis to prove in ②-C. **H4** (`respond`) is plugin-solvable in principle
-> but is **not closed yet**: the real `ClientResponse` carries `rpcId + result`,
-> not `sessionId`, so authorization needs `rpcId → sessionId` correlation.
-> **H2** (resource model) stays deferred.
+This document preserves the earlier Web/API authorization investigation. It is **not the current transport architecture authority**. v0.3 transport design starts from the canonical Tenant/Principal Runtime Contract in [`architecture.md`](./architecture.md).
 
-## 1. Summary
+## Historical source
 
-DSH Web exposes **five** authorization-relevant surfaces, organized by
-**Resource × Access Shape → Enforcement** (not by transport):
+The original seam map was based on DeepSeek Harness commit:
 
-| # | Surface | Shape | Enforcement | Seam |
-|---|---|---|---|---|
-| 1 | Unary RPC (`session.history`, …) | Point / Collection / Admission | Guard / Filter / Admit / Deny | real `ApiProxy` facade |
-| 2 | `events.mux` | Stream | Filter | `ApiProxy.events.mux()` |
-| 3 | `events.host` | Stream | Filter / deny | `ApiProxy.events.host()` |
-| 4 | `/api/respond` (approval/question) | Response | Guard after correlation | `toFetchHandler` special-case |
-| 5 | `session.create` / fork/subagent/resume | Create | Pre-publication ownership admission | Agent `setup` |
+`47f943859bef60e4160492346772ded9b24f765a`
 
-## 2. Matrix
+It established several reusable enforcement ideas:
 
-| Resource | Operation | Shape | Enforcement | Physical seam | Evidence | Current verdict |
-|---|---|---|---|---|---|---|
-| Session | `history` `prompt` `rename` `fork` `cancel` `models` `selectModel` `attachment` `updateQueue` | Point | Guard | real `ApiProxy` facade | payload carries `sessionId` | **Guardable**; principal binding still needs ②-C (→H3) |
-| Session | `list` | Collection | Filter | real `ApiProxy` facade | current list returns the complete visible baseline | **Post-filterable**; implemented in ②-B |
-| Session | `search` | Query-scoped collection | Deny for v0 | real `ApiProxy` facade | globally ranked/capped (20) + `hasMore`; post-filtering can discard tenant-owned lower-ranked matches | **Not correctly post-filterable**; needs scoped query semantics |
-| Session | `create` | Create | Admit | Agent `setup` + transport bridge | setup admission runs before `sessions.enter`; caller principal is still missing at transport | **H1 solved; H3/②-C still required** |
-| Session | fork / subagent | Create | Inherit | Agent `setup` | parent id is available in create options | **Runtime-proven admission path** |
-| Session | resume | Create | Restore | Agent `setup` | `resumeSessionId` available; durable owner is authoritative | **Runtime-proven admission path** |
-| Session | mux frames | Stream | Filter | `events.mux` | all-session aggregated; session-bearing frames are keyed | **Pending ②-C** |
-| Approval/Question | `respond` | Response | Guard after correlation | `/api/respond` | incoming `ClientResponse` has `rpcId`, not `sessionId`; outgoing request/pending registry identifies the session | **Pending ②-C correlation proof** (H4) |
-| Workspace | host frames / workspace methods | Host/global resource | Deny in v0 | facade / host stream | no tenant resource model yet | **DENY until H2** |
-| Deployment management | settings / credentials / preset authoring / host-scoped LLM config | Host-global privileged surface | Deny in v0 | real `ApiProxy` facade | modifies or reveals deployment-level configuration/capabilities | **DENY** |
+| Surface shape | Useful enforcement idea |
+| --- | --- |
+| Session-keyed point RPC | Guard ownership before dispatch. |
+| Collection RPC | Filter only when post-filter semantics remain correct. |
+| Create/resume | Admit before publication through Agent setup. |
+| Streams/respond/global surfaces | Deny until an explicit tenant resource/correlation model exists. |
 
-## 3. Unary RPC surface (`RpcMethodMap` — closed typed union)
+These ideas remain useful, but the old spike's transport model is no longer the target architecture.
 
-The `/api` unary surface is a **generated, closed map**. `dsh-multi-tenant-web`
-now imports the real `RpcMethodMap` and defines:
+## What changed architecturally
 
-```ts
-Record<keyof RpcMethodMap, Category>
-```
-
-so a new DSH method or a misspelled classification key fails `tsc` instead of
-silently falling through. The runtime backstop still treats unknown string
-methods as `deny`.
-
-Namespaces / methods (52 total):
-
-| Namespace | Methods | Tenant-security treatment |
-|---|---|---|
-| `session.*` | `list` `search` `create` `history` `models` `selectModel` `rename` `fork` `prompt` `attachment` `updateQueue` `cancel` | list=FILTER; search=DENY pending scoped query; create=ADMIT; remaining session-keyed methods=GUARD |
-| `subagent.*` | `list` `history` `prompt` `interrupt` | GUARD on `parentSessionId` |
-| `host.*` | `describe` `pickDirectory` `listDirectory` `createDirectory` `openPath` | DENY (host-global) |
-| `workspace.*` | `list` `create` `rename` `delete` `insertBefore` `insertSessionBefore` `archiveSession` | DENY until H2 |
-| `goal.*` | `create` `edit` `pause` `resume` `complete` `clear` | GUARD on `sessionId` |
-| `skill.*` | `list` | GUARD on `sessionId` |
-| `agentPreset.*` | `list` `select` `read` `copy` `openDocument` `remove` | list=ALLOW picker discovery; select=GUARD; authoring/inspection=DENY |
-| `settings.*` | `describe` `openDocument` `update` `replace` `mutate` | DENY (deployment configuration) |
-| `credentials.*` | `describe` `set` `unset` | DENY (deployment credentials) |
-| `llm.*` | `providers` `models` `discoverModels` | DENY for v0 (host-scoped configuration/catalog); guarded `session.models` remains available |
-
-The important distinction is now explicit: **no session id** does not imply
-**ALLOW**. Host/global privilege surfaces are denied until they have an explicit
-resource/role model.
-
-## 4. Stream surfaces
-
-### 4.1 `events.mux` — `MuxFrame` (all-session aggregated)
-
-```ts
-type MuxFrame =
-  | { type: 'session/event'; sessionId; … }
-  | { type: 'session/subscribed'; sessionId; … }
-  | { type: 'approval/requested'; sessionId; approvalId; … }
-  | { type: 'approval/resolved'; sessionId; … }
-  | { type: 'question/requested'; sessionId; … }
-  | { type: 'question/resolved'; sessionId; … }
-  | { type: 'session/queue'; sessionId; … }
-  | { type: 'session/jobs'; sessionId; … }
-  | { type: 'session/projection'; sessionId; … }
-  | { type: 'stream/error'; error }
-```
-
-Session-bearing frames can be filtered by ownership once a principal is bound to
-the connection. Unclassifiable/control/error frames need an explicit redact or
-terminate policy; they must not be blindly attributed to a tenant.
-
-### 4.2 `events.host` — `HostFrame` (mixed resource)
-
-`events.host` mixes Session, Workspace, and host-global frames. v0 therefore
-allows only explicitly session-keyed frames that pass ownership and denies the
-rest until H2 defines Workspace/host resource ownership.
-
-## 5. `/api/respond` (bidirectional)
-
-Approval/question is server-initiated: the host emits a `ServerRequest` carrying
-its `rpcId` and session-bearing payload; the browser replies with a
-`ClientResponse` over `POST /api/respond`. The **incoming response itself does
-not carry `sessionId`** — it carries only `rpcId` and `result`.
-
-Therefore the tenant guard must keep or query a pending correlation:
+v0.2 introduced a canonical runtime hierarchy:
 
 ```text
-outgoing server request
-rpcId -> sessionId
-        ↓
-incoming ClientResponse(rpcId)
-        ↓
-resolve sessionId
-        ↓
-assertSessionAccess(principal, sessionId)
-        ↓
-api.respond(...)
+Tenant -> Principal -> derived integration fiber -> DSH operation
 ```
 
-This is currently fail-closed in `bindTenant` and remains M4 ②-C work. No
-respond-specific upstream seam is assumed until the real transport proof says
-one is necessary.
+The future authenticated transport path should therefore be:
 
-## 6. Seams and gaps
+```text
+HTTP / WebSocket / other wire boundary
+        ↓ authenticate explicit identity
+TenantPrincipal
+        ↓ resolve canonical Tenant/Principal
+Principal Runtime
+        ↓ derive operation fiber + explicit inject
+DSH API / Agent operation
+```
 
-| Gap | Evidence | Status |
-|---|---|---|
-| Request/connection has no proven principal binding point | unary handler drops Request; WS/HTTP collapse into shared services | H3 hypothesis — prove in ②-C |
-| Mux/host streams are global | shared `ApiProxy` / aggregated streams | ②-C |
-| `/api/respond` identifies the pending interaction by `rpcId`, not `sessionId` | real `ClientResponse` shape | H4 correlation proof pending ②-C |
-| ~~create→claim race~~ | Agent setup runs admission before `sessions.enter` | ~~H1~~ resolved (M4 ②-A) |
-| host/workspace/config surfaces have no tenant resource model | host-global contracts | DENY; H2 / privilege model deferred |
-| `session.search` is globally capped/ranked | max 20 + `hasMore` | scoped query seam/design pending |
+Transport identity is explicit at the security boundary; capability/lifecycle scope comes from the canonical Principal Runtime. This is preferable to attaching `tenantId` parameters to every downstream API or keeping a Web-specific tenant registry.
 
-## 7. Ecosystem notes
+## Current status of the old Web package
 
-- **Stale `latest` dist-tags.** Consumers pin explicit prerelease versions rather
-  than relying on `latest` while the DSH prerelease tags remain inconsistent.
-- **Real `ApiProxy`.** The web package now compiles against the real
-  `@deepseek-ai/dsh-host-apiproxy/api` contract; the old spike-local `ApiSurface`
-  has been removed.
+`packages/multi-tenant-web` remains private and preserves:
+
+- real `ApiProxy` experiments;
+- exhaustive DSH unary API classification;
+- fail-closed guard/filter/deny research.
+
+It is a research/compatibility package, not a production v0.3 framework layer. Code is reusable only when it fits the current runtime structure without compatibility shims or parallel state.
+
+## Current evidence
+
+The admission-before-publication part of the original map is now executable CI evidence through `scripts/admission-decorator-probe.mjs` against the exact DSH baseline (`0.1.1-rc.2`).
+
+Current DSH compatibility policy: [`../reference/compatibility.md`](../reference/compatibility.md).
+Current product direction: [`../../ROADMAP.md`](../../ROADMAP.md).

--- a/docs/specs/web-seam-map.zh-CN.md
+++ b/docs/specs/web-seam-map.zh-CN.md
@@ -1,109 +1,61 @@
 [English](./web-seam-map.md) | 简体中文
 
-# DSH Web 多租户 Seam 图
+# DSH Web Multi-Tenant Seam Map —— 历史研究
 
-> 基于 `deepseek-ai/deepseek-harness` @ `47f943859bef60e4160492346772ded9b24f765a`
-> （master，2026-08-15）。初步判定由可执行证据不断细化；当前策略以 `../adr/web-enforcement.md` 为准。
->
-> **本图最初成文后已收敛**：**H1**（create→claim 原子性）由 Agent `setup` 钩子解决 —— 准入在 `sessions.enter` 之前运行（M4 ②-A 运行时证明）。**H3**（principal 传播）仍是 ②-C 要验证的 transport 假设。**H4**（`respond`）原则上可由插件解决，但**尚未闭环**：真实 `ClientResponse` 只有 `rpcId + result`，没有 `sessionId`，因此授权需要 `rpcId → sessionId` 关联。**H2**（资源模型）仍延后。
+本文档保留早期 Web/API authorization 调查。它**不是当前 transport architecture authority**。v0.3 transport design 应从 [`architecture.zh-CN.md`](./architecture.zh-CN.md) 中的 canonical Tenant / Principal Runtime Contract 出发。
 
-## 1. 概述
+## 历史 Source
 
-DSH Web 暴露**五类**与授权相关的 surface，按 **Resource × Access Shape → Enforcement**（而非按 transport）组织：
+最初 seam map 基于 DeepSeek Harness commit：
 
-| # | Surface | Shape | Enforcement | Seam |
-|---|---|---|---|---|
-| 1 | Unary RPC（`session.history`，…） | Point / Collection / Admission | Guard / Filter / Admit / Deny | 真实 `ApiProxy` facade |
-| 2 | `events.mux` | Stream | Filter | `ApiProxy.events.mux()` |
-| 3 | `events.host` | Stream | Filter / deny | `ApiProxy.events.host()` |
-| 4 | `/api/respond`（approval/question） | Response | correlation 后 Guard | `toFetchHandler` 特例 |
-| 5 | `session.create` / fork/subagent/resume | Create | 发布前所有权准入 | Agent `setup` |
+`47f943859bef60e4160492346772ded9b24f765a`
 
-## 2. 矩阵
+它确认了几类仍有价值的 enforcement idea：
 
-| Resource | Operation | Shape | Enforcement | Physical seam | Evidence | 当前判定 |
-|---|---|---|---|---|---|---|
-| Session | `history` `prompt` `rename` `fork` `cancel` `models` `selectModel` `attachment` `updateQueue` | Point | Guard | 真实 `ApiProxy` facade | payload 携带 `sessionId` | **可守卫**；principal 绑定仍需 ②-C（→H3） |
-| Session | `list` | Collection | Filter | 真实 `ApiProxy` facade | 当前 list 返回完整 baseline | **可正确 post-filter**；②-B 已实现 |
-| Session | `search` | Query-scoped collection | v0 Deny | 真实 `ApiProxy` facade | 全局排序、最多 20 条 + `hasMore`；事后过滤会丢失本租户排名更靠后的结果 | **不能正确 post-filter**；需要 scoped query 语义 |
-| Session | `create` | Create | Admit | Agent `setup` + transport bridge | setup 准入在 `sessions.enter` 之前运行；transport 仍缺 caller principal | **H1 已解；仍需 H3/②-C** |
-| Session | fork / subagent | Create | Inherit | Agent `setup` | create options 中可拿到 parent id | **准入路径已运行时证明** |
-| Session | resume | Create | Restore | Agent `setup` | `resumeSessionId` 可得；durable owner 为权威 | **准入路径已运行时证明** |
-| Session | mux frames | Stream | Filter | `events.mux` | 全 session 聚合，session frame 有键 | **待 ②-C** |
-| Approval/Question | `respond` | Response | correlation 后 Guard | `/api/respond` | incoming `ClientResponse` 只有 `rpcId`，没有 `sessionId`；外发 request / pending registry 能定位 session | **待 ②-C correlation 证明**（H4） |
-| Workspace | host frames / workspace methods | Host/global resource | v0 Deny | facade / host stream | 尚无 tenant resource model | **H2 前 DENY** |
-| Deployment management | settings / credentials / preset authoring / host-scoped LLM config | Host-global privileged surface | v0 Deny | 真实 `ApiProxy` facade | 会修改或暴露 deployment 级配置/能力 | **DENY** |
+| Surface Shape | 可复用 Enforcement Idea |
+| --- | --- |
+| Session-keyed point RPC | dispatch 前 guard ownership。 |
+| Collection RPC | 只有 post-filter 后语义仍正确时才 filter。 |
+| Create / resume | 通过 Agent setup 在 publication 前 admit。 |
+| Streams / respond / global surface | 没有明确 tenant resource / correlation model 前继续 deny。 |
 
-## 3. Unary RPC surface（`RpcMethodMap` — 封闭 typed map）
+这些结论仍有参考价值，但旧 spike 的 transport model 已经不再是目标架构。
 
-`/api` unary surface 是一个生成的封闭 map。`dsh-multi-tenant-web` 现在直接导入真实 `RpcMethodMap` 并定义：
+## 当前架构变化
 
-```ts
-Record<keyof RpcMethodMap, Category>
-```
-
-因此 DSH 新增方法或分类 key 拼错都会让 `tsc` 失败，而不是静默放过。运行时对未知字符串方法仍默认 `deny`。
-
-命名空间 / 方法（共 52 个）：
-
-| 命名空间 | 方法 | 多租户安全处理 |
-|---|---|---|
-| `session.*` | `list` `search` `create` `history` `models` `selectModel` `rename` `fork` `prompt` `attachment` `updateQueue` `cancel` | list=FILTER；search=DENY（待 scoped query）；create=ADMIT；其他 session-keyed 方法=GUARD |
-| `subagent.*` | `list` `history` `prompt` `interrupt` | 在 `parentSessionId` 上 GUARD |
-| `host.*` | `describe` `pickDirectory` `listDirectory` `createDirectory` `openPath` | DENY（host-global） |
-| `workspace.*` | `list` `create` `rename` `delete` `insertBefore` `insertSessionBefore` `archiveSession` | H2 前 DENY |
-| `goal.*` | `create` `edit` `pause` `resume` `complete` `clear` | 在 `sessionId` 上 GUARD |
-| `skill.*` | `list` | 在 `sessionId` 上 GUARD |
-| `agentPreset.*` | `list` `select` `read` `copy` `openDocument` `remove` | list=ALLOW（picker）；select=GUARD；authoring/inspection=DENY |
-| `settings.*` | `describe` `openDocument` `update` `replace` `mutate` | DENY（deployment 配置） |
-| `credentials.*` | `describe` `set` `unset` | DENY（deployment 凭据） |
-| `llm.*` | `providers` `models` `discoverModels` | v0 DENY（host-scoped 配置/目录）；仍可使用受 GUARD 的 `session.models` |
-
-这里的关键区别是：**没有 sessionId 不等于 ALLOW**。Host/global 权限面在建立明确资源/角色模型之前一律拒绝。
-
-## 4. 流 surface
-
-### 4.1 `events.mux` — `MuxFrame`（全 session 聚合）
-
-session-bearing frame 在 connection 已绑定 principal 后可以按所有权过滤。无法归属 tenant 的 control/error frame 需要明确 redact 或 terminate 规则，不能直接归给任意租户。
-
-### 4.2 `events.host` — `HostFrame`（混合资源）
-
-`events.host` 混合 Session、Workspace 与 host-global frame。v0 因此只允许明确 session-keyed 且通过所有权检查的 frame，其余在 H2 定义 Workspace/host 资源所有权之前一律拒绝。
-
-## 5. `/api/respond`（双向）
-
-Approval/question 是服务端发起的：Host 发出一个带 `rpcId` 和 session-bearing payload 的 `ServerRequest`；浏览器再通过 `POST /api/respond` 回一个 `ClientResponse`。**incoming response 自己不带 `sessionId`** —— 只有 `rpcId` 和 `result`。
-
-因此 tenant guard 必须维护或查询 pending correlation：
+v0.2 引入 canonical runtime hierarchy：
 
 ```text
-outgoing server request
-rpcId -> sessionId
-        ↓
-incoming ClientResponse(rpcId)
-        ↓
-resolve sessionId
-        ↓
-assertSessionAccess(principal, sessionId)
-        ↓
-api.respond(...)
+Tenant -> Principal -> derived integration fiber -> DSH operation
 ```
 
-当前 `bindTenant` 对它默认拒绝，仍属于 M4 ②-C。除非真实 transport 证明必须，否则不预设需要 respond 专用上游 seam。
+未来 authenticated transport 应该形成：
 
-## 6. Seam 与缺口
+```text
+HTTP / WebSocket / other wire boundary
+        ↓ authenticate explicit identity
+TenantPrincipal
+        ↓ resolve canonical Tenant / Principal
+Principal Runtime
+        ↓ derive operation fiber + explicit inject
+DSH API / Agent operation
+```
 
-| 缺口 | Evidence | 状态 |
-|---|---|---|
-| Request/connection 尚无被证明的 principal 绑定点 | unary handler 丢失 Request；HTTP/WS 后进入共享服务 | H3 假设 —— ②-C 验证 |
-| Mux/host 流是全局的 | shared `ApiProxy` / aggregated streams | ②-C |
-| `/api/respond` 仅凭 `rpcId` 标识 pending interaction | 真实 `ClientResponse` 结构 | H4 correlation 待 ②-C 证明 |
-| ~~create→claim 竞态~~ | Agent setup 在 `sessions.enter` 前执行准入 | ~~H1~~ 已解决（M4 ②-A） |
-| host/workspace/config surface 无 tenant resource model | host-global contracts | DENY；H2 / 权限模型延后 |
-| `session.search` 全局限量/排序 | max 20 + `hasMore` | scoped query seam/design 待定 |
+Transport identity 在 security boundary 保持 explicit；capability / lifecycle scope 来自 canonical Principal Runtime。这比把 `tenantId` 参数扩散到所有下游 API，或保留 Web-specific tenant registry 更自然。
 
-## 7. 生态备注
+## 旧 Web Package 的当前定位
 
-- **过期的 `latest` dist-tag。** DSH prerelease tag 仍不稳定时，消费者 pin 显式 prerelease 版本，而不是依赖 `latest`。
-- **真实 `ApiProxy`。** Web 包现在已经直接编译到真实 `@deepseek-ai/dsh-host-apiproxy/api` 契约；旧的 spike-local `ApiSurface` 已删除。
+`packages/multi-tenant-web` 继续保持 private，用于保留：
+
+- 真实 `ApiProxy` 实验；
+- DSH unary API exhaustive classification；
+- fail-closed guard / filter / deny 研究。
+
+它是 research / compatibility package，不是 production v0.3 framework layer。只有旧代码能自然适配当前 Runtime Contract、不需要 compatibility shim 或 parallel state 时才复用。
+
+## 当前 Evidence
+
+原 seam map 中 admission-before-publication 的核心结论，现在已经通过 `scripts/admission-decorator-probe.mjs` 在精确 DSH baseline `0.1.1-rc.2` 上成为 blocking CI evidence。
+
+当前 DSH compatibility policy：[`../reference/compatibility.zh-CN.md`](../reference/compatibility.zh-CN.md)。
+当前产品方向：[`../../ROADMAP.zh-CN.md`](../../ROADMAP.zh-CN.md)。

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "typecheck": "pnpm -r typecheck",
     "test": "pnpm -r test",
     "verify": "node scripts/verify-packages.mjs",
-    "probe:dsh": "node scripts/session-genesis-probe.mjs && node scripts/admission-decorator-probe.mjs",
+    "probe:dsh": "node scripts/session-genesis-probe.mjs && node scripts/admission-decorator-probe.mjs && node scripts/agent-owner-context-probe.mjs",
     "smoke": "node scripts/package-smoke.mjs",
     "release:preflight": "node scripts/release-preflight.mjs",
     "release:registry-preflight": "node scripts/registry-preflight.mjs",

--- a/packages/multi-tenant-web/README.md
+++ b/packages/multi-tenant-web/README.md
@@ -2,38 +2,50 @@
 
 # dsh-multi-tenant-web
 
-Experimental DSH Web tenant-bound `ApiProxy` enforcement research.
+Private DSH Web / ApiProxy research package.
 
-> **Repository-only in the 0.1 kernel release.** This workspace package is
-> `private: true` and is intentionally not publishable while its production
-> principal-binding contract depends on a DSH request/connection-scoped transport
-> seam. R3 publishes only `dsh-multi-tenant`.
+This package is **not a current production layer or release artifact**. It preserves useful enforcement experiments and compile-time DSH API-surface evidence while v0.3 redesigns authenticated transport around the canonical Tenant/Principal Runtime Contract.
 
-## Status
+`private: true` is intentional.
 
-The real `ApiProxy` facade and exhaustive unary `RpcMethodMap` classification
-are implemented. The current policy is deliberately fail-closed:
+## Current role
 
-- session-keyed point methods are `guard`;
-- only `session.list` is currently `filter`;
-- `session.create` is `admit` and remains denied until principal-scoped
-  pre-publication admission can be installed;
-- `session.search`, host/global management, streams, `respond`, and downloads
-  remain denied until their supported tenant semantics exist.
+The package still proves useful facts:
 
-DSH RC7's public `ConnectionRpcHandler` exposes decoded
-`(endpoint, payload, signal)`, while the real HTTP/WS request stays inside the DSH
-Web carrier. The official carrier also documents that it currently has no
-authentication layer. The principal-scope gap is therefore treated as an
-**ecosystem seam**.
+- the real DSH `ApiProxy` facade can be exhaustively classified at compile time;
+- session-keyed operations can be guarded/fail-closed;
+- collection filtering must preserve endpoint semantics rather than blindly remove foreign rows;
+- unmodelled/global surfaces must remain denied until a tenant meaning is defined.
 
-## What happens next
+Its DSH-facing dependency is pinned to the repository-wide explicit baseline (`0.1.1-rc.2`) and checked by `pnpm verify`.
 
-This package does **not** block or ship with the first `dsh-multi-tenant` kernel
-prerelease. The next Web deliverable is a small, generic upstream
-request/connection-scope proposal. Once DSH exposes an adequate seam, this
-package can add principal-bound HTTP/WS admission, streams, `respond`, and a
-two-tenant E2E suite, then freeze a production public contract.
+## What this package does not define
 
-See [`ROADMAP.md`](../../ROADMAP.md) and
-[`docs/adr/web-enforcement.md`](../../docs/adr/web-enforcement.md).
+The old spike does not own the v0.3 transport architecture. In particular, production transport should not become another global `tenantId` plumbing layer or rely on an obsolete request model.
+
+The target v0.3 structure is:
+
+```text
+HTTP / WebSocket / other wire boundary
+        ↓ authenticate
+TenantPrincipal
+        ↓ resolve canonical runtime
+Tenant -> Principal
+        ↓ derive operation fiber
+explicit inject of transport / agents / providers
+        ↓
+DSH operation
+```
+
+Identity is explicit at the wire/security boundary. Capability and lifecycle context then flow through the canonical Principal Runtime and its derived integration fiber.
+
+## Reuse policy
+
+v0.3 may reuse code or conclusions from this package only when they fit the new structure naturally. If the old spike requires compatibility shims, parallel registries or transport-specific exceptions to the Runtime Contract, prefer a clean replacement.
+
+Historical Web seam analysis remains in:
+
+- [`docs/adr/web-enforcement.md`](../../docs/adr/web-enforcement.md)
+- [`docs/specs/web-seam-map.md`](../../docs/specs/web-seam-map.md)
+
+Those documents are evidence from earlier investigation, not the current architecture authority. Current architecture is [`docs/specs/architecture.md`](../../docs/specs/architecture.md), and the next product direction is [`ROADMAP.md`](../../ROADMAP.md).

--- a/packages/multi-tenant-web/README.zh-CN.md
+++ b/packages/multi-tenant-web/README.zh-CN.md
@@ -2,23 +2,50 @@
 
 # dsh-multi-tenant-web
 
-实验性的 DSH Web tenant-bound `ApiProxy` enforcement 研究。
+私有的 DSH Web / ApiProxy research package。
 
-> **在 0.1 kernel release 中仅保留在仓库。** 这个 workspace package 已设为 `private: true`，在 production principal-binding contract 仍依赖 DSH request/connection-scoped transport seam 时，刻意禁止发布。R3 只发布 `dsh-multi-tenant`。
+这个 package **不是当前 production layer，也不是 release artifact**。它保留有价值的 enforcement 实验与 DSH API surface 编译期证据；v0.3 会基于 canonical Tenant / Principal Runtime Contract 重新设计 authenticated transport。
 
-## 状态
+`private: true` 是刻意的。
 
-真实 `ApiProxy` facade 与 unary `RpcMethodMap` 穷举分类已经实现。当前策略刻意 fail-closed：
+## 当前作用
 
-- session-keyed point method 为 `guard`；
-- 当前只有 `session.list` 为 `filter`；
-- `session.create` 为 `admit`，在 principal-scoped pre-publication admission 可以安装以前继续拒绝；
-- `session.search`、host/global management、streams、`respond`、downloads 在真正具备支持的 tenant 语义以前继续拒绝。
+这个 package 仍然证明了一些有价值的事实：
 
-DSH RC7 公开的 `ConnectionRpcHandler` 只暴露解码后的 `(endpoint, payload, signal)`，真实 HTTP/WS request 留在 DSH Web carrier 内部。官方 carrier 文档也明确说明当前没有 authentication layer。因此 principal-scope 缺口被归类为**生态 seam**。
+- 真实 DSH `ApiProxy` facade 可以做 compile-time exhaustive classification；
+- session-keyed operation 可以 guard / fail closed；
+- collection filtering 必须保持 endpoint 语义，不能简单删除 foreign row；
+- 未建模 / global surface 在没有明确 tenant 语义前应该继续 deny。
 
-## 下一步
+它的 DSH-facing dependency 固定到仓库统一 baseline `0.1.1-rc.2`，并由 `pnpm verify` 强制检查。
 
-这个 package **不阻塞，也不会随第一次 `dsh-multi-tenant` kernel prerelease 一起发布**。Web 的下一项交付是一个小而通用的 upstream request/connection-scope proposal。DSH 提供足够 seam 以后，本 package 再增加 principal-bound HTTP/WS admission、streams、`respond` 与 two-tenant E2E suite，然后再冻结 production public contract。
+## 本 Package 不定义什么
 
-参见 [`ROADMAP.md`](../../ROADMAP.md) 与 [`docs/adr/web-enforcement.md`](../../docs/adr/web-enforcement.md)。
+旧 spike 不再定义 v0.3 transport architecture。Production transport 不应该变成另一套全局 `tenantId` plumbing，也不应该为了兼容旧 request model 反向污染 Runtime。
+
+v0.3 的目标结构是：
+
+```text
+HTTP / WebSocket / other wire boundary
+        ↓ authenticate
+TenantPrincipal
+        ↓ resolve canonical runtime
+Tenant -> Principal
+        ↓ derive operation fiber
+explicit inject of transport / agents / providers
+        ↓
+DSH operation
+```
+
+Wire / security boundary 保持 explicit identity；之后 capability 与 lifecycle context 通过 canonical Principal Runtime 与 derived integration fiber 自然传播。
+
+## Reuse Policy
+
+v0.3 只有在旧代码 / 结论能自然适配新结构时才复用。如果旧 spike 需要 compatibility shim、parallel registry 或 transport-specific exception 才能接入 Runtime Contract，应优先干净重构或替换。
+
+历史 Web seam 分析继续保存在：
+
+- [`docs/adr/web-enforcement.zh-CN.md`](../../docs/adr/web-enforcement.zh-CN.md)
+- [`docs/specs/web-seam-map.zh-CN.md`](../../docs/specs/web-seam-map.zh-CN.md)
+
+这些文档属于早期 investigation evidence，不是当前 architecture authority。当前架构见 [`docs/specs/architecture.zh-CN.md`](../../docs/specs/architecture.zh-CN.md)，下一阶段产品方向见 [`ROADMAP.zh-CN.md`](../../ROADMAP.zh-CN.md)。

--- a/packages/multi-tenant-web/package.json
+++ b/packages/multi-tenant-web/package.json
@@ -24,7 +24,7 @@
   },
   "devDependencies": {
     "@deepseek-ai/cordis": "^4.0.1",
-    "@deepseek-ai/dsh-host-apiproxy": "0.1.0-rc.7",
+    "@deepseek-ai/dsh-host-apiproxy": "0.1.1-rc.2",
     "@types/node": "^22.20.0",
     "tsdown": "^0.22.2",
     "typescript": "^6.0.3",

--- a/packages/multi-tenant/README.md
+++ b/packages/multi-tenant/README.md
@@ -2,144 +2,144 @@
 
 Context-native multi-tenant runtime primitives for DeepSeek Harness (DSH).
 
-> **v0.2 line:** `0.2.0-rc.1` moves the project from an authorization-only kernel toward a real multi-tenant runtime. The published v0.1 tags are frozen historical contracts: immutable session ownership + fail-closed authorization. v0.2 keeps that kernel and adds tenant/principal Cordis capability scopes.
+> Current package: `0.2.0-rc.3`, published on npm `latest`.
 >
-> Executable DSH compatibility target remains the proven `0.1.0-rc.7` closure for this architecture PR. Current upstream `0.1.1-rc.2` scope behavior was reviewed; dependency/lockfile upgrade is a separate follow-up.
+> Current DSH compatibility baseline: `0.1.1-rc.2` at release commit `b150a551b8d465e31e418e1b2eaf5e79bbb7d28e`. The baseline is explicitly pinned and manually advanced.
+
+## Runtime model
+
+v0.2 models tenancy as a canonical ownership tree with one lifecycle vocabulary:
+
+```text
+Deployment / Root
+│
+├── shared ownership kernel
+├── shared TenantRuntimeService
+│
+├── Tenant(acme)
+│   ├── tenant capability graph
+│   ├── Principal(alice)
+│   │   └── principal capability graph
+│   └── Principal(bob)
+│
+└── Tenant(globex)
+```
+
+Tenant/Principal capability authority uses Cordis service isolation. DSH Agent/Preset registration visibility remains a separate `@deepseek-ai/dsh-scope` plane.
 
 ## Supported guarantee
 
-v0.2 has two enforcement layers:
+v0.2 combines two independent enforcement layers:
 
-1. **Context-native capability isolation** — `ctx.tenantRuntime` mints real Cordis child lifecycles. Selected service names receive tenant-local and optionally principal-local isolation labels. Plugins/providers mounted below those contexts resolve inside that capability graph rather than through an application-level `tenantId -> service` registry.
-2. **Persistent ownership authorization** — the v0.1 `ctx.multiTenant` service remains deployment-global and enforces immutable `(tenantId, userId)` session ownership with fail-closed access decisions.
+1. **Context-native capability isolation** — canonical Tenant/Principal nodes own real Cordis child lifecycles and explicit isolation labels.
+2. **Persistent ownership authorization** — the v0.1 `ctx.multiTenant` kernel remains deployment-global and enforces immutable `(tenantId, userId)` session ownership.
 
-The ownership kernel still guarantees:
+The Runtime Contract guarantees:
 
-- claim-once immutable ownership;
-- unconditional cross-tenant denial;
-- same-user ownership in v0.x;
-- unknown/foreign sessions fail closed;
-- non-enumerating public denial errors;
-- a replaceable async `TenantSessionStore` seam.
+- one canonical active Tenant per tenant id;
+- one canonical active Principal per user id inside that Tenant;
+- one `ensure/get/state/dispose` vocabulary at both levels;
+- preparing nodes are never visible;
+- concurrent `ensure()` calls single-flight;
+- setup runs before publication and may return synchronous `commit()`;
+- failed setup fully rolls back;
+- preparing transactions are cancellable lifecycle resources;
+- registry shutdown closes admission, cancels preparing nodes, then drains published scopes;
+- active definition drift fails explicitly;
+- Tenant teardown owns Principal teardown;
+- ownership/security and Cordis core services cannot be isolated away.
 
-The runtime additionally guarantees:
-
-- one canonical live tenant capability graph per `TenantRuntimeService`;
-- exact tenant/principal identity binding to the returned contexts;
-- tenant-local Cordis service resolution for explicitly isolated services;
-- principal-local Cordis service resolution for explicitly isolated services;
-- the ownership kernel, runtime manager, and Cordis core services cannot be accidentally isolated away;
-- tenant/principal scope disposal follows Cordis fiber lifecycle.
-
-## Context-native runtime
-
-The runtime deliberately uses Cordis as the scope system instead of inventing another dependency container.
+## Canonical publication
 
 ```ts
-const acme = ctx.tenantRuntime.createTenant('acme', {
+const acme = await ctx.tenantRuntime.tenants.ensure('acme', {
   isolateServices: ['tenantAuth', 'tenantMcp'],
+  setup: async ({ ctx: tenantCtx, identity, signal }) => {
+    await tenantCtx.plugin(authProvider, acmeAuthConfig)
+    await tenantCtx.plugin(mcpProvider, acmeMcpConfig)
+
+    return {
+      commit() {
+        // Optional exact publication-boundary commit.
+      },
+    }
+  },
 })
 
-await acme.ctx.plugin(authProvider, acmeAuthConfig)
-await acme.ctx.plugin(mcpProvider, acmeMcpConfig)
-
-const alice = acme.createPrincipal(
-  { tenantId: 'acme', userId: 'alice' },
-  { isolateServices: ['userCredentials'] },
-)
-
-await alice.ctx.plugin(credentialsProvider, aliceCredentials)
+const alice = await acme.principals.ensure('alice', {
+  isolateServices: ['userCredentials'],
+  setup: async ({ ctx: principalCtx }) => {
+    await principalCtx.plugin(credentialsProvider, aliceCredentials)
+  },
+})
 ```
 
-Conceptually:
+A Principal registry is structurally nested under its Tenant, so Principal creation takes only `userId`; the parent Tenant supplies `tenantId` by construction.
 
-```text
-Deployment / Root Context
-│
-├── shared ownership kernel (ctx.multiTenant)
-├── shared durable ownership store
-│
-├── Tenant A Context
-│   ├── tenant-local auth / MCP / providers
-│   └── Principal Alice Context
-│       └── user-local credentials
-│
-└── Tenant B Context
-    ├── tenant-local auth / MCP / providers
-    └── Principal Bob Context
-        └── user-local credentials
-```
+Calling `ensure(key)` without a definition joins an existing canonical node without requiring consumers to know its creation recipe. Only callers that explicitly supply a definition participate in definition-drift validation.
 
-`tenantIdOf(ctx)` and `principalOf(ctx)` expose the trusted same-process contextual identity to plugins. They are routing/composition metadata, **not authorization decisions**. Durable/session boundaries must still use `ctx.multiTenant`.
+## Agent composition boundary
 
-### Two scope planes, on purpose
-
-DSH already has `@deepseek-ai/dsh-scope` for Agent/Preset registration visibility. v0.2 does **not** reuse that single parent chain as the tenant authority graph because Agent Presets already use the Agent scope parent relation.
-
-- **Cordis service isolation:** tenant/principal capability providers.
-- **DSH scope chain:** Agent/Preset tools, prompt contributions, listeners and other registration views.
-
-Keeping these planes separate avoids competing parent bindings and makes the security boundary explicit.
-
-## Core APIs
-
-### `ctx.tenantRuntime`
+A canonical Principal Context is a capability root, not a bypass around Cordis dependency injection. Agent orchestration therefore runs in a derived integration fiber that explicitly injects `agents`:
 
 ```ts
-interface TenantScopeOptions {
-  isolateServices?: readonly string[]
-}
+const alice = await acme.principals.ensure('alice')
 
-interface PrincipalScopeOptions {
-  isolateServices?: readonly string[]
-}
+const operation = alice.ctx.inject(['agents'], async (ownerCtx) => {
+  return ownerCtx.agents.create({
+    sessionId,
+    setup(agentCtx) {
+      const tenantMcp = ownerCtx.get('tenantMcp')
+      // Compose DSH tools/prompts/listeners into agentCtx.
+    },
+  })
+})
 
-ctx.tenantRuntime.createTenant(tenantId, options)
-ctx.tenantRuntime.get(tenantId)
+await operation
 ```
 
-A live tenant id may have only one runtime scope. Dispose it before recreating the same tenant.
+DSH carries that caller-bound context into the Agent factory as `ownerCtx`. CI executes the real public AgentRegistry package to prove Principal identity and A/B capability separation at this boundary.
 
-### `ctx.multiTenant`
+## Tenant-safe provider contract
 
-The v0.1 kernel remains supported:
+`dsh-multi-tenant/testing` exports an executable provider conformance harness:
 
 ```ts
-interface TenantPrincipal {
-  tenantId: string
-  userId: string
-}
-
-ctx.multiTenant.claimSession(sessionId, principal)
-ctx.multiTenant.canAccessSession(principal, sessionId)
-ctx.multiTenant.assertSessionAccess(principal, sessionId)
+await assertRuntimeCapabilityProviderContract({
+  serviceName: 'myCapability',
+  level: 'tenant', // or 'principal'
+  mount: async (ctx, marker) => { /* mount provider */ },
+  fingerprint: async ctx => { /* identify resolved instance */ },
+})
 ```
+
+The harness checks same-name A/B isolation, root/parent non-leakage, descendant inheritance, sibling non-interference, disposal isolation, clean recreation and unpublished setup ownership.
+
+## Context identity is not authorization
+
+`runtimeIdentityOf(ctx)`, `tenantIdOf(ctx)` and `principalOf(ctx)` expose trusted same-process composition metadata. They are **not** durable authorization decisions. Session/durable boundaries must still use `ctx.multiTenant`.
 
 ## Explicit boundaries
 
-This package is **not** a process/container sandbox. Cordis contexts isolate service resolution and lifecycle, not arbitrary same-process code. A trusted plugin can still reach process globals, filesystem, network, environment variables, or deliberately walk to `ctx.root`.
+This package is not a hostile-code/process sandbox. Cordis Context does not isolate process globals, filesystem, shell, network, environment variables, or a plugin deliberately escaping to `ctx.root`.
 
-Strong process/filesystem/network/shell isolation belongs to deployment boundaries such as one tenant per container/Pod.
+Strong isolation belongs to process/container/Pod deployment boundaries.
 
-v0.2 RC1 also does **not** claim that every existing DSH plugin is automatically tenant-aware. Providers must be compatible with being instantiated below a tenant context. Known example from the reviewed current upstream: the DSH MCP client reserves `serverName` against `ctx.root`, so identical server names across tenant-local MCP instances still require an upstream/provider change or unique names. That is an ecosystem compatibility gap, not something this package hides with a second registry.
-
-The package also does not provide billing, organization UI, a general RBAC framework, or a full HTTP/WebSocket authentication transport. An authenticated boundary must select/create the correct tenant/principal context before driving DSH work.
+The package also does not claim every existing DSH provider is tenant-safe. Provider compatibility must be proven rather than assumed. Product-level auth, HTTP/WebSocket binding, billing, organization UI and production MCP SaaS composition belong to the upcoming SaaS Framework / Plugin Family.
 
 ## Install
 
-Prereleases use the `next` dist-tag:
-
 ```sh
-dsh plugin --profile <profile> add dsh-multi-tenant@next
+dsh plugin --profile <profile> add dsh-multi-tenant
 ```
+
+The project currently publishes only one npm channel: `latest` is the newest intentionally released build.
 
 The bundle installs three deployment-global rows:
 
-- `ctx.tenantSessionStore` — in-memory reference provider;
+- `ctx.tenantSessionStore` — in-memory reference ownership provider;
 - `ctx.multiTenant` — persistent ownership/authorization kernel;
-- `ctx.tenantRuntime` — context-native tenant runtime manager.
-
-Production deployments should replace the in-memory ownership store with a durable provider.
+- `ctx.tenantRuntime` — canonical Tenant/Principal runtime manager.
 
 ## Release verification
 
@@ -148,7 +148,7 @@ pnpm install --frozen-lockfile
 pnpm release:check
 ```
 
-The release gates cover package invariants, typecheck, unit/contract tests, packed external-consumer smoke, and the pinned DSH runtime probes.
+CI additionally checks out the exact upstream DSH release commit and verifies its version, then runs executable compatibility probes against the exact npm packages.
 
 ## License
 

--- a/packages/multi-tenant/README.zh-CN.md
+++ b/packages/multi-tenant/README.zh-CN.md
@@ -2,146 +2,146 @@
 
 # dsh-multi-tenant
 
-面向 DeepSeek Harness（DSH）的 Context-native 多租户 Runtime 原语。
+面向 DeepSeek Harness（DSH）的 Context-native Multi-Tenant Runtime 原语。
 
-> **v0.2 版本线：** `0.2.0-rc.1` 将项目从“授权 Kernel”提升为“真正的 Multi-Tenant Runtime”。已经发布的 v0.1 tag 作为历史契约冻结：不可变 session ownership + fail-closed authorization。v0.2 保留这层 Kernel，并新增 Tenant / Principal 的 Cordis capability scope。
+> 当前 package：`0.2.0-rc.3`，发布到 npm `latest`。
 >
-> 本 PR 的可执行 DSH compatibility target 保持仓库已经验证的 `0.1.0-rc.7` 依赖闭包；设计阶段已审阅当前上游 `0.1.1-rc.2` 的 scope 行为，完整依赖/lockfile 升级单独处理。
+> 当前 DSH compatibility baseline：`0.1.1-rc.2`，release commit 为 `b150a551b8d465e31e418e1b2eaf5e79bbb7d28e`。Baseline 显式固定，由我们手动推进。
+
+## Runtime Model
+
+v0.2 把 tenancy 建模成一棵 canonical ownership tree，并统一生命周期语义：
+
+```text
+Deployment / Root
+│
+├── shared ownership kernel
+├── shared TenantRuntimeService
+│
+├── Tenant(acme)
+│   ├── tenant capability graph
+│   ├── Principal(alice)
+│   │   └── principal capability graph
+│   └── Principal(bob)
+│
+└── Tenant(globex)
+```
+
+Tenant / Principal capability authority 使用 Cordis service isolation；DSH Agent / Preset registration visibility 保持独立的 `@deepseek-ai/dsh-scope` plane。
 
 ## Supported guarantee
 
-v0.2 有两层保证：
+v0.2 保留两层互相独立的 enforcement：
 
-1. **Context-native capability isolation** —— `ctx.tenantRuntime` 创建真实 Cordis child lifecycle；显式指定的 service name 获得 tenant-local、以及可选的 principal-local isolation label。Tenant Provider 挂在对应 Context 下，不再额外发明一套 `tenantId -> service` 容器。
-2. **Persistent ownership authorization** —— v0.1 的 `ctx.multiTenant` 保持 deployment-global，继续对 `(tenantId, userId)` session ownership 做不可变、fail-closed 的持久安全校验。
+1. **Context-native capability isolation** —— canonical Tenant / Principal node 拥有真实 Cordis child lifecycle 与显式 isolation label；
+2. **Persistent ownership authorization** —— v0.1 `ctx.multiTenant` Kernel 保持 deployment-global，对 `(tenantId, userId)` session ownership 做不可变、fail-closed 授权。
 
-Ownership Kernel 继续保证：
+Runtime Contract 进一步保证：
 
-- claim-once、不可变 ownership；
-- cross-tenant 永远拒绝；
-- v0.x 同用户 ownership；
-- unknown / foreign session fail closed；
-- public denial 不可枚举；
-- 可替换的 async `TenantSessionStore` seam。
+- 每个 tenantId 一个 canonical active Tenant；
+- 每个 Tenant 内每个 userId 一个 canonical active Principal；
+- Tenant / Principal 共用 `ensure / get / state / dispose` 语义；
+- preparing node 永远不可见；
+- 同 key 并发 `ensure()` single-flight；
+- setup 在 publication 前运行，并可返回同步 `commit()`；
+- setup 失败完整 rollback；
+- preparing transaction 是可取消的 first-class lifecycle resource；
+- registry shutdown 先 close admission、cancel preparing，再 drain published scope；
+- active definition drift 明确失败；
+- Tenant teardown 拥有 Principal teardown；
+- ownership/security 与 Cordis core service 不可被隔离掉。
 
-Runtime 新增保证：
-
-- 一个 `TenantRuntimeService` 内，同 tenantId 只能存在一个 canonical live capability graph；
-- Tenant / Principal identity 精确绑定到返回的 Context；
-- 显式隔离的 service 在 Tenant Context 中独立解析；
-- 显式隔离的 service 在 Principal Context 中可再独立一层；
-- ownership kernel、runtime manager 与 Cordis core service 禁止被错误隔离；
-- Tenant / Principal 生命周期沿 Cordis Fiber dispose。
-
-## Context-native runtime
-
-v0.2 直接使用 Cordis 作为 scope system，而不是在 Cordis 里面重新实现一套 dependency container。
+## Canonical Publication
 
 ```ts
-const acme = ctx.tenantRuntime.createTenant('acme', {
+const acme = await ctx.tenantRuntime.tenants.ensure('acme', {
   isolateServices: ['tenantAuth', 'tenantMcp'],
+  setup: async ({ ctx: tenantCtx, identity, signal }) => {
+    await tenantCtx.plugin(authProvider, acmeAuthConfig)
+    await tenantCtx.plugin(mcpProvider, acmeMcpConfig)
+
+    return {
+      commit() {
+        // 可选：只在精确 publication boundary 执行的最终提交。
+      },
+    }
+  },
 })
 
-await acme.ctx.plugin(authProvider, acmeAuthConfig)
-await acme.ctx.plugin(mcpProvider, acmeMcpConfig)
-
-const alice = acme.createPrincipal(
-  { tenantId: 'acme', userId: 'alice' },
-  { isolateServices: ['userCredentials'] },
-)
-
-await alice.ctx.plugin(credentialsProvider, aliceCredentials)
+const alice = await acme.principals.ensure('alice', {
+  isolateServices: ['userCredentials'],
+  setup: async ({ ctx: principalCtx }) => {
+    await principalCtx.plugin(credentialsProvider, aliceCredentials)
+  },
+})
 ```
 
-概念结构：
+Principal registry 结构上嵌套在 Tenant 下，所以 Principal creation 只接受 `userId`；`tenantId` 由父节点决定，错误 tenantId 从数据结构层面不可表达。
 
-```text
-Deployment / Root Context
-│
-├── shared ownership kernel (ctx.multiTenant)
-├── shared durable ownership store
-│
-├── Tenant A Context
-│   ├── tenant-local auth / MCP / providers
-│   └── Principal Alice Context
-│       └── user-local credentials
-│
-└── Tenant B Context
-    ├── tenant-local auth / MCP / providers
-    └── Principal Bob Context
-        └── user-local credentials
-```
+`ensure(key)` 不带 definition 时只表示“加入已有 canonical node”；消费层不需要知道创建配方。只有显式再次提供 definition 的调用方才参与 definition-drift 校验。
 
-`tenantIdOf(ctx)` / `principalOf(ctx)` 给可信的同进程插件读取当前 Context identity。它们只用于 routing / composition，**不是授权结果**；持久/session 边界仍然必须调用 `ctx.multiTenant`。
+## Agent Composition Boundary
 
-### 两套 scope plane 刻意分开
-
-DSH 已经用 `@deepseek-ai/dsh-scope` 管 Agent / Preset registration visibility。v0.2 不把 Tenant 强行塞进这条 parent chain，因为 Agent Preset 已经使用 Agent scope parent relation。
-
-- **Cordis service isolation**：Tenant / Principal capability provider；
-- **DSH scope chain**：Agent / Preset 的 tools、prompt contribution、listener 等 registration view。
-
-二者分开，避免争抢 parent binding，也避免把 capability authority 和 model-facing registration visibility 混成一个概念。
-
-## Core APIs
-
-### `ctx.tenantRuntime`
+Canonical Principal Context 是 capability root，不是绕过 Cordis dependency injection 的万能 Context。Agent orchestration 应在 Principal 派生的 integration fiber 中显式 inject `agents`：
 
 ```ts
-interface TenantScopeOptions {
-  isolateServices?: readonly string[]
-}
+const alice = await acme.principals.ensure('alice')
 
-interface PrincipalScopeOptions {
-  isolateServices?: readonly string[]
-}
+const operation = alice.ctx.inject(['agents'], async (ownerCtx) => {
+  return ownerCtx.agents.create({
+    sessionId,
+    setup(agentCtx) {
+      const tenantMcp = ownerCtx.get('tenantMcp')
+      // 把需要的 DSH tools / prompt / listeners 组合到 agentCtx。
+    },
+  })
+})
 
-ctx.tenantRuntime.createTenant(tenantId, options)
-ctx.tenantRuntime.get(tenantId)
+await operation
 ```
 
-同一个 tenantId 不能同时创建两套 live runtime；必须先 dispose 再重新创建。
+DSH 会把这个 caller-bound Context 作为 `ownerCtx` 传给 Agent factory。CI 直接执行真实 public AgentRegistry package，证明 Principal identity 与 A/B capability separation 在这个边界保持正确。
 
-### `ctx.multiTenant`
+## Tenant-Safe Provider Contract
 
-v0.1 Kernel API 保持：
+`dsh-multi-tenant/testing` 提供可执行 Provider conformance harness：
 
 ```ts
-interface TenantPrincipal {
-  tenantId: string
-  userId: string
-}
-
-ctx.multiTenant.claimSession(sessionId, principal)
-ctx.multiTenant.canAccessSession(principal, sessionId)
-ctx.multiTenant.assertSessionAccess(principal, sessionId)
+await assertRuntimeCapabilityProviderContract({
+  serviceName: 'myCapability',
+  level: 'tenant', // 或 principal
+  mount: async (ctx, marker) => { /* mount provider */ },
+  fingerprint: async ctx => { /* 识别 resolved instance */ },
+})
 ```
+
+Harness 会验证同名 A/B isolation、root/parent 不泄漏、descendant inheritance、sibling 不干扰、dispose isolation、clean recreation、以及 unpublished setup ownership。
+
+## Context Identity 不是 Authorization
+
+`runtimeIdentityOf(ctx)`、`tenantIdOf(ctx)`、`principalOf(ctx)` 是可信同进程 composition metadata，**不是持久授权结果**。Session / durable boundary 仍然必须使用 `ctx.multiTenant`。
 
 ## Explicit boundaries
 
-这个 package **不是** process/container sandbox。Cordis Context 隔离的是 service resolution 与 lifecycle，不会隔离同进程任意代码。可信插件仍然可以访问 process global、filesystem、network、environment variable，也可以故意访问 `ctx.root`。
+这个 package 不是 hostile-code / process sandbox。Cordis Context 不隔离 process global、filesystem、shell、network、environment variable，也挡不住故意访问 `ctx.root` 的同进程插件。
 
-强 process/filesystem/network/shell isolation 仍应由 deployment boundary 负责，例如 one tenant per container / Pod。
+Strong isolation 属于独立 process / container / Pod deployment boundary。
 
-v0.2 RC1 也**不声称现有每一个 DSH 插件自动具备 tenant-awareness**。Provider 必须允许在 Tenant Context 下实例化。已审阅的当前上游有一个明确例子：DSH MCP client 的 `serverName` reservation 仍按 `ctx.root` 全局管理，因此不同 Tenant 使用相同 `serverName` 时仍需要上游/provider 改造或显式使用不同名称。这是 ecosystem compatibility gap，不应该通过我们再造一个 registry 去掩盖。
-
-本 package 也不负责 billing、组织 UI、general RBAC 或完整 HTTP/WebSocket authentication transport。外部认证边界需要先选择/创建正确的 Tenant / Principal Context，再驱动 DSH 工作。
+本 package 同样不声称现有所有 DSH provider 自动 tenant-safe；provider compatibility 必须通过 contract 验证。产品级 Auth、HTTP/WebSocket binding、billing、organization UI、production MCP SaaS composition 属于后续 SaaS Framework / Plugin Family。
 
 ## 安装
 
-Prerelease 使用 `next` dist-tag：
-
 ```sh
-dsh plugin --profile <profile> add dsh-multi-tenant@next
+dsh plugin --profile <profile> add dsh-multi-tenant
 ```
 
-Bundle 会加载三条 deployment-global service：
+当前只维护一个 npm channel：`latest` 就是我们明确发布的最新版本。
 
-- `ctx.tenantSessionStore` —— 内存参考 provider；
-- `ctx.multiTenant` —— ownership / authorization kernel；
-- `ctx.tenantRuntime` —— context-native tenant runtime manager。
+Bundle 加载三条 deployment-global service：
 
-Production 应替换内存 ownership store 为 durable provider。
+- `ctx.tenantSessionStore` —— 内存参考 ownership provider；
+- `ctx.multiTenant` —— 持久 ownership / authorization kernel；
+- `ctx.tenantRuntime` —— canonical Tenant / Principal runtime manager。
 
 ## 发布验证
 
@@ -150,7 +150,7 @@ pnpm install --frozen-lockfile
 pnpm release:check
 ```
 
-Release gate 覆盖 package invariant、typecheck、unit / contract tests、packed external-consumer smoke 与锁定版本的 DSH runtime probes。
+CI 还会 checkout 精确的上游 DSH release commit 验证 version，并对精确 npm 包运行 executable compatibility probes。
 
 ## License
 

--- a/packages/multi-tenant/demo/fixture.ts
+++ b/packages/multi-tenant/demo/fixture.ts
@@ -18,11 +18,20 @@ export function apply(ctx: Context): void {
     const sameAllowed = await ctx.multiTenant.canAccessSession(alice, 's1')
     const crossTenantAllowed = await ctx.multiTenant.canAccessSession(eve, 's1')
 
-    const acme = ctx.tenantRuntime.createTenant('acme', { isolateServices: ['tenantAuth'] })
-    const evilcorp = ctx.tenantRuntime.createTenant('evilcorp', { isolateServices: ['tenantAuth'] })
-    await acme.ctx.plugin(marker, { name: 'tenantAuth', value: 'auth-acme' })
-    await evilcorp.ctx.plugin(marker, { name: 'tenantAuth', value: 'auth-evilcorp' })
-    const acmeAuth = acme.ctx.get('tenantAuth')
+    const acme = await ctx.tenantRuntime.tenants.ensure('acme', {
+      isolateServices: ['tenantAuth'],
+      setup: async ({ ctx: tenantCtx }) => {
+        await tenantCtx.plugin(marker, { name: 'tenantAuth', value: 'auth-acme' })
+      },
+    })
+    const evilcorp = await ctx.tenantRuntime.tenants.ensure('evilcorp', {
+      isolateServices: ['tenantAuth'],
+      setup: async ({ ctx: tenantCtx }) => {
+        await tenantCtx.plugin(marker, { name: 'tenantAuth', value: 'auth-evilcorp' })
+      },
+    })
+    const acmePrincipal = await acme.principals.ensure('alice')
+    const acmeAuth = acmePrincipal.ctx.get('tenantAuth')
     const evilcorpAuth = evilcorp.ctx.get('tenantAuth')
     const rootAuth = ctx.get('tenantAuth')
 

--- a/packages/multi-tenant/package.json
+++ b/packages/multi-tenant/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dsh-multi-tenant",
-  "version": "0.2.0-rc.1",
-  "description": "Context-native multi-tenant runtime for DeepSeek Harness: tenant/principal capability scopes plus immutable session ownership and fail-closed authorization.",
+  "version": "0.2.0-rc.3",
+  "description": "Context-native multi-tenant runtime for DeepSeek Harness: canonical tenant/principal publication, capability isolation, immutable session ownership, and fail-closed authorization.",
   "author": "DeepSeek Harness community contributors",
   "license": "MIT",
   "repository": {
@@ -14,7 +14,7 @@
   },
   "publishConfig": {
     "access": "public",
-    "tag": "next",
+    "tag": "latest",
     "provenance": true
   },
   "sideEffects": false,

--- a/packages/multi-tenant/src/index.ts
+++ b/packages/multi-tenant/src/index.ts
@@ -1,8 +1,8 @@
 /**
  * dsh-multi-tenant — context-native multi-tenant runtime for DeepSeek Harness.
  *
- * v0.2 keeps the v0.1 immutable session-ownership kernel and adds a Cordis
- * context-native tenant/principal capability runtime (`ctx.tenantRuntime`).
+ * v0.2 keeps the v0.1 immutable session-ownership kernel and adds a canonical,
+ * transactionally published Tenant -> Principal runtime tree.
  *
  * @module dsh-multi-tenant
  */
@@ -21,14 +21,26 @@ export default MultiTenantService
 export {
   TenantRuntimeService,
   MultiTenantRuntimeError,
+  RuntimeDefinitionConflictError,
+  RuntimeRegistryClosedError,
+  runtimeIdentityOf,
   tenantIdOf,
   principalOf,
 } from './runtime.ts'
 export type {
+  TenantIdentity,
+  RuntimeContextIdentity,
+  RuntimeScopeState,
+  RuntimeScopeSetupCommit,
+  RuntimeScopePreparation,
+  RuntimeScopeSetup,
+  RuntimeScopeDefinition,
+  RuntimeScope,
+  RuntimeScopeRegistry,
   TenantRuntimeScope,
   PrincipalRuntimeScope,
-  TenantScopeOptions,
-  PrincipalScopeOptions,
+  TenantScopeDefinition,
+  PrincipalScopeDefinition,
 } from './runtime.ts'
 
 export { TenantSessionStore, InMemoryTenantSessionStore } from './store.ts'

--- a/packages/multi-tenant/src/runtime.ts
+++ b/packages/multi-tenant/src/runtime.ts
@@ -1,14 +1,11 @@
 /**
  * Context-native multi-tenant runtime primitives for DeepSeek Harness.
  *
- * v0.2 separates two independent planes:
- *
- * - Cordis service isolation owns tenant/principal capability graphs.
- * - DSH scope routing keeps owning agent/preset registration visibility.
- *
- * The v0.1 session-ownership kernel remains shared and is deliberately NOT
- * isolated. It is the persistent fail-closed authorization invariant under the
- * runtime capability boundary.
+ * v0.2 models runtime tenancy as a canonical ownership tree. Tenant and
+ * Principal nodes share one lifecycle vocabulary and one publication model:
+ * reserve identity -> prepare unpublished scope -> setup -> optional commit ->
+ * publish. Preparing transactions are cancellable structural resources, so
+ * parent teardown can close admission and abort/drain unpublished children.
  *
  * @module dsh-multi-tenant/runtime
  */
@@ -18,7 +15,6 @@ import { ValidationError } from './errors.ts'
 import type { TenantPrincipal } from './types.ts'
 import { validateTenantId, validateTenantPrincipal } from './validation.ts'
 
-/** Services that must remain shared for Cordis itself or the v0.1 security kernel. */
 const RESERVED_SHARED_SERVICES = new Set([
   'events',
   'logger',
@@ -29,59 +25,80 @@ const RESERVED_SHARED_SERVICES = new Set([
   'multiTenant',
 ])
 
-/** Metadata inherited by every context below one tenant scope. */
 const kTenantRuntime = Symbol('dsh-multi-tenant.tenant-runtime')
-/** Metadata shadowed on a principal scope below its tenant. */
 const kPrincipalRuntime = Symbol('dsh-multi-tenant.principal-runtime')
 
-interface TenantMetadata {
+export interface TenantIdentity {
   readonly tenantId: string
 }
 
-/** Runtime options for a tenant capability boundary. */
-export interface TenantScopeOptions {
-  /**
-   * Cordis service names that receive independent tenant-local isolation labels.
-   * Providers for these names must be mounted below the returned tenant context.
-   */
-  isolateServices?: readonly string[]
+export interface RuntimeContextIdentity {
+  readonly tenant: Readonly<TenantIdentity>
+  readonly principal?: Readonly<TenantPrincipal>
 }
 
-/** Runtime options for one authenticated principal below a tenant. */
-export interface PrincipalScopeOptions {
-  /**
-   * Cordis service names that receive independent user/principal-local labels.
-   * Use this for user OAuth credentials or other per-principal capabilities.
-   */
-  isolateServices?: readonly string[]
+export type RuntimeScopeState = 'active' | 'disposing' | 'disposed'
+
+export interface RuntimeScopeSetupCommit {
+  commit(): void
 }
 
-/** One authenticated principal capability scope. */
-export interface PrincipalRuntimeScope {
-  /** Exact authenticated identity bound to this scope. */
-  readonly principal: Readonly<TenantPrincipal>
-  /** Context used to mount and resolve principal-local capabilities. */
+export interface RuntimeScopePreparation<I> {
   readonly ctx: Context
-  /** Dispose every plugin/effect owned by this principal scope. */
+  readonly identity: Readonly<I>
+  readonly signal: AbortSignal
+}
+
+export type RuntimeScopeSetup<I> = (
+  preparation: RuntimeScopePreparation<I>,
+) => RuntimeScopeSetupCommit | PromiseLike<RuntimeScopeSetupCommit | void> | void
+
+export interface RuntimeScopeDefinition<I> {
+  readonly isolateServices?: readonly string[]
+  readonly setup?: RuntimeScopeSetup<I>
+}
+
+export type TenantScopeDefinition = RuntimeScopeDefinition<TenantIdentity>
+export type PrincipalScopeDefinition = RuntimeScopeDefinition<TenantPrincipal>
+
+export interface RuntimeScope<K extends 'tenant' | 'principal', I> {
+  readonly kind: K
+  readonly identity: Readonly<I>
+  readonly ctx: Context
+  readonly state: RuntimeScopeState
   dispose(): Promise<void>
 }
 
-/** One tenant capability graph. */
-export interface TenantRuntimeScope {
-  /** Opaque tenant identifier. */
-  readonly tenantId: string
-  /** Context used to mount and resolve tenant-local capabilities. */
-  readonly ctx: Context
+export interface RuntimeScopeRegistry<Key, Scope, Definition> {
+  get(key: Key): Scope | undefined
   /**
-   * Create an authenticated principal scope below this tenant.
-   * The principal tenant id must exactly match this scope.
+   * Join the canonical active node, or create it when absent.
+   *
+   * Omitting `definition` means the caller only depends on identity and does
+   * not need to know the creation recipe of an already-live node. Supplying a
+   * definition opts into structural-drift validation.
    */
-  createPrincipal(principal: TenantPrincipal, options?: PrincipalScopeOptions): PrincipalRuntimeScope
-  /** Dispose the tenant scope and every descendant principal/plugin lifecycle. */
-  dispose(): Promise<void>
+  ensure(key: Key, definition?: Definition): Promise<Scope>
 }
 
-/** Shared no-op plugin used only to mint an owned Cordis fiber for a scope. */
+export interface PrincipalRuntimeScope extends RuntimeScope<'principal', TenantPrincipal> {}
+
+export interface TenantRuntimeScope extends RuntimeScope<'tenant', TenantIdentity> {
+  readonly principals: RuntimeScopeRegistry<string, PrincipalRuntimeScope, PrincipalScopeDefinition>
+}
+
+export class MultiTenantRuntimeError extends Error {
+  override name = 'MultiTenantRuntimeError'
+}
+
+export class RuntimeDefinitionConflictError extends MultiTenantRuntimeError {
+  override name = 'RuntimeDefinitionConflictError'
+}
+
+export class RuntimeRegistryClosedError extends MultiTenantRuntimeError {
+  override name = 'RuntimeRegistryClosedError'
+}
+
 function runtimeScopeOwner(): void {}
 
 function normalizeServiceNames(names: readonly string[] | undefined): string[] {
@@ -92,128 +109,416 @@ function normalizeServiceNames(names: readonly string[] | undefined): string[] {
       throw new ValidationError('isolated service names must be non-empty trimmed strings')
     }
     if (RESERVED_SHARED_SERVICES.has(name)) {
-      throw new ValidationError(`service "${name}" is shared/reserved and cannot be tenant-isolated`)
+      throw new ValidationError(`service "${name}" is shared/reserved and cannot be runtime-isolated`)
     }
     unique.add(name)
   }
-  return [...unique]
+  return [...unique].sort()
+}
+
+interface NormalizedDefinition<I> {
+  readonly services: readonly string[]
+  readonly signature: string
+  readonly setup: RuntimeScopeSetup<I> | undefined
+}
+
+function normalizeDefinition<I>(definition: RuntimeScopeDefinition<I> = {}): NormalizedDefinition<I> {
+  const services = normalizeServiceNames(definition.isolateServices)
+  return {
+    services,
+    signature: JSON.stringify(services),
+    setup: definition.setup,
+  }
 }
 
 function isolatedContext(base: Context, names: readonly string[], scopeKind: 'tenant' | 'principal'): Context {
   let current = base
   for (const name of names) {
-    // Symbol identity, not its diagnostic description, is the isolation key.
-    // Keep tenant/user identifiers out of framework diagnostics by design.
     current = current.isolate(name, Symbol(`${scopeKind}:${name}`))
   }
   return current
 }
 
-/** Await a Cordis fiber's complete quiescent disposal. */
 async function disposeFiber(fiber: Fiber): Promise<void> {
   await Promise.resolve(fiber.dispose())
   while (fiber.inertia !== undefined) await fiber.inertia
 }
 
+async function raceAbort<T>(operation: PromiseLike<T> | T, signal: AbortSignal): Promise<T> {
+  if (signal.aborted) {
+    throw signal.reason instanceof Error ? signal.reason : new Error('runtime scope setup aborted')
+  }
+  const aborted = Promise.withResolvers<never>()
+  const listener = (): void => {
+    aborted.reject(signal.reason instanceof Error ? signal.reason : new Error('runtime scope setup aborted'))
+  }
+  signal.addEventListener('abort', listener, { once: true })
+  try {
+    return await Promise.race([Promise.resolve(operation), aborted.promise])
+  } finally {
+    signal.removeEventListener('abort', listener)
+  }
+}
+
+interface PreparedScope<I> {
+  readonly ctx: Context
+  readonly fiber: Fiber
+  readonly identity: Readonly<I>
+}
+
+interface ScopeCreation<Scope> {
+  readonly ready: Promise<Scope>
+  cancel(reason: Error): Promise<void>
+}
+
 /**
- * Read the tenant selected by the nearest runtime scope.
+ * Start an unpublished, cancellable scope transaction.
  *
- * This is contextual identity for trusted same-process plugins. It is not an
- * authorization decision; durable/session boundaries must still use
- * `ctx.multiTenant` ownership checks.
+ * `ready` resolves only after setup and its optional synchronous commit have
+ * completed. `cancel()` can run while setup is pending; it aborts the setup
+ * signal and structurally disposes the unpublished Cordis subtree.
  */
+function prepareScope<I>(
+  parent: Context,
+  kind: 'tenant' | 'principal',
+  identity: Readonly<I>,
+  definition: NormalizedDefinition<I>,
+  metadata: Record<PropertyKey, unknown>,
+): ScopeCreation<PreparedScope<I>> {
+  const base = isolatedContext(parent, definition.services, kind)
+  const fiber = base.plugin(runtimeScopeOwner)
+  const ctx = fiber.ctx.extend(metadata)
+  const abort = new AbortController()
+  let disposal: Promise<void> | undefined
+
+  const cancel = (reason: Error): Promise<void> => {
+    if (!abort.signal.aborted) abort.abort(reason)
+    return (disposal ??= disposeFiber(fiber))
+  }
+
+  ctx.effect(() => () => {
+    if (!abort.signal.aborted) {
+      abort.abort(new MultiTenantRuntimeError(`${kind} runtime setup owner disposed`))
+    }
+  }, `tenantRuntime.${kind}.setupAbort()`)
+
+  const ready = (async (): Promise<PreparedScope<I>> => {
+    try {
+      const result = definition.setup === undefined
+        ? undefined
+        : await raceAbort(definition.setup({ ctx, identity, signal: abort.signal }), abort.signal)
+
+      fiber.assertActive()
+      if (result !== undefined) {
+        if (typeof result !== 'object' || result === null || typeof result.commit !== 'function') {
+          throw new TypeError('runtime scope setup must return void or { commit(): void }')
+        }
+        result.commit()
+      }
+      fiber.assertActive()
+      return { ctx, fiber, identity }
+    } catch (error) {
+      await cancel(error instanceof Error ? error : new Error(String(error)))
+      throw error
+    }
+  })()
+
+  return { ready, cancel }
+}
+
+interface CanonicalEntry<Scope> {
+  readonly signature: string
+  readonly creation: ScopeCreation<Scope>
+  scope: Scope | undefined
+}
+
+type PublishedScope = RuntimeScope<'tenant' | 'principal', unknown>
+
+/**
+ * Generic canonical registry shared by Tenant and Principal nodes.
+ *
+ * The registry owns both unpublished creation transactions and published
+ * scopes. Closing it first stops admission, then cancels/drains every entry.
+ */
+class CanonicalRuntimeRegistry<Key, Scope extends PublishedScope, Identity, Definition extends RuntimeScopeDefinition<Identity>>
+implements RuntimeScopeRegistry<Key, Scope, Definition> {
+  private readonly entries = new Map<Key, CanonicalEntry<Scope>>()
+  private accepting = true
+  private closing: Promise<void> | undefined
+
+  constructor(
+    private readonly normalize: (definition: Definition | undefined) => NormalizedDefinition<Identity>,
+    private readonly create: (
+      key: Key,
+      definition: NormalizedDefinition<Identity>,
+      retire: (scope: Scope) => void,
+    ) => ScopeCreation<Scope>,
+  ) {}
+
+  get(key: Key): Scope | undefined {
+    if (!this.accepting) return undefined
+    const scope = this.entries.get(key)?.scope
+    return scope?.state === 'active' ? scope : undefined
+  }
+
+  async ensure(key: Key, definition?: Definition): Promise<Scope> {
+    if (!this.accepting) throw new RuntimeRegistryClosedError('runtime scope registry is closing')
+
+    const definitionSupplied = definition !== undefined
+    const normalized = this.normalize(definition)
+    const existing = this.entries.get(key)
+    if (existing !== undefined) {
+      if (definitionSupplied && existing.signature !== normalized.signature) {
+        throw new RuntimeDefinitionConflictError(
+          'canonical runtime scope already exists with a different isolated-service definition',
+        )
+      }
+      const scope = await existing.creation.ready
+      if (!this.accepting) throw new RuntimeRegistryClosedError('runtime scope registry is closing')
+      if (scope.state !== 'active') {
+        await scope.dispose()
+        return this.ensure(key, definition)
+      }
+      return scope
+    }
+
+    let entry!: CanonicalEntry<Scope>
+    const retire = (scope: Scope): void => {
+      if (this.entries.get(key) === entry && entry.scope === scope) this.entries.delete(key)
+    }
+    const rawCreation = this.create(key, normalized, retire)
+    const creation: ScopeCreation<Scope> = {
+      cancel: reason => rawCreation.cancel(reason),
+      ready: rawCreation.ready.then(
+        (scope) => {
+          if (this.entries.get(key) === entry) entry.scope = scope
+          return scope
+        },
+        (error) => {
+          if (this.entries.get(key) === entry) this.entries.delete(key)
+          throw error
+        },
+      ),
+    }
+    entry = { signature: normalized.signature, creation, scope: undefined }
+    this.entries.set(key, entry)
+
+    const scope = await creation.ready
+    if (!this.accepting) {
+      await scope.dispose()
+      throw new RuntimeRegistryClosedError('runtime scope registry is closing')
+    }
+    return scope
+  }
+
+  disposeAll(): Promise<void> {
+    if (this.closing !== undefined) return this.closing
+    this.accepting = false
+    const reason = new RuntimeRegistryClosedError('runtime scope registry is closing')
+    const entries = [...this.entries.values()]
+
+    this.closing = (async () => {
+      await Promise.all(entries.map(async (entry) => {
+        try {
+          await entry.creation.cancel(reason)
+        } catch {
+          // Continue draining siblings even if one provider cleanup fails.
+        }
+        try {
+          const scope = await entry.creation.ready
+          if (scope.state !== 'disposed') await scope.dispose()
+        } catch {
+          // A cancelled/failed unpublished creation has no published scope.
+        }
+      }))
+      this.entries.clear()
+    })()
+    return this.closing
+  }
+}
+
+function createScopeLifecycle(
+  fiber: Fiber,
+  beforeDispose: () => Promise<void>,
+  onDisposed: () => void,
+): { readonly state: RuntimeScopeState; dispose(): Promise<void> } {
+  let state: RuntimeScopeState = 'active'
+  let disposing: Promise<void> | undefined
+
+  return {
+    get state() {
+      return state
+    },
+    dispose() {
+      if (disposing !== undefined) return disposing
+      if (state === 'disposed') return Promise.resolve()
+      state = 'disposing'
+      disposing = (async () => {
+        try {
+          await beforeDispose()
+          await disposeFiber(fiber)
+        } finally {
+          state = 'disposed'
+          onDisposed()
+        }
+      })()
+      return disposing
+    },
+  }
+}
+
+function bindPreparedScope<Scope extends PublishedScope, I>(
+  preparation: ScopeCreation<PreparedScope<I>>,
+  build: (prepared: PreparedScope<I>) => Scope,
+): ScopeCreation<Scope> {
+  let scope: Scope | undefined
+  let cancellation: Promise<void> | undefined
+
+  const ready = preparation.ready.then((prepared) => {
+    prepared.fiber.assertActive()
+    scope = build(prepared)
+    return scope
+  })
+
+  return {
+    ready,
+    cancel(reason: Error): Promise<void> {
+      if (cancellation !== undefined) return cancellation
+      cancellation = (async () => {
+        if (scope !== undefined) {
+          await scope.dispose()
+          return
+        }
+        await preparation.cancel(reason)
+        try {
+          const published = await ready
+          if (published.state !== 'disposed') await published.dispose()
+        } catch {
+          // Cancellation or setup failure prevented publication.
+        }
+      })()
+      return cancellation
+    },
+  }
+}
+
+export function runtimeIdentityOf(ctx: Context): RuntimeContextIdentity | undefined {
+  const tenant = (ctx as Context & { [kTenantRuntime]?: Readonly<TenantIdentity> })[kTenantRuntime]
+  if (tenant === undefined) return undefined
+  const principal = (ctx as Context & { [kPrincipalRuntime]?: Readonly<TenantPrincipal> })[kPrincipalRuntime]
+  return principal === undefined ? { tenant } : { tenant, principal }
+}
+
 export function tenantIdOf(ctx: Context): string | undefined {
-  const metadata = (ctx as Context & { [kTenantRuntime]?: TenantMetadata })[kTenantRuntime]
-  return metadata?.tenantId
+  return runtimeIdentityOf(ctx)?.tenant.tenantId
 }
 
-/**
- * Read the authenticated principal selected by the nearest principal scope.
- * Returns undefined in root/tenant-only contexts.
- */
 export function principalOf(ctx: Context): Readonly<TenantPrincipal> | undefined {
-  return (ctx as Context & { [kPrincipalRuntime]?: Readonly<TenantPrincipal> })[kPrincipalRuntime]
+  return runtimeIdentityOf(ctx)?.principal
 }
 
-/**
- * Runtime manager that mints canonical tenant contexts over one shared DSH
- * process/service graph.
- *
- * The service itself is deployment-global. Each tenant gets a real Cordis
- * child lifecycle plus independent isolation labels for explicitly selected
- * capability services. This avoids a second ad-hoc `tenantId -> service Map`
- * resolver while keeping the v0.1 ownership kernel globally authoritative.
- */
 export class TenantRuntimeService extends Service {
   static inject = ['multiTenant']
 
   private readonly selfCtx: Context
-  private readonly tenants = new Map<string, TenantRuntimeScope>()
+  private readonly tenantRegistry: CanonicalRuntimeRegistry<
+    string,
+    TenantRuntimeScope,
+    TenantIdentity,
+    TenantScopeDefinition
+  >
+  readonly tenants: RuntimeScopeRegistry<string, TenantRuntimeScope, TenantScopeDefinition>
 
   constructor(ctx: Context) {
     super(ctx, 'tenantRuntime')
     this.selfCtx = ctx
+    this.tenantRegistry = new CanonicalRuntimeRegistry(
+      definition => normalizeDefinition(definition),
+      (tenantId, definition, retire) => this.prepareTenant(tenantId, definition, retire),
+    )
+    this.tenants = this.tenantRegistry
+    ctx.effect(() => () => this.tenantRegistry.disposeAll(), 'tenantRuntime.disposeAll()')
   }
 
-  /** Return the currently live tenant scope, if one exists. */
-  get(tenantId: string): TenantRuntimeScope | undefined {
+  private prepareTenant(
+    tenantId: string,
+    definition: NormalizedDefinition<TenantIdentity>,
+    retire: (scope: TenantRuntimeScope) => void,
+  ): ScopeCreation<TenantRuntimeScope> {
     validateTenantId(tenantId)
-    return this.tenants.get(tenantId)
+    const identity = Object.freeze({ tenantId })
+    const preparation = prepareScope(
+      this.selfCtx,
+      'tenant',
+      identity,
+      definition,
+      { [kTenantRuntime]: identity },
+    )
+
+    return bindPreparedScope(preparation, (prepared) => {
+      const principalRegistry = new CanonicalRuntimeRegistry<
+        string,
+        PrincipalRuntimeScope,
+        TenantPrincipal,
+        PrincipalScopeDefinition
+      >(
+        principalDefinition => normalizeDefinition(principalDefinition),
+        (userId, principalDefinition, retirePrincipal) => this.preparePrincipal(
+          prepared.ctx,
+          identity,
+          userId,
+          principalDefinition,
+          retirePrincipal,
+        ),
+      )
+
+      let scope!: TenantRuntimeScope
+      const lifecycle = createScopeLifecycle(
+        prepared.fiber,
+        () => principalRegistry.disposeAll(),
+        () => retire(scope),
+      )
+      scope = {
+        kind: 'tenant',
+        identity,
+        ctx: prepared.ctx,
+        principals: principalRegistry,
+        get state() { return lifecycle.state },
+        dispose: () => lifecycle.dispose(),
+      }
+      return scope
+    })
   }
 
-  /**
-   * Create the canonical live scope for one tenant.
-   *
-   * Duplicate live scopes are rejected: a tenant must have one capability
-   * graph per runtime, otherwise two requests could silently resolve different
-   * auth/MCP/credential providers for the same tenant identity.
-   */
-  createTenant(tenantId: string, options: TenantScopeOptions = {}): TenantRuntimeScope {
-    validateTenantId(tenantId)
-    if (this.tenants.has(tenantId)) {
-      throw new MultiTenantRuntimeError(`tenant "${tenantId}" already has a live runtime scope`)
-    }
+  private preparePrincipal(
+    tenantCtx: Context,
+    tenant: Readonly<TenantIdentity>,
+    userId: string,
+    definition: NormalizedDefinition<TenantPrincipal>,
+    retire: (scope: PrincipalRuntimeScope) => void,
+  ): ScopeCreation<PrincipalRuntimeScope> {
+    const principal = Object.freeze({ tenantId: tenant.tenantId, userId })
+    validateTenantPrincipal(principal)
+    const preparation = prepareScope(
+      tenantCtx,
+      'principal',
+      principal,
+      definition,
+      { [kPrincipalRuntime]: principal },
+    )
 
-    const services = normalizeServiceNames(options.isolateServices)
-    const base = isolatedContext(this.selfCtx, services, 'tenant')
-    const fiber = base.plugin(runtimeScopeOwner)
-    const metadata: TenantMetadata = Object.freeze({ tenantId })
-    const tenantCtx = fiber.ctx.extend({ [kTenantRuntime]: metadata })
-    let disposing: Promise<void> | undefined
-
-    const scope: TenantRuntimeScope = {
-      tenantId,
-      ctx: tenantCtx,
-      createPrincipal: (principal, principalOptions = {}) => {
-        validateTenantPrincipal(principal)
-        if (principal.tenantId !== tenantId) {
-          throw new ValidationError('principal tenantId does not match the tenant runtime scope')
-        }
-        const principalServices = normalizeServiceNames(principalOptions.isolateServices)
-        const principalBase = isolatedContext(tenantCtx, principalServices, 'principal')
-        const principalFiber = principalBase.plugin(runtimeScopeOwner)
-        const boundPrincipal = Object.freeze({ tenantId: principal.tenantId, userId: principal.userId })
-        const principalCtx = principalFiber.ctx.extend({ [kPrincipalRuntime]: boundPrincipal })
-        let principalDisposing: Promise<void> | undefined
-        return {
-          principal: boundPrincipal,
-          ctx: principalCtx,
-          dispose: () => (principalDisposing ??= disposeFiber(principalFiber)),
-        }
-      },
-      dispose: () => {
-        if (disposing !== undefined) return disposing
-        // Keep the canonical scope registered until teardown reaches quiescence,
-        // so callers cannot overlap a replacement graph with one still disposing.
-        disposing = disposeFiber(fiber).finally(() => {
-          if (this.tenants.get(tenantId) === scope) this.tenants.delete(tenantId)
-        })
-        return disposing
-      },
-    }
-
-    this.tenants.set(tenantId, scope)
-    return scope
+    return bindPreparedScope(preparation, (prepared) => {
+      let scope!: PrincipalRuntimeScope
+      const lifecycle = createScopeLifecycle(prepared.fiber, async () => {}, () => retire(scope))
+      scope = {
+        kind: 'principal',
+        identity: principal,
+        ctx: prepared.ctx,
+        get state() { return lifecycle.state },
+        dispose: () => lifecycle.dispose(),
+      }
+      return scope
+    })
   }
 }
 
@@ -221,11 +526,6 @@ declare module '@deepseek-ai/cordis' {
   interface Context {
     tenantRuntime: TenantRuntimeService
   }
-}
-
-/** Runtime lifecycle/configuration error distinct from an access denial. */
-export class MultiTenantRuntimeError extends Error {
-  override name = 'MultiTenantRuntimeError'
 }
 
 export default TenantRuntimeService

--- a/packages/multi-tenant/src/testing.ts
+++ b/packages/multi-tenant/src/testing.ts
@@ -1,19 +1,16 @@
 /**
- * Contract test suite for the `TenantSessionStore` provider seam.
+ * Executable provider contracts for dsh-multi-tenant extension points.
  *
- * Exposed via the `dsh-multi-tenant/testing` subpath so a third-party provider
- * (PostgreSQL / Redis / …) can prove it satisfies the same contract as the
- * official in-memory default. This is the executable form of "default ≠ only".
- *
- * The suite is framework-agnostic: it takes a store factory and throws an
- * `Error` naming the violated clause — the caller wraps it in its own test
- * runner (the core uses Vitest).
+ * Third-party providers can import this subpath and prove that they satisfy the
+ * same lifecycle/isolation invariants as the reference implementations.
  *
  * @module dsh-multi-tenant/testing
  */
 
 import { Context } from '@deepseek-ai/cordis'
-import type { TenantSessionStore } from './store.ts'
+import { MultiTenantService } from './service.ts'
+import { InMemoryTenantSessionStore, type TenantSessionStore } from './store.ts'
+import { TenantRuntimeService } from './runtime.ts'
 import type { SessionOwner } from './types.ts'
 
 /** Produce a fresh, isolated store for one contract clause. */
@@ -47,34 +44,29 @@ export async function assertTenantSessionStoreContract(factory: TenantSessionSto
   const bob: SessionOwner = { tenantId: 'acme', userId: 'bob' }
   const eve: SessionOwner = { tenantId: 'evilcorp', userId: 'alice' }
 
-  // 1. first claim establishes ownership.
   await withStore(factory, async (store) => {
     const result = await store.claim('s1', alice)
     if (result !== 'created') fail('first-claim', result)
   })
 
-  // 2. same-owner re-claim is idempotent.
   await withStore(factory, async (store) => {
     await store.claim('s1', alice)
     const result = await store.claim('s1', alice)
     if (result !== 'idempotent') fail('idempotent-reclaim', result)
   })
 
-  // 3. different user in the same tenant conflicts.
   await withStore(factory, async (store) => {
     await store.claim('s1', alice)
     const result = await store.claim('s1', bob)
     if (result !== 'conflict') fail('same-tenant-different-user', result)
   })
 
-  // 4. different tenant conflicts.
   await withStore(factory, async (store) => {
     await store.claim('s1', alice)
     const result = await store.claim('s1', eve)
     if (result !== 'conflict') fail('different-tenant', result)
   })
 
-  // 5. a conflict never overwrites the original owner.
   await withStore(factory, async (store) => {
     await store.claim('s1', alice)
     await store.claim('s1', bob)
@@ -84,13 +76,11 @@ export async function assertTenantSessionStoreContract(factory: TenantSessionSto
     }
   })
 
-  // 6. get of an unknown session is undefined.
   await withStore(factory, async (store) => {
     const owner = await store.get('missing')
     if (owner !== undefined) fail('unknown-get', JSON.stringify(owner))
   })
 
-  // 7. get returns the claimed owner.
   await withStore(factory, async (store) => {
     await store.claim('s1', alice)
     const owner = await store.get('s1')
@@ -99,7 +89,6 @@ export async function assertTenantSessionStoreContract(factory: TenantSessionSto
     }
   })
 
-  // 8. concurrent claims resolve atomically to exactly one owner.
   await withStore(factory, async (store) => {
     const results = await Promise.allSettled([store.claim('s1', alice), store.claim('s1', bob)])
     const outcomes = results.map(r => (r.status === 'fulfilled' ? r.value : 'rejected'))
@@ -108,4 +97,121 @@ export async function assertTenantSessionStoreContract(factory: TenantSessionSto
     if (created !== 1 || conflict !== 1) fail('atomic-concurrency', JSON.stringify(outcomes))
     if ((await store.get('s1')) === undefined) fail('atomic-owner', 'no owner after concurrent claim')
   })
+}
+
+/** Runtime level at which a capability provider claims isolation. */
+export type RuntimeCapabilityLevel = 'tenant' | 'principal'
+
+/**
+ * Adapter used by the conformance harness to exercise a real provider with
+ * distinguishable A/B configurations without knowing its implementation type.
+ */
+export interface RuntimeCapabilityProviderProbe {
+  /** Cordis service name isolated by the provider. */
+  readonly serviceName: string
+  /** Tenant-wide or principal-local provider contract. */
+  readonly level: RuntimeCapabilityLevel
+  /** Mount/configure the provider below the supplied unpublished scope. */
+  mount(ctx: Context, marker: string): void | PromiseLike<void>
+  /** Return a stable marker proving which provider instance this context resolves. */
+  fingerprint(ctx: Context): string | undefined | PromiseLike<string | undefined>
+}
+
+function capabilityFail(clause: string, detail: unknown): never {
+  throw new Error(`Runtime capability provider contract violation (${clause}): ${String(detail)}`)
+}
+
+async function createContractRuntime(): Promise<{ ctx: Context; runtime: TenantRuntimeService }> {
+  const ctx = new Context()
+  await ctx.plugin(InMemoryTenantSessionStore)
+  await ctx.plugin(MultiTenantService)
+  await ctx.plugin(TenantRuntimeService)
+  return { ctx, runtime: ctx.tenantRuntime }
+}
+
+/**
+ * Prove that a provider is safe to compose at its declared runtime level.
+ *
+ * The contract checks same-name A/B isolation, inheritance to descendants,
+ * sibling non-interference, teardown isolation, and clean recreation. Mounting
+ * occurs inside the unpublished setup transaction, so a provider that cannot
+ * be lifecycle-owned by the scope fails the intended usage model naturally.
+ */
+export async function assertRuntimeCapabilityProviderContract(
+  probe: RuntimeCapabilityProviderProbe,
+): Promise<void> {
+  if (probe.serviceName.length === 0 || probe.serviceName !== probe.serviceName.trim()) {
+    capabilityFail('service-name', 'serviceName must be a non-empty trimmed string')
+  }
+
+  const { ctx, runtime } = await createContractRuntime()
+  try {
+    if (probe.level === 'tenant') {
+      const tenantA = await runtime.tenants.ensure('contract-a', {
+        isolateServices: [probe.serviceName],
+        setup: async ({ ctx: tenantCtx }) => { await probe.mount(tenantCtx, 'A') },
+      })
+      const tenantB = await runtime.tenants.ensure('contract-b', {
+        isolateServices: [probe.serviceName],
+        setup: async ({ ctx: tenantCtx }) => { await probe.mount(tenantCtx, 'B') },
+      })
+
+      if (await probe.fingerprint(tenantA.ctx) !== 'A') capabilityFail('tenant-a', 'wrong provider instance')
+      if (await probe.fingerprint(tenantB.ctx) !== 'B') capabilityFail('tenant-b', 'wrong provider instance')
+      if (await probe.fingerprint(ctx) !== undefined) capabilityFail('root-leak', 'tenant capability visible at root')
+
+      const principalA = await tenantA.principals.ensure('alice')
+      if (await probe.fingerprint(principalA.ctx) !== 'A') {
+        capabilityFail('descendant-inheritance', 'principal did not inherit tenant provider')
+      }
+
+      await tenantA.dispose()
+      if (await probe.fingerprint(tenantB.ctx) !== 'B') {
+        capabilityFail('tenant-disposal-isolation', 'disposing A affected B')
+      }
+
+      const tenantA2 = await runtime.tenants.ensure('contract-a', {
+        isolateServices: [probe.serviceName],
+        setup: async ({ ctx: tenantCtx }) => { await probe.mount(tenantCtx, 'A2') },
+      })
+      if (await probe.fingerprint(tenantA2.ctx) !== 'A2') {
+        capabilityFail('tenant-recreation', 'recreated tenant resolved stale provider state')
+      }
+      await tenantA2.dispose()
+      await tenantB.dispose()
+      return
+    }
+
+    const tenant = await runtime.tenants.ensure('contract-tenant')
+    const alice = await tenant.principals.ensure('alice', {
+      isolateServices: [probe.serviceName],
+      setup: async ({ ctx: principalCtx }) => { await probe.mount(principalCtx, 'A') },
+    })
+    const bob = await tenant.principals.ensure('bob', {
+      isolateServices: [probe.serviceName],
+      setup: async ({ ctx: principalCtx }) => { await probe.mount(principalCtx, 'B') },
+    })
+
+    if (await probe.fingerprint(alice.ctx) !== 'A') capabilityFail('principal-a', 'wrong provider instance')
+    if (await probe.fingerprint(bob.ctx) !== 'B') capabilityFail('principal-b', 'wrong provider instance')
+    if (await probe.fingerprint(tenant.ctx) !== undefined) {
+      capabilityFail('tenant-leak', 'principal capability visible at tenant level')
+    }
+
+    await alice.dispose()
+    if (await probe.fingerprint(bob.ctx) !== 'B') {
+      capabilityFail('principal-disposal-isolation', 'disposing Alice affected Bob')
+    }
+
+    const alice2 = await tenant.principals.ensure('alice', {
+      isolateServices: [probe.serviceName],
+      setup: async ({ ctx: principalCtx }) => { await probe.mount(principalCtx, 'A2') },
+    })
+    if (await probe.fingerprint(alice2.ctx) !== 'A2') {
+      capabilityFail('principal-recreation', 'recreated principal resolved stale provider state')
+    }
+    await tenant.dispose()
+  } finally {
+    await ctx.fiber.dispose()
+  }
 }

--- a/packages/multi-tenant/tests/runtime-capability.contract.test.ts
+++ b/packages/multi-tenant/tests/runtime-capability.contract.test.ts
@@ -1,0 +1,20 @@
+import type { Context } from '@deepseek-ai/cordis'
+import { describe, it } from 'vitest'
+import { assertRuntimeCapabilityProviderContract } from '../src/testing.ts'
+
+function markerProvider(ctx: Context, marker: string): void {
+  ctx.provide('contractCapability', marker)
+}
+
+for (const level of ['tenant', 'principal'] as const) {
+  describe(`Runtime capability provider contract (${level})`, () => {
+    it('accepts a context-scoped provider with clean lifecycle isolation', async () => {
+      await assertRuntimeCapabilityProviderContract({
+        serviceName: 'contractCapability',
+        level,
+        mount: async (ctx, marker) => { await ctx.plugin(markerProvider, marker) },
+        fingerprint: ctx => ctx.get('contractCapability') as string | undefined,
+      })
+    })
+  })
+}

--- a/packages/multi-tenant/tests/runtime.test.ts
+++ b/packages/multi-tenant/tests/runtime.test.ts
@@ -2,128 +2,211 @@ import { Context } from '@deepseek-ai/cordis'
 import { describe, expect, it } from 'vitest'
 import { InMemoryTenantSessionStore, MultiTenantService } from '../src/index.ts'
 import {
-  MultiTenantRuntimeError,
+  RuntimeDefinitionConflictError,
+  RuntimeRegistryClosedError,
   TenantRuntimeService,
   principalOf,
+  runtimeIdentityOf,
   tenantIdOf,
 } from '../src/runtime.ts'
 import { ValidationError } from '../src/errors.ts'
-
-function provideMarker(ctx: Context, config: { name: string; value: string }): void {
-  ctx.provide(config.name, config.value)
-}
 
 async function createRuntime(): Promise<{ ctx: Context; runtime: TenantRuntimeService }> {
   const ctx = new Context()
   await ctx.plugin(InMemoryTenantSessionStore)
   await ctx.plugin(MultiTenantService)
   await ctx.plugin(TenantRuntimeService)
-  return { ctx, runtime: ctx.get('tenantRuntime') as TenantRuntimeService }
+  return { ctx, runtime: ctx.tenantRuntime }
 }
 
-describe('TenantRuntimeService', () => {
-  it('creates real tenant-local Cordis service graphs without an ad-hoc service registry', async () => {
-    const { ctx, runtime } = await createRuntime()
-    await ctx.plugin(provideMarker, { name: 'sharedAdapter', value: 'shared' })
+describe('TenantRuntimeService runtime contract', () => {
+  it('publishes a tenant atomically and single-flights concurrent ensure calls', async () => {
+    const { runtime } = await createRuntime()
+    const gate = Promise.withResolvers<void>()
+    let setupRuns = 0
+    let commitRuns = 0
 
-    const tenantA = runtime.createTenant('acme', { isolateServices: ['tenantAuth', 'tenantMcp'] })
-    const tenantB = runtime.createTenant('globex', { isolateServices: ['tenantAuth', 'tenantMcp'] })
+    const first = runtime.tenants.ensure('acme', {
+      isolateServices: ['tenantAuth'],
+      setup: async ({ ctx, identity }) => {
+        setupRuns += 1
+        expect(identity).toEqual({ tenantId: 'acme' })
+        ctx.provide('tenantAuth', 'auth-A')
+        await gate.promise
+        return { commit: () => { commitRuns += 1 } }
+      },
+    })
+    const second = runtime.tenants.ensure('acme', {
+      isolateServices: ['tenantAuth'],
+      setup: () => { throw new Error('second initializer must never run') },
+    })
 
-    await tenantA.ctx.plugin(provideMarker, { name: 'tenantAuth', value: 'auth-A' })
-    await tenantA.ctx.plugin(provideMarker, { name: 'tenantMcp', value: 'mcp-A' })
-    await tenantB.ctx.plugin(provideMarker, { name: 'tenantAuth', value: 'auth-B' })
-    await tenantB.ctx.plugin(provideMarker, { name: 'tenantMcp', value: 'mcp-B' })
+    expect(runtime.tenants.get('acme')).toBeUndefined()
+    expect(setupRuns).toBe(1)
 
+    gate.resolve()
+    const [tenantA, tenantB] = await Promise.all([first, second])
+
+    expect(tenantA).toBe(tenantB)
+    expect(await runtime.tenants.ensure('acme')).toBe(tenantA)
+    expect(runtime.tenants.get('acme')).toBe(tenantA)
+    expect(tenantA.state).toBe('active')
     expect(tenantA.ctx.get('tenantAuth')).toBe('auth-A')
-    expect(tenantA.ctx.get('tenantMcp')).toBe('mcp-A')
-    expect(tenantB.ctx.get('tenantAuth')).toBe('auth-B')
-    expect(tenantB.ctx.get('tenantMcp')).toBe('mcp-B')
-    expect(ctx.get('tenantAuth')).toBeUndefined()
-    expect(ctx.get('tenantMcp')).toBeUndefined()
-
-    // Non-isolated deployment services are intentionally shared.
-    expect(tenantA.ctx.get('sharedAdapter')).toBe('shared')
-    expect(tenantB.ctx.get('sharedAdapter')).toBe('shared')
-
-    // Prove the v0.1 kernel is one shared persistent invariant by behavior,
-    // rather than comparing Cordis trace proxies (whose identity is caller-bound).
-    const alice = { tenantId: 'acme', userId: 'alice' }
-    await tenantA.ctx.multiTenant.claimSession('shared-kernel', alice)
-    await expect(ctx.multiTenant.getSessionOwner('shared-kernel')).resolves.toEqual(alice)
-    await expect(tenantB.ctx.multiTenant.canAccessSession(
-      { tenantId: 'globex', userId: 'bob' },
-      'shared-kernel',
-    )).resolves.toBe(false)
+    expect(commitRuns).toBe(1)
   })
 
-  it('adds a principal-local capability layer below the tenant layer', async () => {
+  it('rolls back failed unpublished setup and permits a clean retry', async () => {
+    const { ctx, runtime } = await createRuntime()
+
+    await expect(runtime.tenants.ensure('acme', {
+      isolateServices: ['tenantAuth'],
+      setup: ({ ctx: tenantCtx }) => {
+        tenantCtx.provide('tenantAuth', 'should-never-publish')
+        throw new Error('boom')
+      },
+    })).rejects.toThrow('boom')
+
+    expect(runtime.tenants.get('acme')).toBeUndefined()
+    expect(ctx.get('tenantAuth')).toBeUndefined()
+
+    const tenant = await runtime.tenants.ensure('acme', {
+      isolateServices: ['tenantAuth'],
+      setup: ({ ctx: tenantCtx }) => { tenantCtx.provide('tenantAuth', 'auth-A') },
+    })
+    expect(tenant.ctx.get('tenantAuth')).toBe('auth-A')
+  })
+
+  it('uses the same canonical registry semantics for principals', async () => {
     const { runtime } = await createRuntime()
-    const tenant = runtime.createTenant('acme', { isolateServices: ['tenantAuth'] })
-    await tenant.ctx.plugin(provideMarker, { name: 'tenantAuth', value: 'acme-auth' })
+    const tenant = await runtime.tenants.ensure('acme', {
+      isolateServices: ['tenantAuth'],
+      setup: ({ ctx }) => { ctx.provide('tenantAuth', 'acme-auth') },
+    })
 
-    const alice = tenant.createPrincipal(
-      { tenantId: 'acme', userId: 'alice' },
-      { isolateServices: ['userCredentials'] },
-    )
-    const bob = tenant.createPrincipal(
-      { tenantId: 'acme', userId: 'bob' },
-      { isolateServices: ['userCredentials'] },
-    )
-    await alice.ctx.plugin(provideMarker, { name: 'userCredentials', value: 'alice-token' })
-    await bob.ctx.plugin(provideMarker, { name: 'userCredentials', value: 'bob-token' })
+    let aliceSetups = 0
+    const alice1 = tenant.principals.ensure('alice', {
+      isolateServices: ['userCredentials'],
+      setup: ({ ctx, identity }) => {
+        aliceSetups += 1
+        expect(identity).toEqual({ tenantId: 'acme', userId: 'alice' })
+        ctx.provide('userCredentials', 'alice-token')
+      },
+    })
+    const alice2 = tenant.principals.ensure('alice', {
+      isolateServices: ['userCredentials'],
+    })
+    const bob = tenant.principals.ensure('bob', {
+      isolateServices: ['userCredentials'],
+      setup: ({ ctx }) => { ctx.provide('userCredentials', 'bob-token') },
+    })
 
-    expect(alice.ctx.get('tenantAuth')).toBe('acme-auth')
-    expect(bob.ctx.get('tenantAuth')).toBe('acme-auth')
-    expect(alice.ctx.get('userCredentials')).toBe('alice-token')
-    expect(bob.ctx.get('userCredentials')).toBe('bob-token')
+    const [a1, a2, b] = await Promise.all([alice1, alice2, bob])
+    expect(a1).toBe(a2)
+    expect(await tenant.principals.ensure('alice')).toBe(a1)
+    expect(aliceSetups).toBe(1)
+    expect(a1.identity).toEqual({ tenantId: 'acme', userId: 'alice' })
+    expect(b.identity).toEqual({ tenantId: 'acme', userId: 'bob' })
+    expect(a1.ctx.get('tenantAuth')).toBe('acme-auth')
+    expect(b.ctx.get('tenantAuth')).toBe('acme-auth')
+    expect(a1.ctx.get('userCredentials')).toBe('alice-token')
+    expect(b.ctx.get('userCredentials')).toBe('bob-token')
     expect(tenant.ctx.get('userCredentials')).toBeUndefined()
 
-    expect(tenantIdOf(alice.ctx)).toBe('acme')
-    expect(tenantIdOf(bob.ctx)).toBe('acme')
-    expect(principalOf(alice.ctx)).toEqual({ tenantId: 'acme', userId: 'alice' })
-    expect(principalOf(bob.ctx)).toEqual({ tenantId: 'acme', userId: 'bob' })
-    expect(principalOf(tenant.ctx)).toBeUndefined()
+    expect(runtimeIdentityOf(a1.ctx)).toEqual({
+      tenant: { tenantId: 'acme' },
+      principal: { tenantId: 'acme', userId: 'alice' },
+    })
+    expect(tenantIdOf(a1.ctx)).toBe('acme')
+    expect(principalOf(a1.ctx)).toEqual({ tenantId: 'acme', userId: 'alice' })
   })
 
-  it('rejects a principal from another tenant before any capability scope exists', async () => {
+  it('rejects definition drift for an already active canonical node', async () => {
     const { runtime } = await createRuntime()
-    const tenant = runtime.createTenant('acme')
+    await runtime.tenants.ensure('acme', { isolateServices: ['tenantAuth'] })
 
-    expect(() => tenant.createPrincipal({ tenantId: 'globex', userId: 'eve' }))
-      .toThrow(ValidationError)
+    await expect(runtime.tenants.ensure('acme', { isolateServices: ['tenantMcp'] }))
+      .rejects.toThrow(RuntimeDefinitionConflictError)
   })
 
-  it('refuses duplicate live tenant graphs and allows recreation after disposal', async () => {
+  it('cascades lifecycle ownership and allows recreation only after quiescent disposal', async () => {
     const { runtime } = await createRuntime()
-    const first = runtime.createTenant('acme')
+    const disposed: string[] = []
+    const lifecyclePlugin = (ctx: Context, name: string): (() => void) => {
+      ctx.provide('lifecycleMarker', name)
+      return () => { disposed.push(name) }
+    }
 
-    expect(() => runtime.createTenant('acme')).toThrow(MultiTenantRuntimeError)
-    await first.dispose()
+    const tenant = await runtime.tenants.ensure('acme', { isolateServices: ['lifecycleMarker'] })
+    await tenant.ctx.plugin(lifecyclePlugin, 'tenant-A')
+    const alice = await tenant.principals.ensure('alice', { isolateServices: ['userCredentials'] })
+    await alice.ctx.plugin((ctx: Context) => {
+      ctx.provide('userCredentials', 'alice-token')
+      return () => { disposed.push('alice') }
+    })
 
-    const second = runtime.createTenant('acme')
-    expect(second).not.toBe(first)
-    await second.dispose()
+    expect(runtime.tenants.get('acme')).toBe(tenant)
+    expect(tenant.principals.get('alice')).toBe(alice)
+
+    await tenant.dispose()
+
+    expect(tenant.state).toBe('disposed')
+    expect(alice.state).toBe('disposed')
+    expect(runtime.tenants.get('acme')).toBeUndefined()
+    expect(disposed).toContain('alice')
+    expect(disposed).toContain('tenant-A')
+
+    const replacement = await runtime.tenants.ensure('acme', { isolateServices: ['lifecycleMarker'] })
+    expect(replacement).not.toBe(tenant)
+    expect(replacement.state).toBe('active')
   })
 
-  it('forbids isolating the ownership kernel or Cordis core services', async () => {
+  it('closes child admission and cancels unpublished principal setup during tenant teardown', async () => {
     const { runtime } = await createRuntime()
+    const tenant = await runtime.tenants.ensure('acme')
+    const started = Promise.withResolvers<void>()
 
-    expect(() => runtime.createTenant('acme', { isolateServices: ['multiTenant'] }))
-      .toThrow(ValidationError)
-    expect(() => runtime.createTenant('globex', { isolateServices: ['registry'] }))
-      .toThrow(ValidationError)
+    const pendingAlice = tenant.principals.ensure('alice', {
+      setup: async ({ signal }) => {
+        started.resolve()
+        await new Promise<never>((_, reject) => {
+          signal.addEventListener('abort', () => reject(signal.reason), { once: true })
+        })
+      },
+    })
+
+    await started.promise
+    expect(tenant.principals.get('alice')).toBeUndefined()
+
+    const disposing = tenant.dispose()
+    await expect(pendingAlice).rejects.toThrow(RuntimeRegistryClosedError)
+    await disposing
+
+    expect(tenant.state).toBe('disposed')
+    await expect(tenant.principals.ensure('bob')).rejects.toThrow(RuntimeRegistryClosedError)
   })
 
-  it('keeps ownership authorization effective inside a principal context', async () => {
+  it('keeps ownership authorization shared across the runtime tree', async () => {
     const { ctx, runtime } = await createRuntime()
-    const acme = runtime.createTenant('acme')
-    const globex = runtime.createTenant('globex')
-    const alice = acme.createPrincipal({ tenantId: 'acme', userId: 'alice' })
-    const eve = globex.createPrincipal({ tenantId: 'globex', userId: 'eve' })
+    const acme = await runtime.tenants.ensure('acme')
+    const globex = await runtime.tenants.ensure('globex')
+    const alice = await acme.principals.ensure('alice')
+    const eve = await globex.principals.ensure('eve')
 
-    await alice.ctx.multiTenant.claimSession('session-a', alice.principal)
-    await expect(alice.ctx.multiTenant.canAccessSession(alice.principal, 'session-a')).resolves.toBe(true)
-    await expect(eve.ctx.multiTenant.canAccessSession(eve.principal, 'session-a')).resolves.toBe(false)
-    await expect(ctx.multiTenant.getSessionOwner('session-a')).resolves.toEqual(alice.principal)
+    await alice.ctx.multiTenant.claimSession('session-a', alice.identity)
+    await expect(alice.ctx.multiTenant.canAccessSession(alice.identity, 'session-a')).resolves.toBe(true)
+    await expect(eve.ctx.multiTenant.canAccessSession(eve.identity, 'session-a')).resolves.toBe(false)
+    await expect(ctx.multiTenant.getSessionOwner('session-a')).resolves.toEqual(alice.identity)
+  })
+
+  it('keeps security/kernel services shared and validates principal keys', async () => {
+    const { runtime } = await createRuntime()
+
+    await expect(runtime.tenants.ensure('acme', { isolateServices: ['multiTenant'] }))
+      .rejects.toThrow(ValidationError)
+    await expect(runtime.tenants.ensure('globex', { isolateServices: ['registry'] }))
+      .rejects.toThrow(ValidationError)
+
+    const tenant = await runtime.tenants.ensure('initech')
+    await expect(tenant.principals.ensure(' ')).rejects.toThrow(ValidationError)
   })
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,8 +45,8 @@ importers:
         specifier: ^4.0.1
         version: 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
       '@deepseek-ai/dsh-host-apiproxy':
-        specifier: 0.1.0-rc.7
-        version: 0.1.0-rc.7(227e91a6307a4a5d4a380ed795ce9271)
+        specifier: 0.1.1-rc.2
+        version: 0.1.1-rc.2(f74314e544c4485f20172402a2d85310)
       '@types/node':
         specifier: ^22.20.0
         version: 22.20.1
@@ -101,6 +101,15 @@ packages:
       '@deepseek-ai/dsh-llm': ^0.1.0-rc.7
       '@deepseek-ai/dsh-settings': ^0.1.0-rc.7
 
+  '@deepseek-ai/dsh-agent-default-model@0.1.1-rc.2':
+    resolution: {integrity: sha512-Pv+4p20Eol7Ds/n0OS0vjtChCWfFTJAMThxugXcEcLKEJ9WAtpI4mzWfLgjmeVXnwD2yvp6HlLKDrrQV9PIkww==}
+    peerDependencies:
+      '@deepseek-ai/cordis': ^4.0.1
+      '@deepseek-ai/dsh-agent': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-invariants': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-llm': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-settings': ^0.1.1-rc.2
+
   '@deepseek-ai/dsh-agent-presets@0.1.0-rc.7':
     resolution: {integrity: sha512-T/VcMV7lrXCFmRKrtoMTAz5DAdUmku6hz95wbikRvRc0WizIwQ3R04ke9KIeDiQcxK8xkE8cx+IYqEWa9C5gPg==}
     peerDependencies:
@@ -126,6 +135,17 @@ packages:
       '@deepseek-ai/dsh-session': ^0.1.0-rc.7
       '@deepseek-ai/dsh-system-prompt': ^0.1.0-rc.7
       '@deepseek-ai/dsh-typert-protocol': ^0.1.0-rc.7
+
+  '@deepseek-ai/dsh-agent@0.1.1-rc.2':
+    resolution: {integrity: sha512-cC7lnJe7JgPFcreNXxcxLMxQd78LnpVO9ZXROjZsGRQN1zGH6i/DduI892F1am85IfzzO+XTxMwwUHmfwamb0g==}
+    peerDependencies:
+      '@deepseek-ai/cordis': ^4.0.1
+      '@deepseek-ai/dsh-invariants': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-llm': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-scope': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-session': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-system-prompt': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-typert-protocol': ^0.1.1-rc.2
 
   '@deepseek-ai/dsh-api-gateway@0.1.0-rc.7':
     resolution: {integrity: sha512-tcoOuHMSqYqCtMxLjWBHKN+glS56XaUo3ImphvDvUkB84FyU3btHNJbYeAt2oXoWbHfOedcIRWpfNN4tSmhPwQ==}
@@ -155,6 +175,28 @@ packages:
       '@deepseek-ai/dsh-settings': ^0.1.0-rc.7
       '@deepseek-ai/dsh-typert-registry': ^0.1.0-rc.7
 
+  '@deepseek-ai/dsh-api-remotes@0.1.1-rc.2':
+    resolution: {integrity: sha512-mtmMxA0TZwTjy46E2DF0kmsPCXVq6RBhrwEHWXBaRzc0DLjnYqmJODrZ0X+XwXOkwFZtDxWSv/uheiIsXf8now==}
+    peerDependencies:
+      '@deepseek-ai/cordis': ^4.0.1
+      '@deepseek-ai/dsh-agent': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-agent-presets': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-api-gateway': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-commands': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-cordis-host-runner': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-credentials': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-file-reference': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-goal': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-host-plugin-inventory': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-invariants': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-llm': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-message-feedback': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-session': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-session-persistence': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-session-reference': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-settings': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-typert-registry': ^0.1.1-rc.2
+
   '@deepseek-ai/dsh-atomic-write@0.1.0-rc.7':
     resolution: {integrity: sha512-LxRx6K8FJ8bXZHiNhH6Rvj+jh/ZIpolmsmi138XrvMUGvbOBWE6QLbdzcgTgwrYZm5GP2kqqLe/3gQlgtt2bXA==}
     peerDependencies:
@@ -168,11 +210,24 @@ packages:
       '@deepseek-ai/dsh-brand': ^0.1.0-rc.7
       '@deepseek-ai/dsh-invariants': ^0.1.0-rc.7
 
+  '@deepseek-ai/dsh-attachment@0.1.1-rc.2':
+    resolution: {integrity: sha512-rCYAt8QsawP1yfDCU7XxNwYT/XWvyFsxYrkwhLLkdfW83QVD0CQHizSkTQE7RFX74nKUD1z3sTLfnLr7xneArw==}
+    peerDependencies:
+      '@deepseek-ai/cordis': ^4.0.1
+      '@deepseek-ai/dsh-brand': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-invariants': ^0.1.1-rc.2
+
   '@deepseek-ai/dsh-brand@0.1.0-rc.7':
     resolution: {integrity: sha512-P7+w0fN40yXXQkV360p6jQi63pcl68OOWebNGN5gf8w8sguvni2mA1cU8RLZzDkRNFSZD+BCw3D4uWYM+hhh7A==}
     peerDependencies:
       '@deepseek-ai/cordis': ^4.0.1
       '@deepseek-ai/dsh-invariants': ^0.1.0-rc.7
+
+  '@deepseek-ai/dsh-brand@0.1.1-rc.2':
+    resolution: {integrity: sha512-8vXsAXoUdzKAgvd/E9DgyT6HKmR6ZM4rtJ3fs/XoJ6n2kBk4tWil8Lv+jxCMWJeMOnTJF55gu2+NWQ3ECFPtJw==}
+    peerDependencies:
+      '@deepseek-ai/cordis': ^4.0.1
+      '@deepseek-ai/dsh-invariants': ^0.1.1-rc.2
 
   '@deepseek-ai/dsh-client-connection@0.1.0-rc.7':
     resolution: {integrity: sha512-JZWDKCbwKHOUcm7+JadKA3aJCSEB34XfPycCtPgdWfABIiHMaSpnmSVy/8Jed4hw6hxhnR6A3rnvW02Xr2yqwA==}
@@ -198,6 +253,29 @@ packages:
       '@deepseek-ai/dsh-session': ^0.1.0-rc.7
       '@deepseek-ai/dsh-typert-protocol': ^0.1.0-rc.7
 
+  '@deepseek-ai/dsh-commands@0.1.1-rc.2':
+    resolution: {integrity: sha512-BOIe4Sht9rmMv1a6b3GWjWBbeWr7PtHlAy41vgpaymvUUuzOapOIA648ZMGCI/crRIt72Umev2FHtSwCNSbYZg==}
+    peerDependencies:
+      '@deepseek-ai/cordis': ^4.0.1
+      '@deepseek-ai/dsh-agent': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-attachment': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-brand': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-invariants': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-llm': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-scope': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-session': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-typert-protocol': ^0.1.1-rc.2
+
+  '@deepseek-ai/dsh-compaction@0.1.1-rc.2':
+    resolution: {integrity: sha512-LV5GAIx7GO8DCRivnN2bmLmuucsYDG+ifG18BaXBqsVKdrzmaIu5o+CBxQAI2bX1N6mfBenLxmvCnROkyumLTg==}
+    peerDependencies:
+      '@deepseek-ai/cordis': ^4.0.1
+      '@deepseek-ai/dsh-brand': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-commands': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-invariants': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-llm': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-session': ^0.1.1-rc.2
+
   '@deepseek-ai/dsh-cordis-host-runner@0.1.0-rc.7':
     resolution: {integrity: sha512-A7R39cSNsLwjm+P54bUFBUd5+YbdyKkC5cLQqYt12STt0Z06az10Qt5rsL25rnWkxW7x7Ql0wVA83tOmO2oy0g==}
     peerDependencies:
@@ -218,6 +296,21 @@ packages:
       '@deepseek-ai/dsh-brand': ^0.1.0-rc.7
       '@deepseek-ai/dsh-invariants': ^0.1.0-rc.7
 
+  '@deepseek-ai/dsh-credentials@0.1.1-rc.2':
+    resolution: {integrity: sha512-aeVBaH07rox7NuSNbSqbz8g0eNb2IIhNbrZngj/VxUsr/TR9TXOq7lm1CL6SBUDlstGw3vNWeXyhim/DmA5iSQ==}
+    peerDependencies:
+      '@deepseek-ai/cordis': ^4.0.1
+      '@deepseek-ai/dsh-brand': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-invariants': ^0.1.1-rc.2
+
+  '@deepseek-ai/dsh-file-reference@0.1.1-rc.2':
+    resolution: {integrity: sha512-8Pd4SNHhV6OlbwfV5K4qmFb709I0Z68qgaUQJ7zM4BTjClNe1/dktQnETtWPfqbPTx/2sNKXM1rz4WXuROrIfQ==}
+    peerDependencies:
+      '@deepseek-ai/cordis': ^4.0.1
+      '@deepseek-ai/dsh-agent': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-invariants': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-typert-protocol': ^0.1.1-rc.2
+
   '@deepseek-ai/dsh-goal@0.1.0-rc.7':
     resolution: {integrity: sha512-/pI2o0YcP21ReT+OQx7aA8SyUsnuEHxTQtMbu3DvN9ChvaFeptCTXGvHWocwVtzEEi48mdvAXF4Mx0Ptj1LJYA==}
     peerDependencies:
@@ -230,6 +323,19 @@ packages:
       '@deepseek-ai/dsh-session': ^0.1.0-rc.7
       '@deepseek-ai/dsh-session-projection': ^0.1.0-rc.7
       '@deepseek-ai/dsh-typert-protocol': ^0.1.0-rc.7
+
+  '@deepseek-ai/dsh-goal@0.1.1-rc.2':
+    resolution: {integrity: sha512-lSHTh4vfS6eRb9to/y+bjRf2+0QkNpY3tHJ29HMTewR9fJYZsEVVu4Hc+GPhPEjF7RpiD35/sKx+akijtDasyg==}
+    peerDependencies:
+      '@deepseek-ai/cordis': ^4.0.1
+      '@deepseek-ai/dsh-agent': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-brand': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-invariants': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-llm': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-scope': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-session': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-session-projection': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-typert-protocol': ^0.1.1-rc.2
 
   '@deepseek-ai/dsh-home-paths@0.1.0-rc.7':
     resolution: {integrity: sha512-9Bu0eAbPw/FfCNpiX9hvyP5wedMUUQBc2sVTtU+xtH27/iUPxXoamFtBt3ydBJUeuVhja/leuhJ/d3MRhXO9fQ==}
@@ -245,11 +351,25 @@ packages:
       '@deepseek-ai/dsh-cordis-host-runner': ^0.1.0-rc.7
       '@deepseek-ai/dsh-invariants': ^0.1.0-rc.7
 
+  '@deepseek-ai/dsh-host-apiproxy@0.1.1-rc.2':
+    resolution: {integrity: sha512-dplRnGGXXsQYFQ1KMHymAM0iaxuE9Z153JHYcGEgOwXNkS3HA20gSi3yMt6fz+zi/cMHYXvY1JQhS54BTc761A==}
+    peerDependencies:
+      '@deepseek-ai/cordis': ^4.0.1
+      '@deepseek-ai/dsh-agent-presets': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-cordis-host-runner': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-invariants': ^0.1.1-rc.2
+
   '@deepseek-ai/dsh-host-directory-picker@0.1.0-rc.7':
     resolution: {integrity: sha512-CamVZ4wOjGcgzOiRFQtG0J0hy4EY3nXJBRFs0S397+H7b9eJUTtaMdOxP5w7VhMQ0Aq2ND7gpadwIcFaqINsMw==}
     peerDependencies:
       '@deepseek-ai/cordis': ^4.0.1
       '@deepseek-ai/dsh-invariants': ^0.1.0-rc.7
+
+  '@deepseek-ai/dsh-host-directory-picker@0.1.1-rc.2':
+    resolution: {integrity: sha512-m3puwS+bvJQ1eASdpEEwlQqKa9znhBSgtoSSI0GZN5VMynZVl7E31HMltENz3QC2Nd+C3bh7vNjrJFtumUDsLQ==}
+    peerDependencies:
+      '@deepseek-ai/cordis': ^4.0.1
+      '@deepseek-ai/dsh-invariants': ^0.1.1-rc.2
 
   '@deepseek-ai/dsh-host-plugin-inventory@0.1.0-rc.7':
     resolution: {integrity: sha512-B8ITfMnBAdgkkuvoMrBdVgydhsCYGnP8XIGXIouOQyT9/eWbD3WqO76XG+u+e2G36ACXu2NaIxsRh3ijzyorwg==}
@@ -280,6 +400,15 @@ packages:
       '@deepseek-ai/dsh-invariants': ^0.1.0-rc.7
       '@deepseek-ai/dsh-session': ^0.1.0-rc.7
 
+  '@deepseek-ai/dsh-jobs@0.1.1-rc.2':
+    resolution: {integrity: sha512-SXvDJMvcUrGrlzIyE7j8/lI4Pj1nDe/UOR8C05Zagp+/0R8p46n6KylySvZdPAFENV5t8WX3Fw3eOaS4No0+wQ==}
+    peerDependencies:
+      '@deepseek-ai/cordis': ^4.0.1
+      '@deepseek-ai/dsh-agent': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-brand': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-invariants': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-session': ^0.1.1-rc.2
+
   '@deepseek-ai/dsh-llm@0.1.0-rc.7':
     resolution: {integrity: sha512-VaB9kQ8XOA+R5jtsWf92QMc1WpaatEAFUvQePGUYrzQ7Z86b9VhQQzmchh5VmknT4oRSSdn0re5tReCvfcYNXQ==}
     peerDependencies:
@@ -288,6 +417,15 @@ packages:
       '@deepseek-ai/dsh-brand': ^0.1.0-rc.7
       '@deepseek-ai/dsh-invariants': ^0.1.0-rc.7
       '@deepseek-ai/dsh-timeout': ^0.1.0-rc.7
+
+  '@deepseek-ai/dsh-llm@0.1.1-rc.2':
+    resolution: {integrity: sha512-ASJfjIdZbIXvLwi3rGo+eZb/GxMVV/WO5/XVD3B96mT8EIzrlw3+nMR6/CvmJVzcycKQ2XN0wj7jD6TasPRySA==}
+    peerDependencies:
+      '@deepseek-ai/cordis': ^4.0.1
+      '@deepseek-ai/dsh-attachment': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-brand': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-invariants': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-timeout': ^0.1.1-rc.2
 
   '@deepseek-ai/dsh-message-feedback@0.1.0-rc.7':
     resolution: {integrity: sha512-P/Inw7dQMZCC6I6NC6G0UF9SeOVlpQxOBg2+LoCdvyTt40itDow2wmlThqkQDIt4UMHLT4yRc0Gd6a4gmTNJ2w==}
@@ -307,6 +445,18 @@ packages:
       '@deepseek-ai/cordis': ^4.0.1
       '@deepseek-ai/dsh-invariants': ^0.1.0-rc.7
 
+  '@deepseek-ai/dsh-native-command@0.1.1-rc.2':
+    resolution: {integrity: sha512-GIknPrwU7vZOUQ2o/ES7Z0uUhUrZGp/yigKP+RXEu41VI9tcybiXQAA8CEdDFmNQ11R2wfYQhr3WO5vy35akWg==}
+    peerDependencies:
+      '@deepseek-ai/cordis': ^4.0.1
+      '@deepseek-ai/dsh-invariants': ^0.1.1-rc.2
+
+  '@deepseek-ai/dsh-output-retention@0.1.1-rc.2':
+    resolution: {integrity: sha512-tCni+bTEp/FWokfz3fqn4p6SzHn6pkY6H3HkS9UY5PHrztUE1ESUQUp41kIVtwUhRmJU7yissqjxe6kLDB6t2Q==}
+    peerDependencies:
+      '@deepseek-ai/cordis': ^4.0.1
+      '@deepseek-ai/dsh-invariants': ^0.1.1-rc.2
+
   '@deepseek-ai/dsh-scope@0.1.0-rc.7':
     resolution: {integrity: sha512-8gn+sANXhpv+9egbNwq49/uI3XhbmB33obo9yMyzyzruan3zFoxeH4UV54jTC2hjbu8gFNPsyNam9AAtRV8/Cg==}
     peerDependencies:
@@ -322,6 +472,15 @@ packages:
       '@deepseek-ai/dsh-session': ^0.1.0-rc.7
       '@deepseek-ai/dsh-timeout': ^0.1.0-rc.7
 
+  '@deepseek-ai/dsh-session-persistence@0.1.1-rc.2':
+    resolution: {integrity: sha512-dxdYxRfmK5jWtiFFabqRNb/jGGjkXyF2djI7O8IIKmDVjhQiv170zpvhbAhRUuqClEdseCtbQpLBrRm2blzt3g==}
+    peerDependencies:
+      '@deepseek-ai/cordis': ^4.0.1
+      '@deepseek-ai/dsh-brand': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-invariants': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-session': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-timeout': ^0.1.1-rc.2
+
   '@deepseek-ai/dsh-session-projection-cache@0.1.0-rc.7':
     resolution: {integrity: sha512-qWf7p2Xgr0LnY4o466ei3L/81QbGFQcCbEi+4XX9rxLKgnU+RvlQzwmIilrgz9N2hK/RqwS1Nb03bFRisxVeaw==}
     peerDependencies:
@@ -332,12 +491,29 @@ packages:
       '@deepseek-ai/dsh-session-projection': ^0.1.0-rc.7
       '@deepseek-ai/dsh-storage-domain': ^0.1.0-rc.7
 
+  '@deepseek-ai/dsh-session-projection-cache@0.1.1-rc.2':
+    resolution: {integrity: sha512-UvCRpIb+LoQI/nCLof17xc2P2KuZoucU3VuzfAukfsF3dYZAy5OP7jrCRdVZIvjRfvFUd7G+awdS9sWbnjcolg==}
+    peerDependencies:
+      '@deepseek-ai/cordis': ^4.0.1
+      '@deepseek-ai/dsh-invariants': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-session': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-session-persistence': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-session-projection': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-storage-domain': ^0.1.1-rc.2
+
   '@deepseek-ai/dsh-session-projection@0.1.0-rc.7':
     resolution: {integrity: sha512-BXehLYt6wYnV0PNNhv5GECePkH1w+1yuu/R63d2tdYdUQ7XVrd6tu5hMwfTH0P9AnBDxJir08FRu2WKO69JypA==}
     peerDependencies:
       '@deepseek-ai/cordis': ^4.0.1
       '@deepseek-ai/dsh-invariants': ^0.1.0-rc.7
       '@deepseek-ai/dsh-session': ^0.1.0-rc.7
+
+  '@deepseek-ai/dsh-session-projection@0.1.1-rc.2':
+    resolution: {integrity: sha512-SNaOrjRS4RMXocna6uL33TeS/uhcQ7jDJtJZ1HyDPL06mXUdAgje2MVt8OZCh6dH95xIiqpQQm+KjzeiQnhYSQ==}
+    peerDependencies:
+      '@deepseek-ai/cordis': ^4.0.1
+      '@deepseek-ai/dsh-invariants': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-session': ^0.1.1-rc.2
 
   '@deepseek-ai/dsh-session-query@0.1.0-rc.7':
     resolution: {integrity: sha512-JKlEpByllYQU9JZLadrS3ClWCVZMcKRB4nc6iCWuNExyRi/Whwa5GicKFs+jXwGKe/rdSbTCom/jYLwkqipjuw==}
@@ -353,6 +529,33 @@ packages:
       '@deepseek-ai/dsh-session-persistence':
         optional: true
 
+  '@deepseek-ai/dsh-session-query@0.1.1-rc.2':
+    resolution: {integrity: sha512-QxQFRg/KnrZnYiO7fNtTJVTakuGs9ZFRkGGgYuNPzSz1pRqiohGNE/JZzBtq+HMv38RRTRZrM4aIOUV8OgqoXQ==}
+    peerDependencies:
+      '@deepseek-ai/cordis': ^4.0.1
+      '@deepseek-ai/dsh-brand': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-invariants': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-llm': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-session': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-session-persistence': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-session-title': ^0.1.1-rc.2
+    peerDependenciesMeta:
+      '@deepseek-ai/dsh-session-persistence':
+        optional: true
+
+  '@deepseek-ai/dsh-session-reference@0.1.1-rc.2':
+    resolution: {integrity: sha512-c9mz19ndxjVxSnXEhmJwGDjyKG4oNmu4Sfneix8OUJ+mAr3jIgb/QZZ8rYEc8Bi+Dd1z7Wr90IeWOBF0nolU3A==}
+    peerDependencies:
+      '@deepseek-ai/cordis': ^4.0.1
+      '@deepseek-ai/dsh-agent': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-compaction': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-invariants': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-llm': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-output-retention': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-session': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-session-query': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-typert-protocol': ^0.1.1-rc.2
+
   '@deepseek-ai/dsh-session-title@0.1.0-rc.7':
     resolution: {integrity: sha512-jhFiZa/C58zchuJkBodnkiPil7AEK8mHfB/hMOAW3N/7tUg5nbMLBERNqHdDMbIrvhTndrF4SN9qy+ltUf0cOQ==}
     peerDependencies:
@@ -362,6 +565,16 @@ packages:
       '@deepseek-ai/dsh-llm': ^0.1.0-rc.7
       '@deepseek-ai/dsh-session': ^0.1.0-rc.7
       '@deepseek-ai/dsh-session-projection': ^0.1.0-rc.7
+
+  '@deepseek-ai/dsh-session-title@0.1.1-rc.2':
+    resolution: {integrity: sha512-qHv+9nE6J/piHsWwckmbJBS1sJjunCWsv00arhsgjW1XMLCHxG6QOB+U48P4EBZjve798Tz8AQIlWZy+9T8XmA==}
+    peerDependencies:
+      '@deepseek-ai/cordis': ^4.0.1
+      '@deepseek-ai/dsh-brand': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-invariants': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-llm': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-session': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-session-projection': ^0.1.1-rc.2
 
   '@deepseek-ai/dsh-session@0.1.0-rc.7':
     resolution: {integrity: sha512-02WVTkqIH+TyDL7dhMN3Hm+qcTEdhD0fVDC0aIAyND2fBdXj3CagEXXvpmt3mzwWfKwOTGL1RdxtC6pMA4Bl1A==}
@@ -373,12 +586,30 @@ packages:
       '@deepseek-ai/dsh-scope': ^0.1.0-rc.7
       '@deepseek-ai/dsh-typert-protocol': ^0.1.0-rc.7
 
+  '@deepseek-ai/dsh-session@0.1.1-rc.2':
+    resolution: {integrity: sha512-4/cv6X9HPhm47eyRhCu/WZwzrtJKegk5J+0xaxcZ9i8S0smdxP57tqy8a0jkSshLQn7BzMFxneQrlYExrLrDhQ==}
+    peerDependencies:
+      '@deepseek-ai/cordis': ^4.0.1
+      '@deepseek-ai/dsh-brand': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-invariants': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-llm': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-scope': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-typert-protocol': ^0.1.1-rc.2
+
   '@deepseek-ai/dsh-settings@0.1.0-rc.7':
     resolution: {integrity: sha512-cS1+StK2xIVykrskw+KrO+hKJxYaVVgY2Jex2we5zASTNLHYCj74WQluPlaFjFgnXoZ1RYz8HNXL5/Ho6h1Ynw==}
     peerDependencies:
       '@deepseek-ai/cordis': ^4.0.1
       '@deepseek-ai/dsh-brand': ^0.1.0-rc.7
       '@deepseek-ai/dsh-invariants': ^0.1.0-rc.7
+      '@deepseek-ai/schemastery': ^3.18.1
+
+  '@deepseek-ai/dsh-settings@0.1.1-rc.2':
+    resolution: {integrity: sha512-iGdKEt91Im3gE7xA9CzRfTJsPcFcxDeDOCLhAjzbpjEv7TAjx/EoYP7lPtiy+QmOjKSKy206SEtAKol9PXWbOw==}
+    peerDependencies:
+      '@deepseek-ai/cordis': ^4.0.1
+      '@deepseek-ai/dsh-brand': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-invariants': ^0.1.1-rc.2
       '@deepseek-ai/schemastery': ^3.18.1
 
   '@deepseek-ai/dsh-skill@0.1.0-rc.7':
@@ -388,6 +619,14 @@ packages:
       '@deepseek-ai/dsh-invariants': ^0.1.0-rc.7
       '@deepseek-ai/dsh-llm': ^0.1.0-rc.7
       '@deepseek-ai/dsh-scope': ^0.1.0-rc.7
+
+  '@deepseek-ai/dsh-skill@0.1.1-rc.2':
+    resolution: {integrity: sha512-FACjlOqdsWX+0RtSs3RWrdY0QQEpPJrBfvxUbWSh7E8UyCM8dKdIbsQnuXIjsAgC7GgYp7lyFDSCMovQ3ARp8g==}
+    peerDependencies:
+      '@deepseek-ai/cordis': ^4.0.1
+      '@deepseek-ai/dsh-invariants': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-llm': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-scope': ^0.1.1-rc.2
 
   '@deepseek-ai/dsh-storage-domain@0.1.0-rc.7':
     resolution: {integrity: sha512-UxXwoCB0q4+/F+zddvi8I4LknTIlGD/1ec57Ym52kWRb7a8qGgrcIYrOC3yPCozn8rkirAuhEAkyAhR6AO5QDw==}
@@ -439,6 +678,43 @@ packages:
       '@deepseek-ai/dsh-user-approval':
         optional: true
 
+  '@deepseek-ai/dsh-subagent@0.1.1-rc.2':
+    resolution: {integrity: sha512-CNa0WuFCR69TMnBKYQInz49/olDSaVHiYkDTyTuDh7YW7Y80/f/HjQe5G0fQaqZMLla3IUSXCIPl5EssWmjcQw==}
+    peerDependencies:
+      '@deepseek-ai/cordis': ^4.0.1
+      '@deepseek-ai/dsh-agent': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-agent-presets': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-brand': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-invariants': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-jobs': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-llm': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-sandbox': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-sandbox-policy': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-scope': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-session': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-session-persistence': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-session-projection': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-session-projection-cache': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-tools': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-user-approval': ^0.1.1-rc.2
+    peerDependenciesMeta:
+      '@deepseek-ai/dsh-agent-presets':
+        optional: true
+      '@deepseek-ai/dsh-jobs':
+        optional: true
+      '@deepseek-ai/dsh-sandbox':
+        optional: true
+      '@deepseek-ai/dsh-sandbox-policy':
+        optional: true
+      '@deepseek-ai/dsh-session-persistence':
+        optional: true
+      '@deepseek-ai/dsh-session-projection':
+        optional: true
+      '@deepseek-ai/dsh-session-projection-cache':
+        optional: true
+      '@deepseek-ai/dsh-user-approval':
+        optional: true
+
   '@deepseek-ai/dsh-system-prompt@0.1.0-rc.7':
     resolution: {integrity: sha512-Rair2ZkzgoIIr+UstYVYeqeUgORNPIW1LNcsXz3Zjglx4FGjsmzs0UALdNYvSBpBvCLNmt4E6+XQIrBbS/s9jw==}
     peerDependencies:
@@ -466,11 +742,30 @@ packages:
       '@deepseek-ai/dsh-system-prompt': ^0.1.0-rc.7
       '@deepseek-ai/dsh-user-approval': ^0.1.0-rc.7
 
+  '@deepseek-ai/dsh-tools@0.1.1-rc.2':
+    resolution: {integrity: sha512-0GGL4D55MwYDepzZMOI3L0ycu5b2qr96GL0Y7snwhAnpK2Di61rbX3fJE+PB3ZrovGX0csIRdt9n3iJZDVtDrw==}
+    peerDependencies:
+      '@deepseek-ai/cordis': ^4.0.1
+      '@deepseek-ai/dsh-agent': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-code-runtime': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-invariants': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-llm': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-scope': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-session': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-system-prompt': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-user-approval': ^0.1.1-rc.2
+
   '@deepseek-ai/dsh-typert-protocol@0.1.0-rc.7':
     resolution: {integrity: sha512-R7qdvaRRHbz5xijoVOxueeBB/VT0eDzuQNQN4iNEBUbI/L9xG9bZutktTQlgrIlBSn1sPH4pLqiCiM6ErQPTaQ==}
     peerDependencies:
       '@deepseek-ai/cordis': ^4.0.1
       '@deepseek-ai/dsh-invariants': ^0.1.0-rc.7
+
+  '@deepseek-ai/dsh-typert-protocol@0.1.1-rc.2':
+    resolution: {integrity: sha512-lxBssDc5Pz1qBE5kuIyaArA7AvIPq9rpaVclylodiSzVJe95e2xruBg73tflyjtd8y00toet+DLgQ6tSSsq6Kw==}
+    peerDependencies:
+      '@deepseek-ai/cordis': ^4.0.1
+      '@deepseek-ai/dsh-invariants': ^0.1.1-rc.2
 
   '@deepseek-ai/dsh-typert-registry@0.1.0-rc.7':
     resolution: {integrity: sha512-7AQNJLNZTw7/5DzjbfBy4dRqr6VSwc74HBOSPpxm0zzzbmXOEqRCRzMps25IByoAeltRz1ZyY4fzN3tcYa+XwQ==}
@@ -490,6 +785,18 @@ packages:
       '@deepseek-ai/dsh-session': ^0.1.0-rc.7
       '@deepseek-ai/dsh-system-prompt': ^0.1.0-rc.7
 
+  '@deepseek-ai/dsh-user-approval@0.1.1-rc.2':
+    resolution: {integrity: sha512-SdsO4Rs+NeJFoertkVilXBACREOLfkKPJJznYKqDhJxeRo38RJ56dtj0Xd0/6rERmsQiMck4Bwdrzg1ubUqPNA==}
+    peerDependencies:
+      '@deepseek-ai/cordis': ^4.0.1
+      '@deepseek-ai/dsh-agent': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-brand': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-invariants': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-llm': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-scope': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-session': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-system-prompt': ^0.1.1-rc.2
+
   '@deepseek-ai/dsh-user-questions@0.1.0-rc.7':
     resolution: {integrity: sha512-dfT6pj84lJdhrtbW2pV6hRftoKDkqx0aJevrhUhOy7Lv3CqTOheuLwwyT69Lww+n/q80Z+yp41qJq9loCkrOaw==}
     peerDependencies:
@@ -497,6 +804,14 @@ packages:
       '@deepseek-ai/dsh-agent': ^0.1.0-rc.7
       '@deepseek-ai/dsh-invariants': ^0.1.0-rc.7
       '@deepseek-ai/dsh-llm': ^0.1.0-rc.7
+
+  '@deepseek-ai/dsh-user-questions@0.1.1-rc.2':
+    resolution: {integrity: sha512-9lYoB7qCFE+Vvgwjny3MnRfS7QUefOspj4KpE3b30DAAJfxwrU4hRtLCHOKxyurF01qrkoEBBpXn4H5ilXYTKg==}
+    peerDependencies:
+      '@deepseek-ai/cordis': ^4.0.1
+      '@deepseek-ai/dsh-agent': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-invariants': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-llm': ^0.1.1-rc.2
 
   '@deepseek-ai/dsh-workspace@0.1.0-rc.7':
     resolution: {integrity: sha512-0czW0bI+uFFOS8h8eJ9SGZSdv+StEsa/+E1WEjZQXVeIOxo520Pv47dq+Z3mTyBfV8gJB+UcY0AQ3F0FddYohg==}
@@ -508,6 +823,17 @@ packages:
       '@deepseek-ai/dsh-session-persistence': ^0.1.0-rc.7
       '@deepseek-ai/dsh-storage': ^0.1.0-rc.7
       '@deepseek-ai/dsh-storage-domain': ^0.1.0-rc.7
+
+  '@deepseek-ai/dsh-workspace@0.1.1-rc.2':
+    resolution: {integrity: sha512-jBUob4H5TZAiExq9YNVCglKAFmAKMtd1UbyqFfnZZ1Owm+3c3NbAXY947MHiD6NwCwFEW1y7FjrFj66UQvG90A==}
+    peerDependencies:
+      '@deepseek-ai/cordis': ^4.0.1
+      '@deepseek-ai/dsh-brand': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-invariants': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-session': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-session-persistence': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-storage': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-storage-domain': ^0.1.1-rc.2
 
   '@deepseek-ai/schemastery@3.18.1':
     resolution: {integrity: sha512-Qn0FCSwCQnpnj6SB31I6i2sIKgKWnkbJM8O0EU91Gv2UsYVvtZTl6IA0sCwk2e2MZf5S8w5hpq9QkeVvK9qwxg==}
@@ -1391,67 +1717,108 @@ snapshots:
 
   '@deepseek-ai/cosmokit@1.8.2': {}
 
-  '@deepseek-ai/dsh-agent-default-model@0.1.0-rc.7(1eb7ceb2998733be9eba21a37a3dc291)':
+  '@deepseek-ai/dsh-agent-default-model@0.1.0-rc.7(c74ec2dd3262c805134d5ad981ca1e21)':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
-      '@deepseek-ai/dsh-agent': 0.1.0-rc.7(1e28fca6adb316c000fd361f8e5f3a08)
+      '@deepseek-ai/dsh-agent': 0.1.0-rc.7(2159b1e0165b1d0e28bdde123a84571a)
       '@deepseek-ai/dsh-invariants': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)
-      '@deepseek-ai/dsh-llm': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
+      '@deepseek-ai/dsh-llm': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
       '@deepseek-ai/dsh-settings': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/schemastery@3.18.1)
       '@deepseek-ai/schemastery': 3.18.1
 
-  '@deepseek-ai/dsh-agent-presets@0.1.0-rc.7(c0f9f44edab94cddae92cd4b4f319bab)':
+  '@deepseek-ai/dsh-agent-default-model@0.1.1-rc.2(78cd69dc3ebaef70bf1a6f181a22dfa8)':
+    dependencies:
+      '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
+      '@deepseek-ai/dsh-agent': 0.1.1-rc.2(68de7455d024c703f96e98dc56c95398)
+      '@deepseek-ai/dsh-invariants': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)
+      '@deepseek-ai/dsh-llm': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
+      '@deepseek-ai/dsh-settings': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/schemastery@3.18.1)
+      '@deepseek-ai/schemastery': 3.18.1
+
+  '@deepseek-ai/dsh-agent-presets@0.1.0-rc.7(32310cb66b87c92a592dba1b12447dde)':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
       '@deepseek-ai/cordis-plugin-include': 1.0.6(@deepseek-ai/cordis-plugin-loader@1.0.2)(@deepseek-ai/cordis@4.0.1)
       '@deepseek-ai/cordis-plugin-loader': 1.0.2(@deepseek-ai/cordis@4.0.1)
-      '@deepseek-ai/dsh-agent': 0.1.0-rc.7(1e28fca6adb316c000fd361f8e5f3a08)
+      '@deepseek-ai/dsh-agent': 0.1.1-rc.2(68de7455d024c703f96e98dc56c95398)
       '@deepseek-ai/dsh-atomic-write': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
       '@deepseek-ai/dsh-home-paths': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
       '@deepseek-ai/dsh-invariants': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)
       '@deepseek-ai/dsh-scope': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
-      '@deepseek-ai/dsh-session': 0.1.0-rc.7(1dcde9bfc9fa0140c66648fbcb67b346)
-      '@deepseek-ai/dsh-settings': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/schemastery@3.18.1)
-      '@deepseek-ai/dsh-system-prompt': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-llm@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))))(@deepseek-ai/dsh-scope@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
+      '@deepseek-ai/dsh-session': 0.1.1-rc.2(efbed06cee3aff66518ec36b0d2553ef)
+      '@deepseek-ai/dsh-settings': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/schemastery@3.18.1)
+      '@deepseek-ai/dsh-system-prompt': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-llm@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))))(@deepseek-ai/dsh-scope@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
       '@deepseek-ai/schemastery': 3.18.1
       js-yaml: 4.3.1
 
-  '@deepseek-ai/dsh-agent@0.1.0-rc.7(1e28fca6adb316c000fd361f8e5f3a08)':
+  '@deepseek-ai/dsh-agent@0.1.0-rc.7(2159b1e0165b1d0e28bdde123a84571a)':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
       '@deepseek-ai/dsh-invariants': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)
-      '@deepseek-ai/dsh-llm': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
+      '@deepseek-ai/dsh-llm': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
       '@deepseek-ai/dsh-scope': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
-      '@deepseek-ai/dsh-session': 0.1.0-rc.7(1dcde9bfc9fa0140c66648fbcb67b346)
-      '@deepseek-ai/dsh-system-prompt': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-llm@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))))(@deepseek-ai/dsh-scope@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
-      '@deepseek-ai/dsh-typert-protocol': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-session': 0.1.0-rc.7(c2cd14161e3936b56a33c89d5af7a3ce)
+      '@deepseek-ai/dsh-system-prompt': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-llm@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))))(@deepseek-ai/dsh-scope@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
+      '@deepseek-ai/dsh-typert-protocol': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
+
+  '@deepseek-ai/dsh-agent@0.1.1-rc.2(68de7455d024c703f96e98dc56c95398)':
+    dependencies:
+      '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
+      '@deepseek-ai/dsh-invariants': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)
+      '@deepseek-ai/dsh-llm': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
+      '@deepseek-ai/dsh-scope': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-session': 0.1.1-rc.2(efbed06cee3aff66518ec36b0d2553ef)
+      '@deepseek-ai/dsh-system-prompt': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-llm@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))))(@deepseek-ai/dsh-scope@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
+      '@deepseek-ai/dsh-typert-protocol': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
 
   '@deepseek-ai/dsh-api-gateway@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-connection@0.1.0-rc.7)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-typert-registry@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
-      '@deepseek-ai/dsh-client-connection': 0.1.0-rc.7(18ff0c05ab41670b8daa2e2e166479db)
+      '@deepseek-ai/dsh-client-connection': 0.1.0-rc.7(1c57de25a83d3fae072ecdec6986d528)
       '@deepseek-ai/dsh-invariants': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)
       '@deepseek-ai/dsh-typert-protocol': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
       '@deepseek-ai/dsh-typert-registry': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
 
-  '@deepseek-ai/dsh-api-remotes@0.1.0-rc.7(022498c733cc9b813e36f108b907ce4c)':
+  '@deepseek-ai/dsh-api-remotes@0.1.0-rc.7(68aba4fff4e69bf285801e4a0e55cf1c)':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
-      '@deepseek-ai/dsh-agent': 0.1.0-rc.7(1e28fca6adb316c000fd361f8e5f3a08)
-      '@deepseek-ai/dsh-agent-presets': 0.1.0-rc.7(c0f9f44edab94cddae92cd4b4f319bab)
+      '@deepseek-ai/dsh-agent': 0.1.0-rc.7(2159b1e0165b1d0e28bdde123a84571a)
+      '@deepseek-ai/dsh-agent-presets': 0.1.0-rc.7(32310cb66b87c92a592dba1b12447dde)
       '@deepseek-ai/dsh-api-gateway': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-connection@0.1.0-rc.7)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-typert-registry@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
-      '@deepseek-ai/dsh-commands': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-agent@0.1.0-rc.7(1e28fca6adb316c000fd361f8e5f3a08))(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-scope@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-session@0.1.0-rc.7(1dcde9bfc9fa0140c66648fbcb67b346))(@deepseek-ai/dsh-typert-protocol@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
-      '@deepseek-ai/dsh-cordis-host-runner': 0.1.0-rc.7(2a80d56ba6af58ca8075e00e0fa2157b)
+      '@deepseek-ai/dsh-commands': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-agent@0.1.0-rc.7(2159b1e0165b1d0e28bdde123a84571a))(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-scope@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-session@0.1.0-rc.7(c2cd14161e3936b56a33c89d5af7a3ce))(@deepseek-ai/dsh-typert-protocol@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
+      '@deepseek-ai/dsh-cordis-host-runner': 0.1.0-rc.7(fe90f3c870d2b099319f6fc56b9fddd9)
       '@deepseek-ai/dsh-credentials': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
-      '@deepseek-ai/dsh-goal': 0.1.0-rc.7(9616cea51a4bea931c5522310292a042)
-      '@deepseek-ai/dsh-host-plugin-inventory': 0.1.0-rc.7(@deepseek-ai/cordis-plugin-loader@1.0.2)(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-typert-protocol@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
+      '@deepseek-ai/dsh-goal': 0.1.0-rc.7(8ae38312132a962ec1af0ea5f5344689)
+      '@deepseek-ai/dsh-host-plugin-inventory': 0.1.0-rc.7(@deepseek-ai/cordis-plugin-loader@1.0.2)(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-typert-protocol@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
       '@deepseek-ai/dsh-invariants': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)
-      '@deepseek-ai/dsh-llm': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
-      '@deepseek-ai/dsh-message-feedback': 0.1.0-rc.7(1fcfefbbf5e365eda1a59fadd94056b9)
-      '@deepseek-ai/dsh-session': 0.1.0-rc.7(1dcde9bfc9fa0140c66648fbcb67b346)
-      '@deepseek-ai/dsh-session-persistence': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-session@0.1.0-rc.7(1dcde9bfc9fa0140c66648fbcb67b346))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
+      '@deepseek-ai/dsh-llm': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
+      '@deepseek-ai/dsh-message-feedback': 0.1.0-rc.7(64222bbea17d671ab0fcac175cde7f84)
+      '@deepseek-ai/dsh-session': 0.1.0-rc.7(c2cd14161e3936b56a33c89d5af7a3ce)
+      '@deepseek-ai/dsh-session-persistence': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-session@0.1.0-rc.7(c2cd14161e3936b56a33c89d5af7a3ce))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
       '@deepseek-ai/dsh-settings': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/schemastery@3.18.1)
       '@deepseek-ai/dsh-typert-protocol': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-typert-registry': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
+
+  '@deepseek-ai/dsh-api-remotes@0.1.1-rc.2(647f8017564617187c7f3ed788dcebf3)':
+    dependencies:
+      '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
+      '@deepseek-ai/dsh-agent': 0.1.1-rc.2(68de7455d024c703f96e98dc56c95398)
+      '@deepseek-ai/dsh-agent-presets': 0.1.0-rc.7(32310cb66b87c92a592dba1b12447dde)
+      '@deepseek-ai/dsh-api-gateway': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-connection@0.1.0-rc.7)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-typert-registry@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
+      '@deepseek-ai/dsh-commands': 0.1.1-rc.2(d2a4c008be2ab9b8e1fa6dba07a7d731)
+      '@deepseek-ai/dsh-cordis-host-runner': 0.1.0-rc.7(fe90f3c870d2b099319f6fc56b9fddd9)
+      '@deepseek-ai/dsh-credentials': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-file-reference': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-agent@0.1.1-rc.2(68de7455d024c703f96e98dc56c95398))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-typert-protocol@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
+      '@deepseek-ai/dsh-goal': 0.1.1-rc.2(17bb93726c32b5b8eae34dec63a39bd0)
+      '@deepseek-ai/dsh-host-plugin-inventory': 0.1.0-rc.7(@deepseek-ai/cordis-plugin-loader@1.0.2)(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-typert-protocol@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
+      '@deepseek-ai/dsh-invariants': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)
+      '@deepseek-ai/dsh-llm': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
+      '@deepseek-ai/dsh-message-feedback': 0.1.0-rc.7(64222bbea17d671ab0fcac175cde7f84)
+      '@deepseek-ai/dsh-session': 0.1.1-rc.2(efbed06cee3aff66518ec36b0d2553ef)
+      '@deepseek-ai/dsh-session-persistence': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-session@0.1.1-rc.2(efbed06cee3aff66518ec36b0d2553ef))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
+      '@deepseek-ai/dsh-session-reference': 0.1.1-rc.2(6f879a430ccfed450153cf332c19be17)
+      '@deepseek-ai/dsh-settings': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/schemastery@3.18.1)
+      '@deepseek-ai/dsh-typert-protocol': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
       '@deepseek-ai/dsh-typert-registry': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
 
   '@deepseek-ai/dsh-atomic-write@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))':
@@ -1465,22 +1832,39 @@ snapshots:
       '@deepseek-ai/dsh-brand': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
       '@deepseek-ai/dsh-invariants': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)
 
+  '@deepseek-ai/dsh-attachment@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))':
+    dependencies:
+      '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
+      '@deepseek-ai/dsh-brand': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-invariants': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)
+
+  '@deepseek-ai/dsh-attachment@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))':
+    dependencies:
+      '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
+      '@deepseek-ai/dsh-brand': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-invariants': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)
+
   '@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
       '@deepseek-ai/dsh-invariants': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)
 
-  '@deepseek-ai/dsh-client-connection@0.1.0-rc.7(18ff0c05ab41670b8daa2e2e166479db)':
+  '@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
-      '@deepseek-ai/dsh-attachment': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
-      '@deepseek-ai/dsh-commands': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-agent@0.1.0-rc.7(1e28fca6adb316c000fd361f8e5f3a08))(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-scope@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-session@0.1.0-rc.7(1dcde9bfc9fa0140c66648fbcb67b346))(@deepseek-ai/dsh-typert-protocol@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
-      '@deepseek-ai/dsh-host-apiproxy': 0.1.0-rc.7(227e91a6307a4a5d4a380ed795ce9271)
+      '@deepseek-ai/dsh-invariants': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)
+
+  '@deepseek-ai/dsh-client-connection@0.1.0-rc.7(1c57de25a83d3fae072ecdec6986d528)':
+    dependencies:
+      '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
+      '@deepseek-ai/dsh-attachment': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-commands': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-agent@0.1.1-rc.2(68de7455d024c703f96e98dc56c95398))(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-scope@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-session@0.1.0-rc.7(e92f174b7620c8045f6a89dca6f7f0be))(@deepseek-ai/dsh-typert-protocol@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
+      '@deepseek-ai/dsh-host-apiproxy': 0.1.0-rc.7(bd8c540ef3f5027a8b9eac4f90dded1c)
       '@deepseek-ai/dsh-host-webserver': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
       '@deepseek-ai/dsh-invariants': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)
-      '@deepseek-ai/dsh-llm': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
-      '@deepseek-ai/dsh-session': 0.1.0-rc.7(1dcde9bfc9fa0140c66648fbcb67b346)
-      '@deepseek-ai/dsh-tools': 0.1.0-rc.7(38c91eb2d47c5b4ba2c8ead86dfcb4aa)
+      '@deepseek-ai/dsh-llm': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
+      '@deepseek-ai/dsh-session': 0.1.0-rc.7(e92f174b7620c8045f6a89dca6f7f0be)
+      '@deepseek-ai/dsh-tools': 0.1.0-rc.7(7c26b4eb663e9057e43fcdf56580e7ae)
       '@deepseek-ai/schemastery': 3.18.1
       ws: 8.21.3
     transitivePeerDependencies:
@@ -1510,28 +1894,61 @@ snapshots:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
       '@deepseek-ai/dsh-invariants': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)
 
-  '@deepseek-ai/dsh-commands@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-agent@0.1.0-rc.7(1e28fca6adb316c000fd361f8e5f3a08))(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-scope@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-session@0.1.0-rc.7(1dcde9bfc9fa0140c66648fbcb67b346))(@deepseek-ai/dsh-typert-protocol@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))':
+  '@deepseek-ai/dsh-commands@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-agent@0.1.0-rc.7(2159b1e0165b1d0e28bdde123a84571a))(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-scope@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-session@0.1.0-rc.7(c2cd14161e3936b56a33c89d5af7a3ce))(@deepseek-ai/dsh-typert-protocol@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
-      '@deepseek-ai/dsh-agent': 0.1.0-rc.7(1e28fca6adb316c000fd361f8e5f3a08)
+      '@deepseek-ai/dsh-agent': 0.1.0-rc.7(2159b1e0165b1d0e28bdde123a84571a)
       '@deepseek-ai/dsh-brand': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
       '@deepseek-ai/dsh-invariants': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)
       '@deepseek-ai/dsh-scope': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
-      '@deepseek-ai/dsh-session': 0.1.0-rc.7(1dcde9bfc9fa0140c66648fbcb67b346)
-      '@deepseek-ai/dsh-typert-protocol': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-session': 0.1.0-rc.7(c2cd14161e3936b56a33c89d5af7a3ce)
+      '@deepseek-ai/dsh-typert-protocol': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
       zod: 4.4.3
 
-  '@deepseek-ai/dsh-cordis-host-runner@0.1.0-rc.7(2a80d56ba6af58ca8075e00e0fa2157b)':
+  '@deepseek-ai/dsh-commands@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-agent@0.1.1-rc.2(68de7455d024c703f96e98dc56c95398))(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-scope@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-session@0.1.0-rc.7(e92f174b7620c8045f6a89dca6f7f0be))(@deepseek-ai/dsh-typert-protocol@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
-      '@deepseek-ai/dsh-agent': 0.1.0-rc.7(1e28fca6adb316c000fd361f8e5f3a08)
-      '@deepseek-ai/dsh-brand': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-agent': 0.1.1-rc.2(68de7455d024c703f96e98dc56c95398)
+      '@deepseek-ai/dsh-brand': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
       '@deepseek-ai/dsh-invariants': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)
-      '@deepseek-ai/dsh-llm': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
       '@deepseek-ai/dsh-scope': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
-      '@deepseek-ai/dsh-session': 0.1.0-rc.7(1dcde9bfc9fa0140c66648fbcb67b346)
-      '@deepseek-ai/dsh-tools': 0.1.0-rc.7(38c91eb2d47c5b4ba2c8ead86dfcb4aa)
-      '@deepseek-ai/dsh-typert-protocol': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-session': 0.1.0-rc.7(e92f174b7620c8045f6a89dca6f7f0be)
+      '@deepseek-ai/dsh-typert-protocol': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
+      zod: 4.4.3
+
+  '@deepseek-ai/dsh-commands@0.1.1-rc.2(d2a4c008be2ab9b8e1fa6dba07a7d731)':
+    dependencies:
+      '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
+      '@deepseek-ai/dsh-agent': 0.1.1-rc.2(68de7455d024c703f96e98dc56c95398)
+      '@deepseek-ai/dsh-attachment': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-brand': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-invariants': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)
+      '@deepseek-ai/dsh-llm': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
+      '@deepseek-ai/dsh-scope': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-session': 0.1.1-rc.2(efbed06cee3aff66518ec36b0d2553ef)
+      '@deepseek-ai/dsh-typert-protocol': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
+      zod: 4.4.3
+
+  '@deepseek-ai/dsh-compaction@0.1.1-rc.2(0982d650db43160f1b02a3cc38c0484e)':
+    dependencies:
+      '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
+      '@deepseek-ai/dsh-brand': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-commands': 0.1.1-rc.2(d2a4c008be2ab9b8e1fa6dba07a7d731)
+      '@deepseek-ai/dsh-invariants': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)
+      '@deepseek-ai/dsh-llm': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
+      '@deepseek-ai/dsh-session': 0.1.1-rc.2(efbed06cee3aff66518ec36b0d2553ef)
+
+  '@deepseek-ai/dsh-cordis-host-runner@0.1.0-rc.7(fe90f3c870d2b099319f6fc56b9fddd9)':
+    dependencies:
+      '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
+      '@deepseek-ai/dsh-agent': 0.1.1-rc.2(68de7455d024c703f96e98dc56c95398)
+      '@deepseek-ai/dsh-brand': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-invariants': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)
+      '@deepseek-ai/dsh-llm': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
+      '@deepseek-ai/dsh-scope': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-session': 0.1.1-rc.2(efbed06cee3aff66518ec36b0d2553ef)
+      '@deepseek-ai/dsh-tools': 0.1.1-rc.2(4b7dc20617b63a7b3801d32ef21d735f)
+      '@deepseek-ai/dsh-typert-protocol': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
       '@deepseek-ai/schemastery': 3.18.1
       zod: 4.4.3
 
@@ -1541,17 +1958,45 @@ snapshots:
       '@deepseek-ai/dsh-brand': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
       '@deepseek-ai/dsh-invariants': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)
 
-  '@deepseek-ai/dsh-goal@0.1.0-rc.7(9616cea51a4bea931c5522310292a042)':
+  '@deepseek-ai/dsh-credentials@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
-      '@deepseek-ai/dsh-agent': 0.1.0-rc.7(1e28fca6adb316c000fd361f8e5f3a08)
+      '@deepseek-ai/dsh-brand': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-invariants': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)
+
+  '@deepseek-ai/dsh-file-reference@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-agent@0.1.1-rc.2(68de7455d024c703f96e98dc56c95398))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-typert-protocol@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))':
+    dependencies:
+      '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
+      '@deepseek-ai/dsh-agent': 0.1.1-rc.2(68de7455d024c703f96e98dc56c95398)
+      '@deepseek-ai/dsh-invariants': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)
+      '@deepseek-ai/dsh-typert-protocol': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
+      zod: 4.4.3
+
+  '@deepseek-ai/dsh-goal@0.1.0-rc.7(8ae38312132a962ec1af0ea5f5344689)':
+    dependencies:
+      '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
+      '@deepseek-ai/dsh-agent': 0.1.0-rc.7(2159b1e0165b1d0e28bdde123a84571a)
       '@deepseek-ai/dsh-brand': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
       '@deepseek-ai/dsh-invariants': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)
-      '@deepseek-ai/dsh-llm': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
+      '@deepseek-ai/dsh-llm': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
       '@deepseek-ai/dsh-scope': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
-      '@deepseek-ai/dsh-session': 0.1.0-rc.7(1dcde9bfc9fa0140c66648fbcb67b346)
-      '@deepseek-ai/dsh-session-projection': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-session@0.1.0-rc.7(1dcde9bfc9fa0140c66648fbcb67b346))
-      '@deepseek-ai/dsh-typert-protocol': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-session': 0.1.0-rc.7(c2cd14161e3936b56a33c89d5af7a3ce)
+      '@deepseek-ai/dsh-session-projection': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-session@0.1.0-rc.7(c2cd14161e3936b56a33c89d5af7a3ce))
+      '@deepseek-ai/dsh-typert-protocol': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/schemastery': 3.18.1
+      zod: 4.4.3
+
+  '@deepseek-ai/dsh-goal@0.1.1-rc.2(17bb93726c32b5b8eae34dec63a39bd0)':
+    dependencies:
+      '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
+      '@deepseek-ai/dsh-agent': 0.1.1-rc.2(68de7455d024c703f96e98dc56c95398)
+      '@deepseek-ai/dsh-brand': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-invariants': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)
+      '@deepseek-ai/dsh-llm': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
+      '@deepseek-ai/dsh-scope': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-session': 0.1.1-rc.2(efbed06cee3aff66518ec36b0d2553ef)
+      '@deepseek-ai/dsh-session-projection': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-session@0.1.1-rc.2(efbed06cee3aff66518ec36b0d2553ef))
+      '@deepseek-ai/dsh-typert-protocol': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
       '@deepseek-ai/schemastery': 3.18.1
       zod: 4.4.3
 
@@ -1560,37 +2005,37 @@ snapshots:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
       '@deepseek-ai/dsh-invariants': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)
 
-  '@deepseek-ai/dsh-host-apiproxy@0.1.0-rc.7(227e91a6307a4a5d4a380ed795ce9271)':
+  '@deepseek-ai/dsh-host-apiproxy@0.1.0-rc.7(bd8c540ef3f5027a8b9eac4f90dded1c)':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
-      '@deepseek-ai/dsh-agent': 0.1.0-rc.7(1e28fca6adb316c000fd361f8e5f3a08)
-      '@deepseek-ai/dsh-agent-default-model': 0.1.0-rc.7(1eb7ceb2998733be9eba21a37a3dc291)
-      '@deepseek-ai/dsh-agent-presets': 0.1.0-rc.7(c0f9f44edab94cddae92cd4b4f319bab)
-      '@deepseek-ai/dsh-api-remotes': 0.1.0-rc.7(022498c733cc9b813e36f108b907ce4c)
+      '@deepseek-ai/dsh-agent': 0.1.0-rc.7(2159b1e0165b1d0e28bdde123a84571a)
+      '@deepseek-ai/dsh-agent-default-model': 0.1.0-rc.7(c74ec2dd3262c805134d5ad981ca1e21)
+      '@deepseek-ai/dsh-agent-presets': 0.1.0-rc.7(32310cb66b87c92a592dba1b12447dde)
+      '@deepseek-ai/dsh-api-remotes': 0.1.0-rc.7(68aba4fff4e69bf285801e4a0e55cf1c)
       '@deepseek-ai/dsh-attachment': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
       '@deepseek-ai/dsh-brand': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
-      '@deepseek-ai/dsh-commands': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-agent@0.1.0-rc.7(1e28fca6adb316c000fd361f8e5f3a08))(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-scope@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-session@0.1.0-rc.7(1dcde9bfc9fa0140c66648fbcb67b346))(@deepseek-ai/dsh-typert-protocol@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
-      '@deepseek-ai/dsh-cordis-host-runner': 0.1.0-rc.7(2a80d56ba6af58ca8075e00e0fa2157b)
+      '@deepseek-ai/dsh-commands': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-agent@0.1.0-rc.7(2159b1e0165b1d0e28bdde123a84571a))(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-scope@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-session@0.1.0-rc.7(c2cd14161e3936b56a33c89d5af7a3ce))(@deepseek-ai/dsh-typert-protocol@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
+      '@deepseek-ai/dsh-cordis-host-runner': 0.1.0-rc.7(fe90f3c870d2b099319f6fc56b9fddd9)
       '@deepseek-ai/dsh-credentials': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
-      '@deepseek-ai/dsh-goal': 0.1.0-rc.7(9616cea51a4bea931c5522310292a042)
+      '@deepseek-ai/dsh-goal': 0.1.0-rc.7(8ae38312132a962ec1af0ea5f5344689)
       '@deepseek-ai/dsh-host-directory-picker': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
       '@deepseek-ai/dsh-invariants': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)
-      '@deepseek-ai/dsh-jobs': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-agent@0.1.0-rc.7(1e28fca6adb316c000fd361f8e5f3a08))(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-session@0.1.0-rc.7(1dcde9bfc9fa0140c66648fbcb67b346))
+      '@deepseek-ai/dsh-jobs': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-agent@0.1.0-rc.7(2159b1e0165b1d0e28bdde123a84571a))(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-session@0.1.0-rc.7(c2cd14161e3936b56a33c89d5af7a3ce))
       '@deepseek-ai/dsh-llm': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
       '@deepseek-ai/dsh-native-command': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
-      '@deepseek-ai/dsh-session': 0.1.0-rc.7(1dcde9bfc9fa0140c66648fbcb67b346)
-      '@deepseek-ai/dsh-session-persistence': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-session@0.1.0-rc.7(1dcde9bfc9fa0140c66648fbcb67b346))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
-      '@deepseek-ai/dsh-session-projection': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-session@0.1.0-rc.7(1dcde9bfc9fa0140c66648fbcb67b346))
-      '@deepseek-ai/dsh-session-projection-cache': 0.1.0-rc.7(5ae699d01eec9f3ccaa1e8c13f88dd36)
-      '@deepseek-ai/dsh-session-query': 0.1.0-rc.7(fa24861d08a9d735fc78888af6ddf326)
-      '@deepseek-ai/dsh-session-title': 0.1.0-rc.7(54a387d0d580a07b8dbef208df0b04c2)
+      '@deepseek-ai/dsh-session': 0.1.0-rc.7(c2cd14161e3936b56a33c89d5af7a3ce)
+      '@deepseek-ai/dsh-session-persistence': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-session@0.1.0-rc.7(c2cd14161e3936b56a33c89d5af7a3ce))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
+      '@deepseek-ai/dsh-session-projection': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-session@0.1.0-rc.7(c2cd14161e3936b56a33c89d5af7a3ce))
+      '@deepseek-ai/dsh-session-projection-cache': 0.1.0-rc.7(08c67600371b563d613c5228712dbade)
+      '@deepseek-ai/dsh-session-query': 0.1.0-rc.7(ad752b266826abffe29dd228c04467c8)
+      '@deepseek-ai/dsh-session-title': 0.1.0-rc.7(db4b6201d6640c5f871d1399c9e5eb2d)
       '@deepseek-ai/dsh-settings': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/schemastery@3.18.1)
-      '@deepseek-ai/dsh-skill': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-llm@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))))(@deepseek-ai/dsh-scope@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
-      '@deepseek-ai/dsh-subagent': 0.1.0-rc.7(17b22c2aa5d99096c13835bb226cad51)
-      '@deepseek-ai/dsh-tools': 0.1.0-rc.7(38c91eb2d47c5b4ba2c8ead86dfcb4aa)
-      '@deepseek-ai/dsh-user-approval': 0.1.0-rc.7(6b8cefd624fd84694a941b103cc9b3fb)
-      '@deepseek-ai/dsh-user-questions': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-agent@0.1.0-rc.7(1e28fca6adb316c000fd361f8e5f3a08))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-llm@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))))
-      '@deepseek-ai/dsh-workspace': 0.1.0-rc.7(52d55750df813bb508c3c8815dfcc2bd)
+      '@deepseek-ai/dsh-skill': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-llm@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))))(@deepseek-ai/dsh-scope@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
+      '@deepseek-ai/dsh-subagent': 0.1.0-rc.7(a58d973e9923845a70f07f75ac468a45)
+      '@deepseek-ai/dsh-tools': 0.1.0-rc.7(a7c592dee571edf4a7345045fd39556b)
+      '@deepseek-ai/dsh-user-approval': 0.1.0-rc.7(4f74b455ce0d5cd4f00470385949c3a6)
+      '@deepseek-ai/dsh-user-questions': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-agent@0.1.0-rc.7(2159b1e0165b1d0e28bdde123a84571a))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-llm@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))))
+      '@deepseek-ai/dsh-workspace': 0.1.0-rc.7(83c9762da9362c533c2afdb51b721952)
       '@deepseek-ai/schemastery': 3.18.1
       fflate: 0.8.3
       zod: 4.4.3
@@ -1609,18 +2054,74 @@ snapshots:
       - '@deepseek-ai/dsh-typert-protocol'
       - '@deepseek-ai/dsh-typert-registry'
 
+  '@deepseek-ai/dsh-host-apiproxy@0.1.1-rc.2(f74314e544c4485f20172402a2d85310)':
+    dependencies:
+      '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
+      '@deepseek-ai/dsh-agent': 0.1.1-rc.2(68de7455d024c703f96e98dc56c95398)
+      '@deepseek-ai/dsh-agent-default-model': 0.1.1-rc.2(78cd69dc3ebaef70bf1a6f181a22dfa8)
+      '@deepseek-ai/dsh-agent-presets': 0.1.0-rc.7(32310cb66b87c92a592dba1b12447dde)
+      '@deepseek-ai/dsh-api-remotes': 0.1.1-rc.2(647f8017564617187c7f3ed788dcebf3)
+      '@deepseek-ai/dsh-attachment': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-brand': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-commands': 0.1.1-rc.2(d2a4c008be2ab9b8e1fa6dba07a7d731)
+      '@deepseek-ai/dsh-cordis-host-runner': 0.1.0-rc.7(fe90f3c870d2b099319f6fc56b9fddd9)
+      '@deepseek-ai/dsh-credentials': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-goal': 0.1.1-rc.2(17bb93726c32b5b8eae34dec63a39bd0)
+      '@deepseek-ai/dsh-host-directory-picker': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-invariants': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)
+      '@deepseek-ai/dsh-jobs': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-agent@0.1.1-rc.2(68de7455d024c703f96e98dc56c95398))(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-session@0.1.1-rc.2(efbed06cee3aff66518ec36b0d2553ef))
+      '@deepseek-ai/dsh-llm': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
+      '@deepseek-ai/dsh-native-command': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-session': 0.1.1-rc.2(efbed06cee3aff66518ec36b0d2553ef)
+      '@deepseek-ai/dsh-session-persistence': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-session@0.1.1-rc.2(efbed06cee3aff66518ec36b0d2553ef))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
+      '@deepseek-ai/dsh-session-projection': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-session@0.1.1-rc.2(efbed06cee3aff66518ec36b0d2553ef))
+      '@deepseek-ai/dsh-session-projection-cache': 0.1.1-rc.2(d8bd96f0562e27bd76bb943660462fdb)
+      '@deepseek-ai/dsh-session-query': 0.1.1-rc.2(af135a1b8b1cce4999d692812af3da4b)
+      '@deepseek-ai/dsh-session-title': 0.1.1-rc.2(b217108c833e01369c00d7d3f6659abb)
+      '@deepseek-ai/dsh-settings': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/schemastery@3.18.1)
+      '@deepseek-ai/dsh-skill': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-llm@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))))(@deepseek-ai/dsh-scope@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
+      '@deepseek-ai/dsh-subagent': 0.1.1-rc.2(e96c00452477e59d3915ca179ffed550)
+      '@deepseek-ai/dsh-tools': 0.1.1-rc.2(4b7dc20617b63a7b3801d32ef21d735f)
+      '@deepseek-ai/dsh-user-approval': 0.1.1-rc.2(4dc5d270332ecfc5113b51af5b8e8fdd)
+      '@deepseek-ai/dsh-user-questions': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-agent@0.1.1-rc.2(68de7455d024c703f96e98dc56c95398))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-llm@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))))
+      '@deepseek-ai/dsh-workspace': 0.1.1-rc.2(67b88be77c2d50daa79edaf494f4d567)
+      '@deepseek-ai/schemastery': 3.18.1
+      fflate: 0.8.3
+      zod: 4.4.3
+    transitivePeerDependencies:
+      - '@deepseek-ai/dsh-api-gateway'
+      - '@deepseek-ai/dsh-code-runtime'
+      - '@deepseek-ai/dsh-file-reference'
+      - '@deepseek-ai/dsh-host-plugin-inventory'
+      - '@deepseek-ai/dsh-message-feedback'
+      - '@deepseek-ai/dsh-sandbox'
+      - '@deepseek-ai/dsh-sandbox-policy'
+      - '@deepseek-ai/dsh-scope'
+      - '@deepseek-ai/dsh-session-reference'
+      - '@deepseek-ai/dsh-storage'
+      - '@deepseek-ai/dsh-storage-domain'
+      - '@deepseek-ai/dsh-system-prompt'
+      - '@deepseek-ai/dsh-timeout'
+      - '@deepseek-ai/dsh-typert-protocol'
+      - '@deepseek-ai/dsh-typert-registry'
+
   '@deepseek-ai/dsh-host-directory-picker@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
       '@deepseek-ai/dsh-invariants': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)
 
-  '@deepseek-ai/dsh-host-plugin-inventory@0.1.0-rc.7(@deepseek-ai/cordis-plugin-loader@1.0.2)(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-typert-protocol@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))':
+  '@deepseek-ai/dsh-host-directory-picker@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))':
+    dependencies:
+      '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
+      '@deepseek-ai/dsh-invariants': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)
+
+  '@deepseek-ai/dsh-host-plugin-inventory@0.1.0-rc.7(@deepseek-ai/cordis-plugin-loader@1.0.2)(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-typert-protocol@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
       '@deepseek-ai/cordis-plugin-loader': 1.0.2(@deepseek-ai/cordis@4.0.1)
-      '@deepseek-ai/dsh-brand': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-brand': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
       '@deepseek-ai/dsh-invariants': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)
-      '@deepseek-ai/dsh-typert-protocol': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-typert-protocol': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
       zod: 4.4.3
 
   '@deepseek-ai/dsh-host-webserver@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))':
@@ -1634,13 +2135,21 @@ snapshots:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
       '@deepseek-ai/schemastery': 3.18.1
 
-  '@deepseek-ai/dsh-jobs@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-agent@0.1.0-rc.7(1e28fca6adb316c000fd361f8e5f3a08))(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-session@0.1.0-rc.7(1dcde9bfc9fa0140c66648fbcb67b346))':
+  '@deepseek-ai/dsh-jobs@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-agent@0.1.0-rc.7(2159b1e0165b1d0e28bdde123a84571a))(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-session@0.1.0-rc.7(c2cd14161e3936b56a33c89d5af7a3ce))':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
-      '@deepseek-ai/dsh-agent': 0.1.0-rc.7(1e28fca6adb316c000fd361f8e5f3a08)
+      '@deepseek-ai/dsh-agent': 0.1.0-rc.7(2159b1e0165b1d0e28bdde123a84571a)
       '@deepseek-ai/dsh-brand': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
       '@deepseek-ai/dsh-invariants': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)
-      '@deepseek-ai/dsh-session': 0.1.0-rc.7(1dcde9bfc9fa0140c66648fbcb67b346)
+      '@deepseek-ai/dsh-session': 0.1.0-rc.7(c2cd14161e3936b56a33c89d5af7a3ce)
+
+  '@deepseek-ai/dsh-jobs@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-agent@0.1.1-rc.2(68de7455d024c703f96e98dc56c95398))(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-session@0.1.1-rc.2(efbed06cee3aff66518ec36b0d2553ef))':
+    dependencies:
+      '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
+      '@deepseek-ai/dsh-agent': 0.1.1-rc.2(68de7455d024c703f96e98dc56c95398)
+      '@deepseek-ai/dsh-brand': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-invariants': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)
+      '@deepseek-ai/dsh-session': 0.1.1-rc.2(efbed06cee3aff66518ec36b0d2553ef)
 
   '@deepseek-ai/dsh-llm@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))':
     dependencies:
@@ -1651,20 +2160,48 @@ snapshots:
       '@deepseek-ai/dsh-timeout': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
       '@deepseek-ai/schemastery': 3.18.1
 
-  '@deepseek-ai/dsh-message-feedback@0.1.0-rc.7(1fcfefbbf5e365eda1a59fadd94056b9)':
+  '@deepseek-ai/dsh-llm@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
-      '@deepseek-ai/dsh-brand': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-attachment': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-brand': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
       '@deepseek-ai/dsh-invariants': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)
-      '@deepseek-ai/dsh-llm': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
-      '@deepseek-ai/dsh-session': 0.1.0-rc.7(1dcde9bfc9fa0140c66648fbcb67b346)
-      '@deepseek-ai/dsh-session-persistence': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-session@0.1.0-rc.7(1dcde9bfc9fa0140c66648fbcb67b346))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
+      '@deepseek-ai/dsh-timeout': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/schemastery': 3.18.1
+
+  '@deepseek-ai/dsh-llm@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))':
+    dependencies:
+      '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
+      '@deepseek-ai/dsh-attachment': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-brand': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-invariants': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)
+      '@deepseek-ai/dsh-timeout': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/schemastery': 3.18.1
+
+  '@deepseek-ai/dsh-message-feedback@0.1.0-rc.7(64222bbea17d671ab0fcac175cde7f84)':
+    dependencies:
+      '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
+      '@deepseek-ai/dsh-brand': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-invariants': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)
+      '@deepseek-ai/dsh-llm': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
+      '@deepseek-ai/dsh-session': 0.1.1-rc.2(efbed06cee3aff66518ec36b0d2553ef)
+      '@deepseek-ai/dsh-session-persistence': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-session@0.1.1-rc.2(efbed06cee3aff66518ec36b0d2553ef))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
       '@deepseek-ai/dsh-storage-domain': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-storage@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
-      '@deepseek-ai/dsh-typert-protocol': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-typert-protocol': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
       '@deepseek-ai/schemastery': 3.18.1
       zod: 4.4.3
 
   '@deepseek-ai/dsh-native-command@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))':
+    dependencies:
+      '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
+      '@deepseek-ai/dsh-invariants': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)
+
+  '@deepseek-ai/dsh-native-command@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))':
+    dependencies:
+      '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
+      '@deepseek-ai/dsh-invariants': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)
+
+  '@deepseek-ai/dsh-output-retention@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
       '@deepseek-ai/dsh-invariants': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)
@@ -1674,62 +2211,142 @@ snapshots:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
       '@deepseek-ai/dsh-invariants': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)
 
-  '@deepseek-ai/dsh-session-persistence@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-session@0.1.0-rc.7(1dcde9bfc9fa0140c66648fbcb67b346))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))':
+  '@deepseek-ai/dsh-session-persistence@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-session@0.1.0-rc.7(c2cd14161e3936b56a33c89d5af7a3ce))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
       '@deepseek-ai/dsh-brand': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
       '@deepseek-ai/dsh-invariants': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)
-      '@deepseek-ai/dsh-session': 0.1.0-rc.7(1dcde9bfc9fa0140c66648fbcb67b346)
+      '@deepseek-ai/dsh-session': 0.1.0-rc.7(c2cd14161e3936b56a33c89d5af7a3ce)
       '@deepseek-ai/dsh-timeout': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
 
-  '@deepseek-ai/dsh-session-projection-cache@0.1.0-rc.7(5ae699d01eec9f3ccaa1e8c13f88dd36)':
+  '@deepseek-ai/dsh-session-persistence@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-session@0.1.1-rc.2(efbed06cee3aff66518ec36b0d2553ef))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))':
+    dependencies:
+      '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
+      '@deepseek-ai/dsh-brand': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-invariants': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)
+      '@deepseek-ai/dsh-session': 0.1.1-rc.2(efbed06cee3aff66518ec36b0d2553ef)
+      '@deepseek-ai/dsh-timeout': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
+
+  '@deepseek-ai/dsh-session-projection-cache@0.1.0-rc.7(08c67600371b563d613c5228712dbade)':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
       '@deepseek-ai/dsh-invariants': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)
-      '@deepseek-ai/dsh-session': 0.1.0-rc.7(1dcde9bfc9fa0140c66648fbcb67b346)
-      '@deepseek-ai/dsh-session-persistence': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-session@0.1.0-rc.7(1dcde9bfc9fa0140c66648fbcb67b346))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
-      '@deepseek-ai/dsh-session-projection': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-session@0.1.0-rc.7(1dcde9bfc9fa0140c66648fbcb67b346))
+      '@deepseek-ai/dsh-session': 0.1.0-rc.7(c2cd14161e3936b56a33c89d5af7a3ce)
+      '@deepseek-ai/dsh-session-persistence': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-session@0.1.0-rc.7(c2cd14161e3936b56a33c89d5af7a3ce))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
+      '@deepseek-ai/dsh-session-projection': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-session@0.1.0-rc.7(c2cd14161e3936b56a33c89d5af7a3ce))
       '@deepseek-ai/dsh-storage-domain': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-storage@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
       '@deepseek-ai/schemastery': 3.18.1
       zod: 4.4.3
 
-  '@deepseek-ai/dsh-session-projection@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-session@0.1.0-rc.7(1dcde9bfc9fa0140c66648fbcb67b346))':
+  '@deepseek-ai/dsh-session-projection-cache@0.1.1-rc.2(d8bd96f0562e27bd76bb943660462fdb)':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
       '@deepseek-ai/dsh-invariants': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)
-      '@deepseek-ai/dsh-session': 0.1.0-rc.7(1dcde9bfc9fa0140c66648fbcb67b346)
-      zod: 4.4.3
-
-  '@deepseek-ai/dsh-session-query@0.1.0-rc.7(fa24861d08a9d735fc78888af6ddf326)':
-    dependencies:
-      '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
-      '@deepseek-ai/dsh-brand': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
-      '@deepseek-ai/dsh-invariants': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)
-      '@deepseek-ai/dsh-llm': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
-      '@deepseek-ai/dsh-session': 0.1.0-rc.7(1dcde9bfc9fa0140c66648fbcb67b346)
-      '@deepseek-ai/dsh-session-title': 0.1.0-rc.7(54a387d0d580a07b8dbef208df0b04c2)
-    optionalDependencies:
-      '@deepseek-ai/dsh-session-persistence': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-session@0.1.0-rc.7(1dcde9bfc9fa0140c66648fbcb67b346))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
-
-  '@deepseek-ai/dsh-session-title@0.1.0-rc.7(54a387d0d580a07b8dbef208df0b04c2)':
-    dependencies:
-      '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
-      '@deepseek-ai/dsh-brand': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
-      '@deepseek-ai/dsh-invariants': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)
-      '@deepseek-ai/dsh-llm': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
-      '@deepseek-ai/dsh-session': 0.1.0-rc.7(1dcde9bfc9fa0140c66648fbcb67b346)
-      '@deepseek-ai/dsh-session-projection': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-session@0.1.0-rc.7(1dcde9bfc9fa0140c66648fbcb67b346))
+      '@deepseek-ai/dsh-session': 0.1.1-rc.2(efbed06cee3aff66518ec36b0d2553ef)
+      '@deepseek-ai/dsh-session-persistence': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-session@0.1.1-rc.2(efbed06cee3aff66518ec36b0d2553ef))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
+      '@deepseek-ai/dsh-session-projection': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-session@0.1.1-rc.2(efbed06cee3aff66518ec36b0d2553ef))
+      '@deepseek-ai/dsh-storage-domain': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-storage@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
       '@deepseek-ai/schemastery': 3.18.1
       zod: 4.4.3
 
-  '@deepseek-ai/dsh-session@0.1.0-rc.7(1dcde9bfc9fa0140c66648fbcb67b346)':
+  '@deepseek-ai/dsh-session-projection@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-session@0.1.0-rc.7(c2cd14161e3936b56a33c89d5af7a3ce))':
+    dependencies:
+      '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
+      '@deepseek-ai/dsh-invariants': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)
+      '@deepseek-ai/dsh-session': 0.1.0-rc.7(c2cd14161e3936b56a33c89d5af7a3ce)
+      zod: 4.4.3
+
+  '@deepseek-ai/dsh-session-projection@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-session@0.1.1-rc.2(efbed06cee3aff66518ec36b0d2553ef))':
+    dependencies:
+      '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
+      '@deepseek-ai/dsh-invariants': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)
+      '@deepseek-ai/dsh-session': 0.1.1-rc.2(efbed06cee3aff66518ec36b0d2553ef)
+      zod: 4.4.3
+
+  '@deepseek-ai/dsh-session-query@0.1.0-rc.7(ad752b266826abffe29dd228c04467c8)':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
       '@deepseek-ai/dsh-brand': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
       '@deepseek-ai/dsh-invariants': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)
-      '@deepseek-ai/dsh-llm': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
+      '@deepseek-ai/dsh-llm': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
+      '@deepseek-ai/dsh-session': 0.1.0-rc.7(c2cd14161e3936b56a33c89d5af7a3ce)
+      '@deepseek-ai/dsh-session-title': 0.1.0-rc.7(db4b6201d6640c5f871d1399c9e5eb2d)
+    optionalDependencies:
+      '@deepseek-ai/dsh-session-persistence': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-session@0.1.0-rc.7(c2cd14161e3936b56a33c89d5af7a3ce))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
+
+  '@deepseek-ai/dsh-session-query@0.1.1-rc.2(af135a1b8b1cce4999d692812af3da4b)':
+    dependencies:
+      '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
+      '@deepseek-ai/dsh-brand': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-invariants': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)
+      '@deepseek-ai/dsh-llm': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
+      '@deepseek-ai/dsh-session': 0.1.1-rc.2(efbed06cee3aff66518ec36b0d2553ef)
+      '@deepseek-ai/dsh-session-title': 0.1.1-rc.2(b217108c833e01369c00d7d3f6659abb)
+    optionalDependencies:
+      '@deepseek-ai/dsh-session-persistence': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-session@0.1.1-rc.2(efbed06cee3aff66518ec36b0d2553ef))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
+
+  '@deepseek-ai/dsh-session-reference@0.1.1-rc.2(6f879a430ccfed450153cf332c19be17)':
+    dependencies:
+      '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
+      '@deepseek-ai/dsh-agent': 0.1.1-rc.2(68de7455d024c703f96e98dc56c95398)
+      '@deepseek-ai/dsh-compaction': 0.1.1-rc.2(0982d650db43160f1b02a3cc38c0484e)
+      '@deepseek-ai/dsh-invariants': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)
+      '@deepseek-ai/dsh-llm': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
+      '@deepseek-ai/dsh-output-retention': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-session': 0.1.1-rc.2(efbed06cee3aff66518ec36b0d2553ef)
+      '@deepseek-ai/dsh-session-query': 0.1.1-rc.2(af135a1b8b1cce4999d692812af3da4b)
+      '@deepseek-ai/dsh-typert-protocol': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/schemastery': 3.18.1
+      zod: 4.4.3
+
+  '@deepseek-ai/dsh-session-title@0.1.0-rc.7(db4b6201d6640c5f871d1399c9e5eb2d)':
+    dependencies:
+      '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
+      '@deepseek-ai/dsh-brand': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-invariants': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)
+      '@deepseek-ai/dsh-llm': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
+      '@deepseek-ai/dsh-session': 0.1.0-rc.7(c2cd14161e3936b56a33c89d5af7a3ce)
+      '@deepseek-ai/dsh-session-projection': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-session@0.1.0-rc.7(c2cd14161e3936b56a33c89d5af7a3ce))
+      '@deepseek-ai/schemastery': 3.18.1
+      zod: 4.4.3
+
+  '@deepseek-ai/dsh-session-title@0.1.1-rc.2(b217108c833e01369c00d7d3f6659abb)':
+    dependencies:
+      '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
+      '@deepseek-ai/dsh-brand': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-invariants': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)
+      '@deepseek-ai/dsh-llm': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
+      '@deepseek-ai/dsh-session': 0.1.1-rc.2(efbed06cee3aff66518ec36b0d2553ef)
+      '@deepseek-ai/dsh-session-projection': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-session@0.1.1-rc.2(efbed06cee3aff66518ec36b0d2553ef))
+      '@deepseek-ai/schemastery': 3.18.1
+      zod: 4.4.3
+
+  '@deepseek-ai/dsh-session@0.1.0-rc.7(c2cd14161e3936b56a33c89d5af7a3ce)':
+    dependencies:
+      '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
+      '@deepseek-ai/dsh-brand': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-invariants': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)
+      '@deepseek-ai/dsh-llm': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
       '@deepseek-ai/dsh-scope': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
-      '@deepseek-ai/dsh-typert-protocol': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-typert-protocol': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
+
+  '@deepseek-ai/dsh-session@0.1.0-rc.7(e92f174b7620c8045f6a89dca6f7f0be)':
+    dependencies:
+      '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
+      '@deepseek-ai/dsh-brand': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-invariants': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)
+      '@deepseek-ai/dsh-llm': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
+      '@deepseek-ai/dsh-scope': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-typert-protocol': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
+
+  '@deepseek-ai/dsh-session@0.1.1-rc.2(efbed06cee3aff66518ec36b0d2553ef)':
+    dependencies:
+      '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
+      '@deepseek-ai/dsh-brand': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-invariants': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)
+      '@deepseek-ai/dsh-llm': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
+      '@deepseek-ai/dsh-scope': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-typert-protocol': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
 
   '@deepseek-ai/dsh-settings@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/schemastery@3.18.1)':
     dependencies:
@@ -1738,11 +2355,26 @@ snapshots:
       '@deepseek-ai/dsh-invariants': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)
       '@deepseek-ai/schemastery': 3.18.1
 
-  '@deepseek-ai/dsh-skill@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-llm@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))))(@deepseek-ai/dsh-scope@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))':
+  '@deepseek-ai/dsh-settings@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/schemastery@3.18.1)':
+    dependencies:
+      '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
+      '@deepseek-ai/dsh-brand': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-invariants': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)
+      '@deepseek-ai/schemastery': 3.18.1
+
+  '@deepseek-ai/dsh-skill@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-llm@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))))(@deepseek-ai/dsh-scope@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
       '@deepseek-ai/dsh-invariants': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)
-      '@deepseek-ai/dsh-llm': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
+      '@deepseek-ai/dsh-llm': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
+      '@deepseek-ai/dsh-scope': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/schemastery': 3.18.1
+
+  '@deepseek-ai/dsh-skill@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-llm@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))))(@deepseek-ai/dsh-scope@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))':
+    dependencies:
+      '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
+      '@deepseek-ai/dsh-invariants': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)
+      '@deepseek-ai/dsh-llm': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
       '@deepseek-ai/dsh-scope': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
       '@deepseek-ai/schemastery': 3.18.1
 
@@ -1759,30 +2391,49 @@ snapshots:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
       '@deepseek-ai/dsh-invariants': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)
 
-  '@deepseek-ai/dsh-subagent@0.1.0-rc.7(17b22c2aa5d99096c13835bb226cad51)':
+  '@deepseek-ai/dsh-subagent@0.1.0-rc.7(a58d973e9923845a70f07f75ac468a45)':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
-      '@deepseek-ai/dsh-agent': 0.1.0-rc.7(1e28fca6adb316c000fd361f8e5f3a08)
+      '@deepseek-ai/dsh-agent': 0.1.0-rc.7(2159b1e0165b1d0e28bdde123a84571a)
       '@deepseek-ai/dsh-brand': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
       '@deepseek-ai/dsh-invariants': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)
-      '@deepseek-ai/dsh-llm': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
+      '@deepseek-ai/dsh-llm': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
       '@deepseek-ai/dsh-scope': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
-      '@deepseek-ai/dsh-session': 0.1.0-rc.7(1dcde9bfc9fa0140c66648fbcb67b346)
-      '@deepseek-ai/dsh-tools': 0.1.0-rc.7(38c91eb2d47c5b4ba2c8ead86dfcb4aa)
+      '@deepseek-ai/dsh-session': 0.1.0-rc.7(c2cd14161e3936b56a33c89d5af7a3ce)
+      '@deepseek-ai/dsh-tools': 0.1.0-rc.7(a7c592dee571edf4a7345045fd39556b)
       zod: 4.4.3
     optionalDependencies:
-      '@deepseek-ai/dsh-agent-presets': 0.1.0-rc.7(c0f9f44edab94cddae92cd4b4f319bab)
-      '@deepseek-ai/dsh-jobs': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-agent@0.1.0-rc.7(1e28fca6adb316c000fd361f8e5f3a08))(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-session@0.1.0-rc.7(1dcde9bfc9fa0140c66648fbcb67b346))
-      '@deepseek-ai/dsh-session-persistence': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-session@0.1.0-rc.7(1dcde9bfc9fa0140c66648fbcb67b346))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
-      '@deepseek-ai/dsh-session-projection': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-session@0.1.0-rc.7(1dcde9bfc9fa0140c66648fbcb67b346))
-      '@deepseek-ai/dsh-session-projection-cache': 0.1.0-rc.7(5ae699d01eec9f3ccaa1e8c13f88dd36)
-      '@deepseek-ai/dsh-user-approval': 0.1.0-rc.7(6b8cefd624fd84694a941b103cc9b3fb)
+      '@deepseek-ai/dsh-agent-presets': 0.1.0-rc.7(32310cb66b87c92a592dba1b12447dde)
+      '@deepseek-ai/dsh-jobs': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-agent@0.1.0-rc.7(2159b1e0165b1d0e28bdde123a84571a))(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-session@0.1.0-rc.7(c2cd14161e3936b56a33c89d5af7a3ce))
+      '@deepseek-ai/dsh-session-persistence': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-session@0.1.0-rc.7(c2cd14161e3936b56a33c89d5af7a3ce))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
+      '@deepseek-ai/dsh-session-projection': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-session@0.1.0-rc.7(c2cd14161e3936b56a33c89d5af7a3ce))
+      '@deepseek-ai/dsh-session-projection-cache': 0.1.0-rc.7(08c67600371b563d613c5228712dbade)
+      '@deepseek-ai/dsh-user-approval': 0.1.0-rc.7(4f74b455ce0d5cd4f00470385949c3a6)
 
-  '@deepseek-ai/dsh-system-prompt@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-llm@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))))(@deepseek-ai/dsh-scope@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))':
+  '@deepseek-ai/dsh-subagent@0.1.1-rc.2(e96c00452477e59d3915ca179ffed550)':
+    dependencies:
+      '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
+      '@deepseek-ai/dsh-agent': 0.1.1-rc.2(68de7455d024c703f96e98dc56c95398)
+      '@deepseek-ai/dsh-brand': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-invariants': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)
+      '@deepseek-ai/dsh-llm': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
+      '@deepseek-ai/dsh-scope': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-session': 0.1.1-rc.2(efbed06cee3aff66518ec36b0d2553ef)
+      '@deepseek-ai/dsh-tools': 0.1.1-rc.2(4b7dc20617b63a7b3801d32ef21d735f)
+      zod: 4.4.3
+    optionalDependencies:
+      '@deepseek-ai/dsh-agent-presets': 0.1.0-rc.7(32310cb66b87c92a592dba1b12447dde)
+      '@deepseek-ai/dsh-jobs': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-agent@0.1.1-rc.2(68de7455d024c703f96e98dc56c95398))(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-session@0.1.1-rc.2(efbed06cee3aff66518ec36b0d2553ef))
+      '@deepseek-ai/dsh-session-persistence': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-session@0.1.1-rc.2(efbed06cee3aff66518ec36b0d2553ef))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
+      '@deepseek-ai/dsh-session-projection': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-session@0.1.1-rc.2(efbed06cee3aff66518ec36b0d2553ef))
+      '@deepseek-ai/dsh-session-projection-cache': 0.1.1-rc.2(d8bd96f0562e27bd76bb943660462fdb)
+      '@deepseek-ai/dsh-user-approval': 0.1.1-rc.2(4dc5d270332ecfc5113b51af5b8e8fdd)
+
+  '@deepseek-ai/dsh-system-prompt@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-llm@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))))(@deepseek-ai/dsh-scope@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
       '@deepseek-ai/dsh-invariants': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)
-      '@deepseek-ai/dsh-llm': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
+      '@deepseek-ai/dsh-llm': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
       '@deepseek-ai/dsh-scope': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
       '@deepseek-ai/schemastery': 3.18.1
 
@@ -1791,20 +2442,51 @@ snapshots:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
       '@deepseek-ai/dsh-invariants': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)
 
-  '@deepseek-ai/dsh-tools@0.1.0-rc.7(38c91eb2d47c5b4ba2c8ead86dfcb4aa)':
+  '@deepseek-ai/dsh-tools@0.1.0-rc.7(7c26b4eb663e9057e43fcdf56580e7ae)':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
-      '@deepseek-ai/dsh-agent': 0.1.0-rc.7(1e28fca6adb316c000fd361f8e5f3a08)
+      '@deepseek-ai/dsh-agent': 0.1.1-rc.2(68de7455d024c703f96e98dc56c95398)
       '@deepseek-ai/dsh-code-runtime': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
       '@deepseek-ai/dsh-invariants': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)
-      '@deepseek-ai/dsh-llm': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
+      '@deepseek-ai/dsh-llm': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
       '@deepseek-ai/dsh-scope': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
-      '@deepseek-ai/dsh-session': 0.1.0-rc.7(1dcde9bfc9fa0140c66648fbcb67b346)
-      '@deepseek-ai/dsh-system-prompt': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-llm@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))))(@deepseek-ai/dsh-scope@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
-      '@deepseek-ai/dsh-user-approval': 0.1.0-rc.7(6b8cefd624fd84694a941b103cc9b3fb)
+      '@deepseek-ai/dsh-session': 0.1.0-rc.7(e92f174b7620c8045f6a89dca6f7f0be)
+      '@deepseek-ai/dsh-system-prompt': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-llm@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))))(@deepseek-ai/dsh-scope@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
+      '@deepseek-ai/dsh-user-approval': 0.1.1-rc.2(4dc5d270332ecfc5113b51af5b8e8fdd)
+      '@deepseek-ai/schemastery': 3.18.1
+
+  '@deepseek-ai/dsh-tools@0.1.0-rc.7(a7c592dee571edf4a7345045fd39556b)':
+    dependencies:
+      '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
+      '@deepseek-ai/dsh-agent': 0.1.0-rc.7(2159b1e0165b1d0e28bdde123a84571a)
+      '@deepseek-ai/dsh-code-runtime': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-invariants': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)
+      '@deepseek-ai/dsh-llm': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
+      '@deepseek-ai/dsh-scope': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-session': 0.1.0-rc.7(c2cd14161e3936b56a33c89d5af7a3ce)
+      '@deepseek-ai/dsh-system-prompt': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-llm@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))))(@deepseek-ai/dsh-scope@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
+      '@deepseek-ai/dsh-user-approval': 0.1.0-rc.7(4f74b455ce0d5cd4f00470385949c3a6)
+      '@deepseek-ai/schemastery': 3.18.1
+
+  '@deepseek-ai/dsh-tools@0.1.1-rc.2(4b7dc20617b63a7b3801d32ef21d735f)':
+    dependencies:
+      '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
+      '@deepseek-ai/dsh-agent': 0.1.1-rc.2(68de7455d024c703f96e98dc56c95398)
+      '@deepseek-ai/dsh-code-runtime': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-invariants': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)
+      '@deepseek-ai/dsh-llm': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
+      '@deepseek-ai/dsh-scope': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-session': 0.1.1-rc.2(efbed06cee3aff66518ec36b0d2553ef)
+      '@deepseek-ai/dsh-system-prompt': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-llm@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))))(@deepseek-ai/dsh-scope@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
+      '@deepseek-ai/dsh-user-approval': 0.1.1-rc.2(4dc5d270332ecfc5113b51af5b8e8fdd)
       '@deepseek-ai/schemastery': 3.18.1
 
   '@deepseek-ai/dsh-typert-protocol@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))':
+    dependencies:
+      '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
+      '@deepseek-ai/dsh-invariants': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)
+
+  '@deepseek-ai/dsh-typert-protocol@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
       '@deepseek-ai/dsh-invariants': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)
@@ -1816,32 +2498,62 @@ snapshots:
       '@deepseek-ai/dsh-typert-protocol': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
       zod: 4.4.3
 
-  '@deepseek-ai/dsh-user-approval@0.1.0-rc.7(6b8cefd624fd84694a941b103cc9b3fb)':
+  '@deepseek-ai/dsh-user-approval@0.1.0-rc.7(4f74b455ce0d5cd4f00470385949c3a6)':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
-      '@deepseek-ai/dsh-agent': 0.1.0-rc.7(1e28fca6adb316c000fd361f8e5f3a08)
+      '@deepseek-ai/dsh-agent': 0.1.0-rc.7(2159b1e0165b1d0e28bdde123a84571a)
       '@deepseek-ai/dsh-brand': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
       '@deepseek-ai/dsh-invariants': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)
-      '@deepseek-ai/dsh-llm': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
+      '@deepseek-ai/dsh-llm': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
       '@deepseek-ai/dsh-scope': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
-      '@deepseek-ai/dsh-session': 0.1.0-rc.7(1dcde9bfc9fa0140c66648fbcb67b346)
-      '@deepseek-ai/dsh-system-prompt': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-llm@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))))(@deepseek-ai/dsh-scope@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
+      '@deepseek-ai/dsh-session': 0.1.0-rc.7(c2cd14161e3936b56a33c89d5af7a3ce)
+      '@deepseek-ai/dsh-system-prompt': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-llm@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))))(@deepseek-ai/dsh-scope@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
       '@deepseek-ai/schemastery': 3.18.1
 
-  '@deepseek-ai/dsh-user-questions@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-agent@0.1.0-rc.7(1e28fca6adb316c000fd361f8e5f3a08))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-llm@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))))':
+  '@deepseek-ai/dsh-user-approval@0.1.1-rc.2(4dc5d270332ecfc5113b51af5b8e8fdd)':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
-      '@deepseek-ai/dsh-agent': 0.1.0-rc.7(1e28fca6adb316c000fd361f8e5f3a08)
+      '@deepseek-ai/dsh-agent': 0.1.1-rc.2(68de7455d024c703f96e98dc56c95398)
+      '@deepseek-ai/dsh-brand': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
       '@deepseek-ai/dsh-invariants': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)
-      '@deepseek-ai/dsh-llm': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
+      '@deepseek-ai/dsh-llm': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
+      '@deepseek-ai/dsh-scope': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-session': 0.1.1-rc.2(efbed06cee3aff66518ec36b0d2553ef)
+      '@deepseek-ai/dsh-system-prompt': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-llm@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))))(@deepseek-ai/dsh-scope@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
+      '@deepseek-ai/schemastery': 3.18.1
 
-  '@deepseek-ai/dsh-workspace@0.1.0-rc.7(52d55750df813bb508c3c8815dfcc2bd)':
+  '@deepseek-ai/dsh-user-questions@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-agent@0.1.0-rc.7(2159b1e0165b1d0e28bdde123a84571a))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-llm@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))))':
+    dependencies:
+      '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
+      '@deepseek-ai/dsh-agent': 0.1.0-rc.7(2159b1e0165b1d0e28bdde123a84571a)
+      '@deepseek-ai/dsh-invariants': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)
+      '@deepseek-ai/dsh-llm': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
+
+  '@deepseek-ai/dsh-user-questions@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-agent@0.1.1-rc.2(68de7455d024c703f96e98dc56c95398))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-llm@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))))':
+    dependencies:
+      '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
+      '@deepseek-ai/dsh-agent': 0.1.1-rc.2(68de7455d024c703f96e98dc56c95398)
+      '@deepseek-ai/dsh-invariants': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)
+      '@deepseek-ai/dsh-llm': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
+
+  '@deepseek-ai/dsh-workspace@0.1.0-rc.7(83c9762da9362c533c2afdb51b721952)':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
       '@deepseek-ai/dsh-brand': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
       '@deepseek-ai/dsh-invariants': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)
-      '@deepseek-ai/dsh-session': 0.1.0-rc.7(1dcde9bfc9fa0140c66648fbcb67b346)
-      '@deepseek-ai/dsh-session-persistence': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-session@0.1.0-rc.7(1dcde9bfc9fa0140c66648fbcb67b346))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
+      '@deepseek-ai/dsh-session': 0.1.0-rc.7(c2cd14161e3936b56a33c89d5af7a3ce)
+      '@deepseek-ai/dsh-session-persistence': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-session@0.1.0-rc.7(c2cd14161e3936b56a33c89d5af7a3ce))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
+      '@deepseek-ai/dsh-storage': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-storage-domain': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-storage@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
+      zod: 4.4.3
+
+  '@deepseek-ai/dsh-workspace@0.1.1-rc.2(67b88be77c2d50daa79edaf494f4d567)':
+    dependencies:
+      '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
+      '@deepseek-ai/dsh-brand': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-invariants': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)
+      '@deepseek-ai/dsh-session': 0.1.1-rc.2(efbed06cee3aff66518ec36b0d2553ef)
+      '@deepseek-ai/dsh-session-persistence': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-session@0.1.1-rc.2(efbed06cee3aff66518ec36b0d2553ef))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
       '@deepseek-ai/dsh-storage': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))
       '@deepseek-ai/dsh-storage-domain': 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-storage@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))
       zod: 4.4.3

--- a/scripts/admission-decorator-probe.mjs
+++ b/scripts/admission-decorator-probe.mjs
@@ -1,37 +1,25 @@
 #!/usr/bin/env node
 /**
- * Admission-decorator runtime proof: confirm that a plugin can wrap
- * `ctx.agents` (the real AgentRegistry) so that a tenant-admission callback runs
- * inside the Agent `setup` hook — BEFORE `sessions.enter` — for all four genesis
- * paths, against the current pinned DSH prerelease.
+ * Admission-decorator runtime proof against the repository's exact DSH baseline.
  *
- *   P1  create    — admission sees `options.sessionId`; store not yet entered.
- *   P2  fork      — admission sees `options.meta.parentSession`; store not yet entered.
- *   P3  subagent  — admission sees `options.meta.origin === 'subagent'` + `parentSession`.
- *   P4  resume    — admission sees `options.resumeSessionId`; store not yet entered.
- *
- * The `llm` / `tools` / `systemPrompt` services are structurally injected by the
- * AgentLoop but are NOT exercised by the create → setup → enter path, so they are
- * provided as no-op stubs; `sessionPersistence` is a minimal stub that yields a
- * fresh prepared session for the resume path.
- *
- * Run from the repo root: `node scripts/admission-decorator-probe.mjs`.
- * Installs the current target into a throwaway temp dir (not the workspace).
+ * A decorator around `ctx.agents` must be able to run tenant admission in the
+ * Agent `setup` hook before `sessions.enter` for create, fork, subagent and
+ * resume genesis paths.
  */
 import { execFileSync } from 'node:child_process'
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { DSH_TARGET_VERSION } from './dsh-target.mjs'
+import { DSH_TARGET } from './dsh-target.mjs'
 
 const tmp = mkdtempSync(join(tmpdir(), 'dsh-mt-admission-'))
 try {
   writeFileSync(join(tmp, 'package.json'), JSON.stringify({ name: 'admission-probe', private: true, type: 'module' }))
   execFileSync('pnpm', [
     'add',
-    `@deepseek-ai/dsh-agent-loop@${DSH_TARGET_VERSION}`,
-    `@deepseek-ai/dsh-agent@${DSH_TARGET_VERSION}`,
-    `@deepseek-ai/dsh-session@${DSH_TARGET_VERSION}`,
+    `@deepseek-ai/dsh-agent-loop@${DSH_TARGET.version}`,
+    `@deepseek-ai/dsh-agent@${DSH_TARGET.version}`,
+    `@deepseek-ai/dsh-session@${DSH_TARGET.version}`,
     '@deepseek-ai/cordis@4.0.1',
   ], { cwd: tmp, stdio: 'ignore' })
 
@@ -105,7 +93,7 @@ try {
   const out = execFileSync('node', ['probe.mjs'], { cwd: tmp, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] })
   const result = JSON.parse(out.trim())
   const rows = result.seen.map((s) => `${s.via.padEnd(6)} ${s.sessionId ?? s.resumeSessionId}  inStore@setup=${s.inStore}`).join('\n')
-  console.log(`Admission decorator proof passed on DSH ${DSH_TARGET_VERSION}:\n${rows}`)
+  console.log(`Admission decorator proof passed on DSH ${DSH_TARGET.version}:\n${rows}`)
 } finally {
   rmSync(tmp, { recursive: true, force: true })
 }

--- a/scripts/agent-owner-context-probe.mjs
+++ b/scripts/agent-owner-context-probe.mjs
@@ -1,0 +1,142 @@
+#!/usr/bin/env node
+/**
+ * DSH Agent owner-context proof.
+ *
+ * A canonical Principal Context is a capability/composition root, not a bypass
+ * around Cordis injection. Agent creation therefore runs in an ephemeral plugin
+ * fiber derived from the Principal Context and explicitly injecting `agents`.
+ * DSH must carry that caller-bound derived context into the Agent factory as
+ * ownerCtx, preserving Principal identity and tenant capability resolution.
+ */
+import { copyFileSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { basename, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { execFileSync } from 'node:child_process'
+import { DSH_TARGET } from './dsh-target.mjs'
+
+const root = fileURLToPath(new URL('..', import.meta.url))
+const tmp = mkdtempSync(join(tmpdir(), 'dsh-mt-agent-owner-'))
+const src = join(tmp, 'src')
+
+try {
+  mkdirSync(src)
+  for (const name of ['runtime.ts', 'service.ts', 'store.ts', 'types.ts', 'errors.ts', 'validation.ts']) {
+    copyFileSync(join(root, 'packages', 'multi-tenant', 'src', name), join(src, basename(name)))
+  }
+
+  writeFileSync(join(tmp, 'package.json'), JSON.stringify({ name: 'agent-owner-probe', private: true, type: 'module' }))
+  writeFileSync(join(tmp, 'pnpm-workspace.yaml'), 'allowBuilds:\n  esbuild: false\n')
+
+  try {
+    execFileSync('pnpm', [
+      'add',
+      '@deepseek-ai/cordis@4.0.1',
+      'tsx@4',
+      `@deepseek-ai/dsh-agent@${DSH_TARGET.version}`,
+    ], {
+      cwd: tmp,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+  } catch (error) {
+    throw new Error(
+      `failed to install public DSH Agent contract at ${DSH_TARGET.version}\n${String(error.stdout ?? '').trim()}\n${String(error.stderr ?? '').trim()}`,
+      { cause: error },
+    )
+  }
+
+  writeFileSync(join(tmp, 'probe.ts'), `
+import { Context } from '@deepseek-ai/cordis'
+import AgentRegistry from '@deepseek-ai/dsh-agent'
+import { InMemoryTenantSessionStore } from './src/store.ts'
+import { MultiTenantService } from './src/service.ts'
+import { TenantRuntimeService, principalOf, tenantIdOf } from './src/runtime.ts'
+
+const root = new Context()
+await root.plugin(InMemoryTenantSessionStore)
+await root.plugin(MultiTenantService)
+await root.plugin(TenantRuntimeService)
+await root.plugin(AgentRegistry)
+
+const observed = []
+root.agents.setFactory({
+  async createAgent(ownerCtx, options) {
+    observed.push({
+      sessionId: options.sessionId,
+      tenantId: tenantIdOf(ownerCtx),
+      principal: principalOf(ownerCtx),
+      capability: ownerCtx.get('tenantCapability'),
+      ownerFiberName: ownerCtx.fiber.name,
+    })
+
+    const agentCtx = root.extend({})
+    const commit = await options.setup?.(agentCtx)
+    commit?.commit()
+    return {
+      agent: { id: options.sessionId, ctx: agentCtx, session: { id: options.sessionId } },
+      async dispose() {},
+    }
+  },
+  async resume() { throw new Error('resume is outside this proof') },
+})
+
+const acme = await root.tenantRuntime.tenants.ensure('acme', {
+  isolateServices: ['tenantCapability'],
+  setup: ({ ctx }) => { ctx.provide('tenantCapability', 'A') },
+})
+const globex = await root.tenantRuntime.tenants.ensure('globex', {
+  isolateServices: ['tenantCapability'],
+  setup: ({ ctx }) => { ctx.provide('tenantCapability', 'B') },
+})
+const alice = await acme.principals.ensure('alice')
+const bob = await globex.principals.ensure('bob')
+
+async function createFromPrincipal(principalScope, sessionId) {
+  let handle
+  let composedCapability
+  let setupContextIsCordis = false
+  const ownerFiber = principalScope.ctx.inject(['agents'], async (ownerCtx) => {
+    handle = await ownerCtx.agents.create({
+      sessionId,
+      setup(agentCtx) {
+        composedCapability = ownerCtx.get('tenantCapability')
+        setupContextIsCordis = Context.is(agentCtx)
+      },
+    })
+  })
+  await ownerFiber
+  if (handle === undefined) throw new Error('agent handle was not created')
+  return { handle, ownerFiber, composedCapability, setupContextIsCordis }
+}
+
+const agentA = await createFromPrincipal(alice, 'agent-a')
+const agentB = await createFromPrincipal(bob, 'agent-b')
+
+const assert = (cond, msg) => { if (!cond) throw new Error('ASSERT FAILED: ' + msg) }
+assert(observed.length === 2, 'factory must receive both creates')
+assert(observed[0].tenantId === 'acme' && observed[0].principal?.userId === 'alice', 'Agent A owner context must derive from Alice principal')
+assert(observed[1].tenantId === 'globex' && observed[1].principal?.userId === 'bob', 'Agent B owner context must derive from Bob principal')
+assert(observed[0].capability === 'A' && observed[1].capability === 'B', 'owner context capability graph must stay tenant-specific')
+assert(agentA.composedCapability === 'A' && agentB.composedCapability === 'B', 'Agent setup must compose from the correct principal runtime')
+assert(agentA.setupContextIsCordis && agentB.setupContextIsCordis, 'Agent setup must receive a Cordis context')
+
+await agentA.handle.dispose()
+await agentB.handle.dispose()
+await agentA.ownerFiber.dispose()
+await agentB.ownerFiber.dispose()
+await acme.dispose()
+await globex.dispose()
+
+console.log(JSON.stringify({ observed, composedA: agentA.composedCapability, composedB: agentB.composedCapability }))
+`)
+
+  const out = execFileSync('pnpm', ['exec', 'tsx', 'probe.ts'], {
+    cwd: tmp,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  })
+  console.log(`Agent owner-context proof passed on DSH ${DSH_TARGET.version}: ${out.trim()}`)
+} finally {
+  rmSync(tmp, { recursive: true, force: true })
+}

--- a/scripts/dsh-target.mjs
+++ b/scripts/dsh-target.mjs
@@ -1,11 +1,13 @@
 /**
- * Single source of truth for the DeepSeek Harness prerelease used by executable
- * compatibility evidence in this repository.
+ * Exact DeepSeek Harness compatibility baseline for this repository.
  *
- * v0.2 changes the multi-tenant architecture, not the dependency-resolution
- * baseline. Keep the already-proven RC7 closure here; upgrading the complete
- * DSH package graph is an independent follow-up. Historical documents keep the
- * versions they actually proved.
+ * The baseline is intentionally explicit and manually advanced. At each
+ * convergence point we select the current upstream release, pin both its npm
+ * version and release commit, then let CI prove our contracts against that
+ * immutable identity. CI never follows a floating `latest` or `master`.
  */
-export const DSH_TARGET_VERSION = '0.1.0-rc.7'
-export const DSH_TARGET_RELEASE_COMMIT = '99f6f02fecdb7dff40c3fbc9470f5907c29f74ca'
+export const DSH_TARGET = Object.freeze({
+  repository: 'deepseek-ai/deepseek-harness',
+  version: '0.1.1-rc.2',
+  commit: 'b150a551b8d465e31e418e1b2eaf5e79bbb7d28e',
+})

--- a/scripts/package-smoke.mjs
+++ b/scripts/package-smoke.mjs
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 /**
  * Package smoke: prove the packed tarball is a valid distributable for an
- * external consumer. Build → pack → verify contents/exports → install into a
- * clean temp consumer → exercise both the v0.1 kernel and v0.2 runtime.
+ * external consumer. Build -> pack -> verify contents/exports -> install into a
+ * clean temp consumer -> exercise both the v0.1 kernel and v0.2 runtime.
  */
 import { execFileSync } from 'node:child_process'
 import { mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs'
@@ -64,7 +64,7 @@ try {
     'import Store from "dsh-multi-tenant/store";',
     'import Service from "dsh-multi-tenant";',
     'import Runtime from "dsh-multi-tenant/runtime";',
-    'import { assertTenantSessionStoreContract } from "dsh-multi-tenant/testing";',
+    'import { assertTenantSessionStoreContract, assertRuntimeCapabilityProviderContract } from "dsh-multi-tenant/testing";',
     'const ctx = new Context();',
     'await ctx.plugin(Store);',
     'await ctx.plugin(Service);',
@@ -72,15 +72,23 @@ try {
     'const alice = { tenantId: "acme", userId: "alice" };',
     'await ctx.multiTenant.claimSession("s1", alice);',
     'if ((await ctx.multiTenant.canAccessSession(alice, "s1")) !== true) throw new Error("smoke: same-user should be allowed");',
-    'const tenant = ctx.tenantRuntime.createTenant("acme", { isolateServices: ["tenantAuth"] });',
-    'await tenant.ctx.plugin((c, value) => { c.provide("tenantAuth", value); }, "auth-A");',
+    'const tenant = await ctx.tenantRuntime.tenants.ensure("acme", {',
+    '  isolateServices: ["tenantAuth"],',
+    '  setup: ({ ctx: tenantCtx }) => { tenantCtx.provide("tenantAuth", "auth-A"); },',
+    '});',
     'if (tenant.ctx.get("tenantAuth") !== "auth-A") throw new Error("smoke: tenant capability did not resolve");',
     'if (ctx.get("tenantAuth") !== undefined) throw new Error("smoke: tenant capability leaked to root");',
-    'const principal = tenant.createPrincipal(alice);',
-    'await principal.ctx.multiTenant.claimSession("s2", principal.principal);',
+    'const principal = await tenant.principals.ensure("alice");',
+    'await principal.ctx.multiTenant.claimSession("s2", principal.identity);',
     'const ownerFromRoot = await ctx.multiTenant.getSessionOwner("s2");',
     'if (ownerFromRoot?.tenantId !== "acme" || ownerFromRoot?.userId !== "alice") throw new Error("smoke: ownership kernel state did not cross context boundary");',
     'await assertTenantSessionStoreContract(async (c) => { await c.plugin(Store); return c.tenantSessionStore });',
+    'await assertRuntimeCapabilityProviderContract({',
+    '  serviceName: "smokeCapability",',
+    '  level: "tenant",',
+    '  mount: (scopeCtx, marker) => { scopeCtx.provide("smokeCapability", marker); },',
+    '  fingerprint: scopeCtx => scopeCtx.get("smokeCapability"),',
+    '});',
     'await tenant.dispose();',
     'console.log("consumer smoke passed");',
   ].join('\n'))

--- a/scripts/registry-preflight.mjs
+++ b/scripts/registry-preflight.mjs
@@ -1,9 +1,15 @@
 #!/usr/bin/env node
 /**
- * Read-only npm registry preflight used immediately before publication.
+ * Read-only npm registry preflight immediately before publication.
  *
- * It prevents publishing into an already-owned package name and makes release
- * workflow reruns idempotent when the exact version is already present.
+ * The npm package already exists and is owned by this repository. The only
+ * valid release states are therefore:
+ *
+ *   existing package + absent exact version  -> publish
+ *   existing package + existing exact version -> verify/recover
+ *
+ * Missing package identity or repository mismatch is a hard failure rather
+ * than an obsolete bootstrap branch in the release state machine.
  */
 import { execFileSync } from 'node:child_process'
 import { appendFileSync } from 'node:fs'
@@ -41,32 +47,31 @@ function npmView(spec, field) {
 }
 
 const packageRepo = npmView(PACKAGE_NAME, 'repository.url')
-if (packageRepo.found) {
-  const actualRepo = normalizeRepository(packageRepo.value)
-  if (actualRepo !== EXPECTED_REPOSITORY) {
-    console.error(
-      `${PACKAGE_NAME} already exists in npm with repository ${String(packageRepo.value)}; ` +
-        `expected ${EXPECTED_REPOSITORY}. Refusing to publish.`,
-    )
-    process.exit(1)
-  }
-  console.log(`${PACKAGE_NAME} already exists and points at the expected repository`)
-} else {
-  console.log(`${PACKAGE_NAME} does not yet exist in npm; first-publication bootstrap is required`)
+if (!packageRepo.found) {
+  console.error(`${PACKAGE_NAME} is expected to exist in npm; refusing an implicit first-publication/bootstrap path`)
+  process.exit(1)
+}
+
+const actualRepo = normalizeRepository(packageRepo.value)
+if (actualRepo !== EXPECTED_REPOSITORY) {
+  console.error(
+    `${PACKAGE_NAME} points at repository ${String(packageRepo.value)}; expected ${EXPECTED_REPOSITORY}. Refusing to publish.`,
+  )
+  process.exit(1)
 }
 
 const exact = npmView(`${PACKAGE_NAME}@${version}`, 'version')
-const publishNeeded = !exact.found
-
 if (exact.found && exact.value !== version) {
   console.error(`registry returned unexpected version ${String(exact.value)} for requested ${version}`)
   process.exit(1)
 }
 
+const publishNeeded = !exact.found
+console.log(`${PACKAGE_NAME} repository identity verified`)
 console.log(
   publishNeeded
-    ? `${PACKAGE_NAME}@${version} is not present; publication is required`
-    : `${PACKAGE_NAME}@${version} already exists; publication step will be skipped`,
+    ? `${PACKAGE_NAME}@${version} is absent; publication is required`
+    : `${PACKAGE_NAME}@${version} already exists; publication will be skipped and verification may continue`,
 )
 
 if (process.env.GITHUB_OUTPUT) {

--- a/scripts/registry-smoke.mjs
+++ b/scripts/registry-smoke.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-/** Post-publication registry smoke for the exact kernel prerelease. */
+/** Post-publication registry smoke for the exact published runtime version. */
 import { execFileSync } from 'node:child_process'
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
@@ -44,9 +44,9 @@ for (let attempt = 1; attempt <= 10; attempt++) {
 
 if (registryVersion !== version) throw new Error(`registry did not resolve ${PACKAGE_NAME}@${version}`)
 
-const nextVersion = npmJson(['view', `${PACKAGE_NAME}@next`, 'version'])
-if (nextVersion !== version) {
-  throw new Error(`npm next dist-tag resolves to ${String(nextVersion)}, expected ${version}`)
+const latestVersion = npmJson(['view', `${PACKAGE_NAME}@latest`, 'version'])
+if (latestVersion !== version) {
+  throw new Error(`npm latest dist-tag resolves to ${String(latestVersion)}, expected ${version}`)
 }
 
 const repository = npmJson(['view', `${PACKAGE_NAME}@${version}`, 'repository.url'])
@@ -69,15 +69,22 @@ try {
     'import { Context } from "@deepseek-ai/cordis";',
     'import Store from "dsh-multi-tenant/store";',
     'import Service from "dsh-multi-tenant";',
+    'import Runtime from "dsh-multi-tenant/runtime";',
     'import { assertTenantSessionStoreContract } from "dsh-multi-tenant/testing";',
     'const ctx = new Context();',
     'await ctx.plugin(Store);',
     'await ctx.plugin(Service);',
-    'const alice = { tenantId: "acme", userId: "alice" };',
-    'await ctx.multiTenant.claimSession("registry-s1", alice);',
-    'if ((await ctx.multiTenant.canAccessSession(alice, "registry-s1")) !== true) throw new Error("registry smoke: owner access denied");',
+    'await ctx.plugin(Runtime);',
+    'const tenant = await ctx.tenantRuntime.tenants.ensure("acme", { isolateServices: ["tenantAuth"] });',
+    'await tenant.ctx.plugin((child) => { child.provide("tenantAuth", "auth-A"); });',
+    'const alice = await tenant.principals.ensure("alice");',
+    'if (tenant.ctx.get("tenantAuth") !== "auth-A") throw new Error("registry smoke: tenant capability missing");',
+    'if (alice.ctx.get("tenantAuth") !== "auth-A") throw new Error("registry smoke: principal did not inherit tenant capability");',
+    'await alice.ctx.multiTenant.claimSession("registry-s1", alice.identity);',
+    'if ((await alice.ctx.multiTenant.canAccessSession(alice.identity, "registry-s1")) !== true) throw new Error("registry smoke: owner access denied");',
     'await assertTenantSessionStoreContract(async (c) => { await c.plugin(Store); return c.tenantSessionStore });',
-    'console.log("registry consumer smoke passed");',
+    'await tenant.dispose();',
+    'console.log("registry runtime smoke passed");',
   ].join('\n'))
 
   execFileSync('node', ['smoke.mjs'], {
@@ -89,4 +96,4 @@ try {
   rmSync(consumer, { recursive: true, force: true })
 }
 
-console.log(`registry smoke passed: ${PACKAGE_NAME}@${version}; next=${version}; integrity=${integrity.slice(0, 20)}…`)
+console.log(`registry smoke passed: ${PACKAGE_NAME}@${version}; latest=${version}; integrity=${integrity.slice(0, 20)}…`)

--- a/scripts/release-preflight.mjs
+++ b/scripts/release-preflight.mjs
@@ -1,8 +1,10 @@
 #!/usr/bin/env node
 /**
- * Release-manifest preflight for the current v0.2 runtime prerelease.
- * Runtime/API behavior is covered by verify/test/smoke/probe:dsh; this script
- * prevents packaging/publication drift.
+ * Release-manifest preflight.
+ *
+ * package.json is the single source of truth for the release version and npm
+ * channel. Runtime/API behavior is covered by verify/test/smoke/probe:dsh;
+ * this script prevents packaging, workflow and documentation drift.
  */
 import { existsSync, readFileSync, readdirSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
@@ -11,8 +13,7 @@ import { join } from 'node:path'
 const root = fileURLToPath(new URL('..', import.meta.url))
 const packagesDir = join(root, 'packages')
 const expectedPackageName = 'dsh-multi-tenant'
-const expectedVersion = '0.2.0-rc.1'
-const expectedTag = 'next'
+const expectedTag = 'latest'
 const expectedRepository = 'git+https://github.com/GuoMonth/dsh-multi-tenant.git'
 const errors = []
 
@@ -28,11 +29,13 @@ if (publishable.length !== 1 || publishable[0]?.pkg.name !== expectedPackageName
 }
 
 const runtime = packages.find(({ pkg }) => pkg.name === expectedPackageName)
+let releaseVersion
 if (!runtime) {
   errors.push(`${expectedPackageName}: package not found`)
 } else {
   const { pkg, dir } = runtime
-  if (pkg.version !== expectedVersion) errors.push(`${expectedPackageName}: version must be ${expectedVersion}, got ${String(pkg.version)}`)
+  releaseVersion = pkg.version
+  if (typeof releaseVersion !== 'string' || releaseVersion.length === 0) errors.push(`${expectedPackageName}: version is required`)
   if (pkg.publishConfig?.access !== 'public') errors.push(`${expectedPackageName}: publishConfig.access must be public`)
   if (pkg.publishConfig?.tag !== expectedTag) errors.push(`${expectedPackageName}: publishConfig.tag must be ${expectedTag}`)
   if (pkg.publishConfig?.provenance !== true) errors.push(`${expectedPackageName}: publishConfig.provenance must be true`)
@@ -54,7 +57,7 @@ if (!runtime) {
   }
 
   const readme = readFileSync(join(dir, 'README.md'), 'utf8')
-  for (const heading of ['## Supported guarantee', '## Explicit boundaries', '## Context-native runtime']) {
+  for (const heading of ['## Runtime model', '## Supported guarantee', '## Canonical publication', '## Explicit boundaries']) {
     if (!readme.includes(heading)) errors.push(`${expectedPackageName}: README missing ${heading}`)
   }
 }
@@ -73,11 +76,16 @@ if (!existsSync(releaseWorkflowPath)) {
   if (!workflow.includes('actions/setup-node@v7')) errors.push('release workflow must use actions/setup-node@v7')
   if (workflow.includes('registry-url:')) errors.push('release workflow must not let setup-node generate token auth; npm Trusted Publishing owns registry authentication')
   if (workflow.includes('NPM_BOOTSTRAP_TOKEN')) errors.push('release workflow must be OIDC-only; bootstrap token fallback is not allowed')
+  if (workflow.includes('inputs.version')) errors.push('release workflow must derive the version from package.json instead of duplicating version input')
+  if (workflow.includes('--tag next')) errors.push('release workflow must publish the package default latest channel, not next')
 }
 
 for (const requiredPath of [
+  ...(releaseVersion ? [`docs/releases/v${releaseVersion}.md`] : []),
+  'docs/releases/v0.2.0-rc.2.md',
   'docs/releases/v0.2.0-rc.1.md',
   'docs/releases/v0.1.0-rc.2.md',
+  'scripts/agent-owner-context-probe.mjs',
   'scripts/registry-preflight.mjs',
   'scripts/registry-smoke.mjs',
 ]) {
@@ -89,4 +97,4 @@ if (errors.length) {
   process.exit(1)
 }
 
-console.log(`release preflight passed: ${expectedPackageName}@${expectedVersion} -> ${expectedTag}; v0.1 frozen; context-native runtime included; OIDC-only publishing`)
+console.log(`release preflight passed: ${expectedPackageName}@${releaseVersion} -> ${expectedTag}; canonical v0.2 runtime; OIDC-only publishing`)

--- a/scripts/session-genesis-probe.mjs
+++ b/scripts/session-genesis-probe.mjs
@@ -1,26 +1,21 @@
 #!/usr/bin/env node
 /**
- * Session genesis runtime proof: confirm the static Genesis Map findings against
- * the current pinned `@deepseek-ai/dsh-session` runtime.
+ * Session genesis runtime proof against the repository's exact DSH baseline.
  *
- *   F1  — `session/created` fires AFTER the session is already in the store
- *         (get-visible), so it is not a before-visibility admission point.
- *   F2  — a synchronous `session/created` throw vetoes publication (rolls the
- *         store entry back); an async listener's rejection is logged, not vetoed.
- *
- * Run from the repo root: `node scripts/session-genesis-probe.mjs`.
- * Installs the current target into a throwaway temp dir (not the workspace).
+ *   F1  — `session/created` fires AFTER the session is already in the store.
+ *   F2  — a synchronous `session/created` throw vetoes publication; an async
+ *         listener rejection is observed later and cannot veto publication.
  */
 import { execFileSync } from 'node:child_process'
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { DSH_TARGET_VERSION } from './dsh-target.mjs'
+import { DSH_TARGET } from './dsh-target.mjs'
 
 const tmp = mkdtempSync(join(tmpdir(), 'dsh-mt-genesis-'))
 try {
   writeFileSync(join(tmp, 'package.json'), JSON.stringify({ name: 'genesis-probe', private: true, type: 'module' }))
-  execFileSync('pnpm', ['add', `@deepseek-ai/dsh-session@${DSH_TARGET_VERSION}`, '@deepseek-ai/cordis@4.0.1'], {
+  execFileSync('pnpm', ['add', `@deepseek-ai/dsh-session@${DSH_TARGET.version}`, '@deepseek-ai/cordis@4.0.1'], {
     cwd: tmp,
     stdio: 'ignore',
   })
@@ -30,7 +25,6 @@ try {
     '',
     'const results = {};',
     '',
-    '// F1: is the session already get-visible when `session/created` fires?',
     '{',
     '  const ctx = new Context();',
     '  await ctx.plugin(SessionStore);',
@@ -40,7 +34,6 @@ try {
     '  results.F1 = { visibleAtCreated, idExistsAfter: ctx.sessions.get(session.id) !== undefined };',
     '}',
     '',
-    '// F2a: a synchronous throw vetoes publication.',
     '{',
     '  const ctx = new Context();',
     '  await ctx.plugin(SessionStore);',
@@ -50,7 +43,6 @@ try {
     '  results.F2_sync = { threw, sessionCount: ctx.sessions.list().length };',
     '}',
     '',
-    '// F2b: an async rejection is logged, not vetoed.',
     '{',
     '  const ctx = new Context();',
     '  await ctx.plugin(SessionStore);',
@@ -69,7 +61,7 @@ try {
     'console.log(JSON.stringify(results));',
   ].join('\n'))
   const out = execFileSync('node', ['probe.mjs'], { cwd: tmp, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] })
-  console.log(`Session genesis proof passed on DSH ${DSH_TARGET_VERSION}: ${out.trim()}`)
+  console.log(`Session genesis proof passed on DSH ${DSH_TARGET.version}: ${out.trim()}`)
 } finally {
   rmSync(tmp, { recursive: true, force: true })
 }

--- a/scripts/verify-packages.mjs
+++ b/scripts/verify-packages.mjs
@@ -7,12 +7,12 @@
  *   - every package has build / typecheck / test scripts
  *   - the kernel's runtime dependencies are only the Cordis framework
  *   - publishable packages have consistent entry metadata + `engines.node`
- *   - DSH-facing proof packages stay pinned to the repository's target prerelease
+ *   - DSH-facing proof packages stay pinned to the repository's exact baseline
  */
 import { readFileSync, readdirSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import { join } from 'node:path'
-import { DSH_TARGET_VERSION } from './dsh-target.mjs'
+import { DSH_TARGET } from './dsh-target.mjs'
 
 const root = fileURLToPath(new URL('..', import.meta.url))
 const packagesDir = join(root, 'packages')
@@ -48,8 +48,8 @@ for (const name of readdirSync(packagesDir)) {
 
   if (pkg.name === 'dsh-multi-tenant-web') {
     const apiproxy = pkg.devDependencies?.['@deepseek-ai/dsh-host-apiproxy']
-    if (apiproxy !== DSH_TARGET_VERSION) {
-      errors.push(`${label}: @deepseek-ai/dsh-host-apiproxy must pin ${DSH_TARGET_VERSION}, got ${String(apiproxy)}`)
+    if (apiproxy !== DSH_TARGET.version) {
+      errors.push(`${label}: @deepseek-ai/dsh-host-apiproxy must pin ${DSH_TARGET.version}, got ${String(apiproxy)}`)
     }
   }
 
@@ -64,4 +64,4 @@ if (errors.length) {
   console.error('package verification failed:\n- ' + errors.join('\n- '))
   process.exit(1)
 }
-console.log(`package verification passed (${readdirSync(packagesDir).length} packages; DSH target ${DSH_TARGET_VERSION})`)
+console.log(`package verification passed (${readdirSync(packagesDir).length} packages; DSH ${DSH_TARGET.version} @ ${DSH_TARGET.commit.slice(0, 12)})`)


### PR DESCRIPTION
## Goal

One super-PR to finish v0.2 convergence before starting v0.3 SaaS Framework.

This change intentionally optimizes for the best long-term engineering/data/state/type model rather than prerelease compatibility. It also corrects repository history: PR #27 was merged into the v0.2 feature branch rather than `main`, so this PR brings the final canonical Runtime Contract onto the actual mainline.

## Runtime Contract carried into main

The runtime model is one canonical ownership tree:

```text
Root -> Tenant -> Principal -> derived integration fibers -> DSH operations
```

Key semantics:

- Tenant and Principal share one typed `ensure/get/state/dispose` vocabulary;
- Principal is structurally nested below Tenant, so invalid cross-tenant Principal identity is not representable by the public model;
- consumer identity resolution is separated from creation recipe (`ensure(key)` can join an existing node without knowing lower-layer provider configuration);
- creation is `reserve -> unpublished setup(signal) -> optional sync commit -> publish`;
- concurrent creation single-flights by canonical identity;
- preparing creations are first-class cancellable lifecycle resources, not merely `Promise<Scope>`;
- registry shutdown closes admission, cancels unpublished transactions, then drains published nodes;
- Tenant teardown structurally owns Principal teardown;
- Context identity remains composition metadata and never replaces the shared v0.1 ownership kernel.

## Agent / integration structure

A canonical Principal Context is a capability root, not a dependency-injection bypass.

Operations derive a Principal-owned integration fiber and explicitly inject what they need. Agent orchestration uses:

```text
Principal Runtime
  -> derived fiber [inject: agents]
     -> ownerCtx.agents.create(...)
        -> DSH Agent setup / Agent scope
```

This follows the real DSH caller-bound `ownerCtx` seam. We do not copy Cordis private isolation maps into `Agent.ctx`, make Tenant a second DSH scope parent, or add an Agent-specific tenant registry.

## DSH baseline refresh

The exact compatibility baseline is now:

- repository: `deepseek-ai/deepseek-harness`
- version: `0.1.1-rc.2`
- release commit: `b150a551b8d465e31e418e1b2eaf5e79bbb7d28e`

`scripts/dsh-target.mjs` is the single source of truth. The baseline is explicitly selected and manually advanced; blocking CI never follows floating npm `latest` or upstream `master`.

The Web proof package pin and real lockfile closure were refreshed to `@deepseek-ai/dsh-host-apiproxy@0.1.1-rc.2`. The lockfile was regenerated by a one-shot GitHub hosted runner against the real npm registry; the bootstrap workflow was removed afterwards.

## Compatibility evidence

CI now proves the baseline from two independent directions:

1. **Source identity:** checkout the exact upstream DSH release commit and assert HEAD + root package version match `DSH_TARGET`.
2. **Published runtime behavior:** run exact-version session genesis, admission/publication, and Agent owner/composition probes on Node 22.19 and Node 24.

Quality lanes retain frozen install, package/architecture verification, release preflight, TypeScript typecheck, unit/contract tests, build, and packed external-consumer smoke.

## Provider contract

`dsh-multi-tenant/testing` carries the executable Runtime Capability Provider Contract. Tenant/principal providers can prove A/B same-name isolation, parent/root non-leakage, descendant inheritance, sibling isolation, teardown isolation, clean recreation, and unpublished setup ownership.

## Release simplification

Rapid iteration now uses one npm channel:

- package version is sourced only from `packages/multi-tenant/package.json`;
- current version: `0.2.0-rc.3`;
- npm dist-tag: `latest`;
- manual release workflow has no duplicate version input;
- it reads package.json, runs full release proof, publishes via OIDC/provenance, verifies the exact artifact, and asserts `latest` points at it;
- registry preflight no longer carries obsolete first-publication/bootstrap state;
- SemVer itself represents prerelease/stable status.

## Documentation convergence

Current docs were rewritten around one authority model:

- `docs/specs/architecture.*` = current Runtime architecture authority;
- `docs/reference/compatibility.*` = current DSH baseline/evidence authority;
- `docs/reference/release.*` = current release-state authority;
- Session/Agent/Web seam specs/ADRs are explicitly historical investigation/evidence where appropriate;
- `packages/multi-tenant-web` is explicitly private research evidence, not the v0.3 transport architecture;
- README / CONTRIBUTING / ROADMAP / package docs are aligned in EN + zh-CN.

## Next line

After this PR is green and merged, v0.2 is treated as the Runtime Contract foundation and the main development line moves to v0.3:

**an opinionated SaaS Framework / Distribution assembled from a replaceable Plugin Family** (typed provider slots, authenticated transport binding, Agent orchestration, reference providers, diagnostics/compatibility), not a monolithic super-plugin.

## Deliberately not included

No Auth product, billing, production Web transport, production MCP SaaS implementation, organization UI, or other v0.3 product feature is added here. This is the final v0.2 structural/compatibility/release/documentation convergence.

## Final validation

Final squashed head: `bb94f0520df922b2a31e728d9bcecec51b358100` (one semantic commit directly on current `main`).

GitHub Actions run #88 (`32611587302`) is fully green:

- ✅ DSH source baseline — exact upstream `0.1.1-rc.2` / `b150a551...` identity verified;
- ✅ DSH compatibility — Node 22.19.0;
- ✅ DSH compatibility — Node 24.x;
- ✅ quality — Node 22.19.0: frozen install, verify, release preflight, typecheck, tests, build, packed consumer smoke;
- ✅ quality — Node 24.x: same full chain.

The PR is ready for review/merge. Publication is intentionally separate and is not performed by this PR.