### PR TITLE
docs: bring authority-capability vision onto main

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,6 +111,22 @@ Source reading can explain *why* a behavior probably exists; it does not replace
 
 The sequence is iterative: a later vertical slice may expose an over-coupled earlier abstraction. Refactor the live model and Spec instead of preserving prerelease compatibility around disproven structure.
 
+## Vision is not contract
+
+Long-term direction may be documented under `docs/vision/*`, but Vision has a different status from Spec:
+
+- `docs/specs/*` describes implemented/current contracts;
+- `docs/vision/*` records non-binding architectural direction;
+- Vision does not create a release gate;
+- Vision must not be used to pre-approve package names, public APIs or abstract provider families;
+- promotion from Vision to Spec requires real vertical-slice evidence.
+
+The current authority-capability Vision prefers `Capability-as-Authority` over permanently exposing raw credentials to Agent/application code. That means a future Broker may become a replaceable plugin capability and service-specific integrations may provide typed clients/transports. This is **not** permission to redesign M4 again or block M5 on a universal Broker API.
+
+The expected evidence sequence is: ship the real MCP integration first, then a second real integration such as ERP, compare repeated authority/refresh/injection/audit semantics, and only then extract the smallest proven public Broker contract if one actually exists.
+
+See `docs/vision/authority-capabilities.md`.
+
 ## Package conventions
 
 **Do not create a package because a directory seems useful. Create it only when an independent boundary is real.**
@@ -130,7 +146,7 @@ General rules:
 - One package = one independently valuable boundary, not one buzzword/capability name.
 - Prefer native DSH/Cordis Service, Context, Fiber, Agent/Preset scope and typed protocol seams.
 - Contract/default implementation may co-locate early; split only when replacement/lifecycle/versioning value is real.
-- Do not scaffold speculative `saas`, Auth, Credentials, MCP or Transport packages.
+- Do not scaffold speculative `saas`, Auth, Credentials, MCP, Broker, ERP or Transport packages.
 - A future product Distribution may provide opinionated defaults, but Distribution concerns must not dictate Core topology prematurely.
 
 ## Dependency and boundary direction
@@ -153,7 +169,9 @@ Agent Integration
 Native DSH / Cordis
 ```
 
-Credentials are a natural Principal-owned Runtime capability. MCP is currently expected to prove Agent Integration by consuming Tenant config + Principal credentials + Operation state and composing the native DSH MCP Tools plugin.
+Credentials are a natural Principal-owned Runtime capability in the current v0.3 contract. M5 is expected to prove Agent Integration by consuming Tenant config + Principal credentials + Operation state and composing the native DSH MCP Tools plugin.
+
+Long term, service-specific typed clients/transports may sit above a Broker/authority plugin so Operations consume abilities instead of raw credentials. That remains Vision until multiple real integrations prove the common boundary.
 
 Do not build a parallel protocol stack merely to make every product concern look like a Runtime Provider.
 
@@ -171,6 +189,7 @@ Do not build a parallel protocol stack merely to make every product concern look
 - architecture/data/state/type implications reviewed globally;
 - the change is demonstrably relevant to the current product direction;
 - current docs/ADR/spec updated where behavior is decided;
+- Vision is not silently promoted into a public contract without real evidence;
 - blocking external assumptions are proven or explicitly gate unfinished API design;
 - boundary ownership is explicit: Product Ingress vs Runtime capability vs Operation vs Agent Integration;
 - exact DSH/Cordis compatibility evidence is green when relevant;

--- a/CONTRIBUTING.zh-CN.md
+++ b/CONTRIBUTING.zh-CN.md
@@ -111,6 +111,22 @@ Spec -> Assumption Ledger -> executable probe / contract -> 强类型 / 状态 -
 
 这条流程也是迭代式的：后续 vertical slice 如果暴露早期 abstraction 过度耦合，应直接重构 live model 与 Spec，而不是围绕已被证据推翻的结构保 prerelease compatibility。
 
+## Vision 不是 Contract
+
+长期方向可以记录在 `docs/vision/*`，但 Vision 和 Spec 的状态必须明确区分：
+
+- `docs/specs/*` 描述已经实现 / 当前 release line 依赖的 contract；
+- `docs/vision/*` 只记录 non-binding architecture direction；
+- Vision 不进入 release gate；
+- Vision 不能提前批准 package name、public API、Provider Family；
+- Vision 只有经过真实 vertical-slice evidence，才允许升级成 Spec。
+
+当前 authority-capability Vision 长期更偏向 `Capability-as-Authority`，而不是让 Agent/application 永久直接拿 raw credential。未来 Broker 可能成为 replaceable plugin capability，不同 ERP / MCP / GitHub 等 integration 可能提供 typed client / transport。
+
+但这**不是再次 redesign M4、也不是用 universal Broker API 阻塞 M5 的理由**。推荐证据顺序是：先跑通真实 MCP integration，再做第二个真实 integration（例如 ERP），比较重复出现的 authority / refresh / injection / audit 语义，然后才决定是否存在值得提炼的最小 public Broker contract。
+
+见 `docs/vision/authority-capabilities.zh-CN.md`。
+
 ## Package Conventions
 
 **不要因为一个目录看起来有用就创建 package。只有独立边界真实存在时，package 才应该存在。**
@@ -130,7 +146,7 @@ Research、compatibility exploration、一次性 evidence 默认放在 test / sc
 - 一个 package = 一个 independently valuable boundary，不是一个 buzzword / capability 名称；
 - 优先使用 DSH / Cordis 原生 Service、Context、Fiber、Agent/Preset scope 与 typed protocol seam；
 - 早期 contract / default implementation 可以 co-locate；只有 replacement / lifecycle / versioning 价值真实出现再拆；
-- 不提前 scaffold `saas`、Auth、Credentials、MCP、Transport package；
+- 不提前 scaffold `saas`、Auth、Credentials、MCP、Broker、ERP、Transport package；
 - 未来 Product Distribution 可以提供 opinionated defaults，但 Distribution concern 不能提前决定 Core topology。
 
 ## Dependency & Boundary Direction
@@ -153,7 +169,9 @@ Agent Integration
 Native DSH / Cordis
 ```
 
-Credentials 是自然的 Principal-owned Runtime capability。MCP 当前更适合作为 Agent Integration proof：消费 Tenant config + Principal credentials + Operation state，再组合官方 DSH MCP Tools plugin。
+Credentials 在当前 v0.3 contract 中是自然的 Principal-owned Runtime capability。M5 当前更适合作为 Agent Integration proof：消费 Tenant config + Principal credentials + Operation state，再组合官方 DSH MCP Tools plugin。
+
+长期可以让 service-specific typed client / transport 建立在 Broker / authority plugin 之上，让 Operation 消费能力而不是 raw credential；但多个真实 integration 证明共同 boundary 之前，这仍然只是 Vision。
 
 不要为了让所有 product concern 看起来都像 Runtime Provider，就重造平行 protocol stack。
 
@@ -171,6 +189,7 @@ Credentials 是自然的 Principal-owned Runtime capability。MCP 当前更适�
 - 从 architecture / data / state / type 维度完成全局审查；
 - 变更与当前产品方向存在明确相关性；
 - 行为决策涉及的 current docs / ADR / spec 已同步；
+- Vision 不能在缺乏真实 evidence 的情况下静默升级成 public contract；
 - blocking external assumption 已证明，或显式阻塞尚未完成的 API design；
 - boundary ownership 明确：Product Ingress vs Runtime capability vs Operation vs Agent Integration；
 - 相关精确 DSH / Cordis compatibility evidence 全绿；

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Make DeepSeek Harness (DSH) a real **Multi-Tenant Runtime** and provide a compos
 
 > Published foundation: `dsh-multi-tenant@0.2.0-rc.3`.
 >
-> Active v0.3 development: CompositionPlan binding/attestation, Product Ingress and Principal Credentials are now part of the Core contract.
+> Active v0.3 development: CompositionPlan binding/attestation, Product Ingress and Principal Credentials are now part of the Core contract; **the next focus is only M5 real MCP Tools Agent Integration**.
 >
 > Pinned DSH baseline: `0.1.1-rc.2` at `b150a551b8d465e31e418e1b2eaf5e79bbb7d28e`; CI does not follow floating `latest`/`master`.
 
@@ -100,7 +100,9 @@ const definition = {
 
 `principalCredentials` is Principal-scoped, isolated between siblings/Tenants, replaceable without changing Core, and consumed through the one-shot Operation snapshot. The in-memory implementation is intentionally a reference/test implementation, not a production secret store, and does not expose an enumeration API.
 
-See `docs/specs/m4-product-ingress-credentials.md`.
+**Positioning:** `PrincipalCredentials` is the current low-level credential primitive used to get real product flows working. It is not a statement that raw-token access is the long-term recommended Agent/Operation API. Over time, Integration Plugins should prefer typed abilities such as `ErpClient` or `McpTransport`, keeping secrets behind a replaceable authority/broker boundary. This long-term direction does not change the current M4 contract and must not block M5.
+
+See `docs/specs/m4-product-ingress-credentials.md`; see `docs/vision/authority-capabilities.md` for the non-binding long-term direction.
 
 ## Core guarantees
 
@@ -120,7 +122,7 @@ Current executable evidence covers:
 
 ## M5 preview
 
-The next target is deliberately small:
+The next target is deliberately small: **do not redesign M4 and do not freeze a universal Broker API yet**.
 
 ```text
 Product Ingress
@@ -133,7 +135,27 @@ Product Ingress
   -> native MCP Tools
 ```
 
-No parallel MCP protocol stack and no Resources/Prompts bridge until DSH exposes a stable native consumer seam. The detailed milestone Roadmap has been retired; `ROADMAP.md` now only records current state and this M5 target.
+Use the existing Credentials primitive to ship a real DSH MCP Tools vertical slice first. If a brokered helper naturally appears, keep it private. Only after MCP plus a second real integration (for example ERP) prove repeated authority/refresh/injection/audit semantics should a later prerelease extract a public Broker contract with deliberate breaking changes.
+
+No parallel MCP protocol stack and no Resources/Prompts bridge until DSH exposes a stable native consumer seam. `ROADMAP.md` records only the current focus and long-term direction rather than a detailed milestone list.
+
+## Long-term principle
+
+```text
+Core identity / lifecycle
+        ↓
+Authority / Credential Broker plugin
+        ↓
+Service Integration plugin
+        ↓
+Typed Client / Transport capability
+        ↓
+Operation
+```
+
+> **Core owns identity/lifecycle; Broker owns authority/secrets; Integration owns vendor protocol; Operation consumes typed abilities; secrets stay behind the authority boundary whenever practical.**
+
+Different ERP/MCP/GitHub/vendor integrations should grow as composable Integration Plugins. A Broker should likewise be a replaceable plugin capability rather than a Core god object. See `docs/vision/authority-capabilities.md`.
 
 ## Public subpaths
 
@@ -151,7 +173,7 @@ dsh-multi-tenant/testing
 
 ## Security boundary
 
-Cordis Context is a trusted same-process composition/lifecycle boundary. It does not isolate process memory, filesystem, shell, network, environment variables or malicious same-process plugins. Strong isolation belongs to process/container/Pod deployment profiles.
+Cordis Context is a trusted same-process composition/lifecycle boundary. It does not isolate process memory, filesystem, shell, network, environment variables or malicious same-process plugins. A future same-process Broker can materially reduce normal-path secret exposure, but it cannot make hostile same-process code safe; strong isolation still belongs to process/container/Pod/sidecar/remote authority boundaries.
 
 ## Install
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -6,7 +6,7 @@
 
 > 已发布基础：`dsh-multi-tenant@0.2.0-rc.3`。
 >
-> 当前 v0.3 开发线：CompositionPlan 绑定/attestation、Product Ingress、Principal Credentials 已进入 Core contract。
+> 当前 v0.3 开发线：CompositionPlan binding/attestation、Product Ingress、Principal Credentials 已进入 Core contract；**下一步只聚焦 M5 真实 MCP Tools Agent Integration**。
 >
 > 当前 pinned DSH baseline：`0.1.1-rc.2` / `b150a551b8d465e31e418e1b2eaf5e79bbb7d28e`；CI 不追 floating `latest` / `master`。
 
@@ -100,7 +100,9 @@ const definition = {
 
 `principalCredentials` 是 Principal-scoped：不同 sibling / Tenant 隔离；provider 可以替换而不改 Core；消费发生在 one-shot Operation snapshot 中。In-memory 实现只用于 reference / test，不是 production secret store，并且刻意不提供枚举 secret 的 API。
 
-详见 `docs/specs/m4-product-ingress-credentials.zh-CN.md`。
+**定位说明：** `PrincipalCredentials` 是当前阶段的 low-level credential primitive，用来把真实产品链路跑起来；它不代表长期推荐让 Agent / Operation 直接接触 raw token。长期更希望 Integration Plugin 提供 `ErpClient` / `McpTransport` 这类 typed ability，把 secret 留在可替换的 authority / broker boundary 后面。这个长期方向不改变当前 M4 contract，也不阻塞 M5。
+
+详见 `docs/specs/m4-product-ingress-credentials.zh-CN.md`；长期非绑定方向见 `docs/vision/authority-capabilities.zh-CN.md`。
 
 ## 当前 Core Guarantees
 
@@ -120,7 +122,7 @@ const definition = {
 
 ## M5 预告
 
-下一目标刻意保持很小：
+下一目标刻意保持很小，**不再 redesign M4，也不提前冻结 universal Broker API**：
 
 ```text
 Product Ingress
@@ -133,7 +135,27 @@ Product Ingress
   -> native MCP Tools
 ```
 
-不造平行 MCP protocol stack；DSH 没有稳定 native consumer seam 前不桥接 Resources / Prompts。详细 milestone Roadmap 已退休，`ROADMAP.zh-CN.md` 只保留当前状态与 M5 目标。
+先使用现有 Credentials primitive 跑通真实 DSH MCP Tools vertical slice；如果实现中自然出现 brokered helper，先保持 private。只有 MCP + 第二个真实 integration（例如 ERP）证明了共享的 authority / refresh / injection / audit 语义以后，才考虑在后续 prerelease 做 breaking change，提炼正式 Broker contract。
+
+不造平行 MCP protocol stack；DSH 没有稳定 native consumer seam 前不桥接 Resources / Prompts。`ROADMAP.zh-CN.md` 只保留当前焦点和长期方向，不恢复长篇 milestone list。
+
+## 长期原则
+
+```text
+Core identity / lifecycle
+        ↓
+Authority / Credential Broker plugin
+        ↓
+Service Integration plugin
+        ↓
+Typed Client / Transport capability
+        ↓
+Operation
+```
+
+> **Core 管身份和生命周期；Broker 管授权与 secret；Integration 管厂商协议；Operation 消费 typed ability；Secret 在可行时留在 authority boundary 后面。**
+
+不同 ERP / MCP / GitHub 等接入应该通过可组合 Integration Plugin 生长，Broker 也应是可替换 plugin capability，而不是 Core 里的上帝对象。详细原则见 `docs/vision/authority-capabilities.zh-CN.md`。
 
 ## Public Subpaths
 
@@ -151,7 +173,7 @@ dsh-multi-tenant/testing
 
 ## Security Boundary
 
-Cordis Context 是 trusted same-process composition / lifecycle boundary，不隔离 process memory、filesystem、shell、network、environment variable 或恶意同进程插件。Strong isolation 属于 process / container / Pod deployment profile。
+Cordis Context 是 trusted same-process composition / lifecycle boundary，不隔离 process memory、filesystem、shell、network、environment variable 或恶意同进程插件。Same-process Broker 未来可以显著减少正常路径上的 secret 暴露，但不能把恶意同进程代码变成安全的；Strong isolation 仍属于 process / container / Pod / sidecar / remote authority boundary。
 
 ## 安装
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,7 +2,7 @@
 
 # Direction
 
-The project no longer maintains a long milestone-by-milestone Roadmap. The detailed M0–M8 planning served its purpose while the v0.3 architecture was uncertain; keeping it alive now creates more narrative debt than engineering value.
+The project no longer maintains a long milestone-by-milestone Roadmap. This file now answers only two questions: **what we are doing now**, and **where we want the architecture to evolve long term**. Current contracts remain authoritative in `docs/specs/*` and executable tests.
 
 ## Current state
 
@@ -22,31 +22,71 @@ The live v0.3 Core now has:
 - trusted Product Ingress -> canonical Principal;
 - a real replaceable Principal Credentials capability.
 
-The current architecture is documented in `docs/specs/*`; those specs and executable tests are authoritative, not this file.
+## Near-term focus only: M5 real Agent Integration
 
-## Next target: M5 Agent Integration reference path
-
-M5 should prove one useful end-to-end path without inventing another protocol framework:
+Do not redesign M4 again and do not block on a universal Broker API. First use the existing `PrincipalCredentials` primitive to ship one real DSH MCP Tools vertical slice with product value:
 
 ```text
 trusted product request
   -> Product Ingress
-  -> bound RuntimeComposition
-  -> Tenant config + Principal Credentials
+  -> RuntimeComposition
+  -> Tenant MCP config + Principal Credentials
   -> one-shot Operation snapshot
-  -> Agent Integration recipe
+  -> Agent Integration
   -> DSH Agent setup
   -> @deepseek-ai/dsh-mcp-client
   -> native DSH MCP Tools
 ```
 
-The target is deliberately narrow:
+M5 only requires:
 
-- use the official DSH MCP client and native Tool bridge;
-- consume the M4 Credentials contract rather than adding auth logic to Agent integration;
-- preserve Tenant/Principal isolation across concurrent Agents;
-- cover create/resume/failure/teardown in executable evidence;
-- keep MCP Resources/Prompts out until the pinned Harness has a stable native consumer seam;
-- do not create a separate package unless the implementation proves an independent boundary.
+- official DSH MCP client/native Tool bridge;
+- correct concurrent Tenant/Principal isolation;
+- executable create/resume/failure/teardown evidence;
+- no Resources/Prompts compatibility stack while DSH lacks a stable native consumer seam;
+- no speculative package split;
+- if a brokered helper naturally appears, keep it private until real evidence justifies a public contract.
 
-After M5, further work will be prioritized from release evidence and real usage rather than another long speculative milestone list.
+**The goal is to ship the real product loop first.**
+
+## Long-term direction: Credential-as-Data -> Capability-as-Authority
+
+`PrincipalCredentials` is intentionally a small low-level credential primitive today. It proves the M4 ownership/isolation/replacement model, but it is not necessarily the long-term recommended Agent-facing API.
+
+The preferred direction is:
+
+```text
+Core identity / lifecycle
+        ↓
+Authority / Credential Broker plugin
+        ↓
+Service Integration plugin
+        ↓
+Typed Client / Transport capability
+        ↓
+Operation
+```
+
+An Operation should eventually prefer `ErpClient.query(...)` or `McpTransport.call(...)` over receiving a raw token and performing arbitrary fetches. Different ERP/MCP/GitHub/vendor integrations should remain composable Integration Plugins; the Broker should also be a replaceable plugin capability rather than a Core god object.
+
+This direction **does not freeze an API today**. The evidence path is:
+
+```text
+M5 real MCP integration
+        ↓
+second real integration (for example ERP)
+        ↓
+observe repeated authority / refresh / injection / audit semantics
+        ↓
+extract the smallest proven Broker contract
+        ↓
+allow a deliberate breaking change in the next prerelease
+```
+
+See the non-binding long-term principles in [`docs/vision/authority-capabilities.md`](./docs/vision/authority-capabilities.md).
+
+## Long-term rule in one sentence
+
+> **Core owns identity/lifecycle; Broker owns authority/secrets; Integration owns vendor protocol; Operation consumes typed abilities; secrets stay behind the authority boundary whenever practical.**
+
+After M5, priorities continue to come from real release evidence and usage rather than another speculative milestone list.

--- a/ROADMAP.zh-CN.md
+++ b/ROADMAP.zh-CN.md
@@ -2,7 +2,7 @@
 
 # Direction
 
-项目不再维护一份很长的逐 Milestone Roadmap。M0–M8 的详细规划在 v0.3 架构尚未收敛时有价值；现在继续维护只会制造叙事债务。
+项目不再维护一份很长的逐 Milestone Roadmap。当前文件只回答两个问题：**现在做什么**，以及**长期希望往哪里演进**。具体架构 contract 仍以 `docs/specs/*` 与 executable tests 为权威。
 
 ## 当前状态
 
@@ -12,41 +12,81 @@ v0.2  Multi-Tenant Runtime Contract           已发布基础
 v0.3  SaaS Framework Core                     当前主线
 ```
 
-当前 v0.3 Core 已经具备：
+当前 v0.3 Core 已具备：
 
 - deterministic typed `SaaSDefinition -> CompositionPlan`；
 - scope-local canonical Tenant / Principal identity；
 - Principal-owned one-shot Operation；
 - 真实 DSH create / resume / failure evidence；
-- 精确的 `CompositionPlan <-> RuntimeComposition` 绑定与 attestation；
+- 精确 `CompositionPlan <-> RuntimeComposition` binding / attestation；
 - trusted Product Ingress -> canonical Principal；
 - 一个真实、可替换的 Principal Credentials capability。
 
-当前架构以 `docs/specs/*` 和 executable tests 为权威，不再以本文件维护详细任务清单。
+## 现在只聚焦：M5 真实 Agent Integration
 
-## 下一目标：M5 Agent Integration Reference Path
-
-M5 只需要证明一条真正有用的端到端链路，不再发明新的 protocol framework：
+短期不再改造 M4，也不提前设计 universal Broker API。先使用现有 `PrincipalCredentials` primitive 跑通一条真正有产品价值的 DSH MCP Tools vertical slice：
 
 ```text
 trusted product request
   -> Product Ingress
-  -> bound RuntimeComposition
-  -> Tenant config + Principal Credentials
+  -> RuntimeComposition
+  -> Tenant MCP config + Principal Credentials
   -> one-shot Operation snapshot
-  -> Agent Integration recipe
+  -> Agent Integration
   -> DSH Agent setup
   -> @deepseek-ai/dsh-mcp-client
   -> native DSH MCP Tools
 ```
 
-目标刻意保持窄：
+M5 只要求：
 
-- 使用官方 DSH MCP client 与原生 Tool bridge；
-- 消费 M4 Credentials contract，不把 auth logic 塞进 Agent integration；
-- 并发 Agent 下保持 Tenant / Principal isolation；
-- create / resume / failure / teardown 都有 executable evidence；
-- pinned Harness 还没有稳定 native consumer seam 时，不做 MCP Resources / Prompts compatibility stack；
-- implementation 没证明独立 boundary 前，不拆新 package。
+- 使用官方 DSH MCP client / native Tool bridge；
+- 并发 Tenant / Principal isolation 正确；
+- create / resume / failure / teardown 有 executable evidence；
+- 当前 DSH 没有稳定 native consumer seam 时，不造 Resources / Prompts compatibility stack；
+- 不为了未来想象提前拆 package；
+- 如果实现中自然出现 brokered helper，先保持 private，不把它提前冻结成 Core contract。
 
-M5 以后根据 release evidence 与真实使用反馈决定优先级，不再继续写一份很长的 speculative milestone list。
+**目标是先把真实产品闭环做出来。**
+
+## 长期方向：Credential-as-Data -> Capability-as-Authority
+
+`PrincipalCredentials` 当前是有意保持很小的 low-level credential primitive；它验证 M4 所需的 ownership / isolation / replacement，但不代表长期推荐的 Agent-facing API。
+
+长期希望逐步演进到：
+
+```text
+Core identity / lifecycle
+        ↓
+Authority / Credential Broker plugin
+        ↓
+Service Integration plugin
+        ↓
+Typed Client / Transport capability
+        ↓
+Operation
+```
+
+例如 Operation 最终更应该消费 `ErpClient.query(...)` / `McpTransport.call(...)`，而不是直接拿 token 自己 fetch。不同 ERP / MCP / GitHub 等协议接入应成为可组合 Integration Plugin；Broker 也应是可替换 plugin capability，而不是 Core 中的上帝对象。
+
+但这个方向**现在不冻结 API**。推荐证据路径是：
+
+```text
+M5 真实 MCP integration
+        ↓
+第二个真实 integration（例如 ERP）
+        ↓
+观察重复的 authority / refresh / injection / audit 语义
+        ↓
+提炼最小 Broker contract
+        ↓
+下一个 prerelease 允许 deliberate breaking change
+```
+
+完整的非绑定长期原则见 [`docs/vision/authority-capabilities.zh-CN.md`](./docs/vision/authority-capabilities.zh-CN.md)。
+
+## 一条长期总纲
+
+> **Core 管身份和生命周期；Broker 管授权与 secret；Integration 管厂商协议；Operation 消费 typed ability；Secret 在可行时留在 authority boundary 后面。**
+
+M5 之后继续根据真实 release evidence 与使用反馈决定下一步，不恢复长篇 speculative milestone list。

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,9 +8,11 @@ Navigation hub for the live `dsh-multi-tenant` architecture and release contract
 
 - [README](../README.md) — current product/runtime overview
 - [CONTRIBUTING](../CONTRIBUTING.md) — engineering and assumption-first policy
-- [Direction](../ROADMAP.md) — short current-state + M5 target preview; no detailed milestone Roadmap
+- [Direction](../ROADMAP.md) — current M5 focus plus long-term direction; no detailed milestone Roadmap
 
 ## Live architecture
+
+These documents describe **implemented contracts or behavior the current release line depends on**:
 
 - [Architecture](./specs/architecture.md) — authoritative topology and security boundaries
 - [SaaS boundaries](./specs/saas-boundaries.md) — Product Ingress, Runtime capability and Agent Integration planes
@@ -19,6 +21,12 @@ Navigation hub for the live `dsh-multi-tenant` architecture and release contract
 - [M4 Product Ingress + Credentials](./specs/m4-product-ingress-credentials.md) — trusted identity mapping and Principal credential contract
 - [Principal operation lifecycle](./specs/operation-lifecycle.md) — Principal-owned one-shot semantic work
 - [Session / Agent publication boundary](./adr/session-genesis.md) — DSH setup/publication decision
+
+## Long-term vision
+
+Vision records direction; it is **not a current API contract and does not create a release gate**:
+
+- [Authority-Oriented Capabilities](./vision/authority-capabilities.md) — evolution from `Credential-as-Data` toward `Capability-as-Authority`, long-term Broker/Integration plugin responsibilities, and why M5 should still ship first on the M4 primitives.
 
 ## Evidence
 

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -8,9 +8,11 @@
 
 - [README](../README.zh-CN.md) —— 当前产品/Runtime 概览
 - [CONTRIBUTING](../CONTRIBUTING.zh-CN.md) —— engineering / assumption-first policy
-- [Direction](../ROADMAP.zh-CN.md) —— 只保留当前状态与 M5 目标，不再维护详细 milestone Roadmap
+- [Direction](../ROADMAP.zh-CN.md) —— 当前 M5 焦点 + 长期演进方向，不再维护详细 milestone Roadmap
 
 ## Live Architecture
+
+下面这些文档描述**已经实现或当前 release line 依赖的 contract**：
 
 - [Architecture](./specs/architecture.zh-CN.md) —— topology 与 security boundary 权威文档
 - [SaaS Boundaries](./specs/saas-boundaries.zh-CN.md) —— Product Ingress、Runtime Capability、Agent Integration planes
@@ -19,6 +21,12 @@
 - [M4 Product Ingress + Credentials](./specs/m4-product-ingress-credentials.zh-CN.md) —— trusted identity mapping 与 Principal credential contract
 - [Principal Operation Lifecycle](./specs/operation-lifecycle.zh-CN.md) —— Principal-owned one-shot semantic work
 - [Session / Agent Publication](./adr/session-genesis.zh-CN.md) —— DSH setup / publication decision
+
+## Long-term Vision
+
+Vision 记录方向，**不是当前 API contract，也不进入 release gate**：
+
+- [Authority-Oriented Capabilities](./vision/authority-capabilities.zh-CN.md) —— 从 `Credential-as-Data` 演进到 `Capability-as-Authority`；Broker / Integration plugin 的长期职责拆分，以及为什么当前仍先用 M4 primitive 完成 M5。
 
 ## Evidence
 

--- a/docs/specs/m4-product-ingress-credentials.md
+++ b/docs/specs/m4-product-ingress-credentials.md
@@ -41,6 +41,14 @@ interface PrincipalCredentials {
 
 It does not expose enumeration, serialization or a universal secret-store API.
 
+### Contract positioning
+
+This API is deliberately a **low-level credential primitive for the current v0.3 line**. It proves Principal ownership, isolation, provider replacement and lifecycle with a real capability and gives M5 a practical way to complete a real integration.
+
+It does **not** assert that application/Agent code should permanently receive raw credentials. A later evidence-driven design may place credential access behind an authority/broker plugin and expose service-specific typed clients/transports to Operations instead.
+
+That future direction is non-binding and does not change this M4 contract. M5 must not be blocked on inventing a universal Broker API. See `../vision/authority-capabilities.md`.
+
 ## Provider adapter
 
 `definePrincipalCredentialsProvider()` receives the resolved Principal and AbortSignal inside Principal setup. A conforming provider may source credentials from any implementation; Core only requires a `PrincipalCredentials` value to be materialized in the correct scope.
@@ -58,6 +66,17 @@ The M4 contract tests prove:
 - missing credential fails explicitly;
 - replacing the credentials provider changes behavior without modifying Framework Core;
 - RuntimeComposition disposal recreates a clean Principal/provider lifecycle.
+
+## Non-goals
+
+M4 does not attempt to define:
+
+- a universal Credential Broker API;
+- service-specific ERP/MCP/GitHub client contracts;
+- credential refresh/audit/policy semantics shared across vendors;
+- a hostile-code secret sandbox.
+
+Those abstractions should be earned by later real integrations before any breaking public contract is introduced.
 
 ## Security boundary
 

--- a/docs/specs/m4-product-ingress-credentials.zh-CN.md
+++ b/docs/specs/m4-product-ingress-credentials.zh-CN.md
@@ -41,6 +41,14 @@ interface PrincipalCredentials {
 
 它不提供枚举、序列化，也不假装自己是 universal secret-store API。
 
+### Contract Positioning
+
+这个 API 被明确定位成**当前 v0.3 的 low-level credential primitive**。它用一个真实 capability 证明 Principal ownership、isolation、provider replacement、lifecycle，并让 M5 能够先完成真正的 integration。
+
+它**不意味着 application / Agent code 长期都应该直接拿 raw credential**。后续如果真实 vertical slice 证明有价值，可以把 credential access 放到 authority / broker plugin 后面，再让 Operation 消费 service-specific typed client / transport。
+
+这个长期方向当前是 non-binding，不改变 M4 contract，也不能成为阻塞 M5、提前设计 universal Broker API 的理由。见 `../vision/authority-capabilities.zh-CN.md`。
+
 ## Provider Adapter
 
 `definePrincipalCredentialsProvider()` 在 Principal setup 中拿到 resolved Principal 与 AbortSignal。Conforming provider 可以从任意后端加载 secret；Core 只要求最终 `PrincipalCredentials` value 被 materialize 到正确 scope。
@@ -58,6 +66,17 @@ M4 contract tests 证明：
 - missing credential 显式失败；
 - 替换 credentials provider 不需要修改 Framework Core；
 - RuntimeComposition dispose 后可以 clean recreation Principal / provider lifecycle。
+
+## Non-goals
+
+M4 不定义：
+
+- universal Credential Broker API；
+- ERP / MCP / GitHub 等 service-specific client contract；
+- 跨 vendor 的 credential refresh / audit / policy 通用语义；
+- hostile-code secret sandbox。
+
+这些 abstraction 必须先由后续真实 integration 挣出来，再考虑 deliberate breaking public contract。
 
 ## Security Boundary
 

--- a/docs/vision/authority-capabilities.md
+++ b/docs/vision/authority-capabilities.md
@@ -1,0 +1,150 @@
+[简体中文](./authority-capabilities.zh-CN.md) | English
+
+# Vision — Authority-Oriented Capabilities
+
+> Status: **non-binding long-term direction**. This document is not a current v0.3 API contract, does not create a release gate, and must not be used to justify speculative packages or abstractions.
+
+## Why this exists
+
+M4 intentionally introduced a small Principal-scoped `PrincipalCredentials` capability so the Framework could prove trusted ingress, Principal ownership, replacement, isolation and lifecycle with a real product-facing capability.
+
+That is useful now, but raw credentials are not the preferred long-term Agent-facing abstraction.
+
+The long-term direction is:
+
+```text
+Credential-as-Data
+        ↓ evolve from real evidence
+Capability-as-Authority
+```
+
+An Operation should ideally receive a typed ability such as `ErpClient`, `McpTransport` or another service-specific client, while the credential remains behind an authority boundary.
+
+## Long-term responsibility split
+
+```text
+dsh-multi-tenant Core
+  identity / lifecycle / composition / attestation
+                │
+                ▼
+Authority / Credential Broker plugin
+  policy / secret resolution / refresh / injection / audit
+                │
+                ▼
+Service Integration plugin
+  ERP-A / ERP-B / MCP / GitHub / internal API / ...
+                │
+                ▼
+Typed client / transport capability
+                │
+                ▼
+Operation
+  client.query(...) / transport.call(...)
+```
+
+The durable principle is more important than any proposed interface name:
+
+> Core owns identity and lifecycle. Broker owns authority and secrets. Integration owns vendor protocol. Operation consumes typed abilities. Secrets stay behind the authority boundary whenever practical.
+
+## Broker is not a Core god object
+
+A future broker should be a replaceable plugin capability, not a growing switch statement inside Core.
+
+Possible implementations may eventually include:
+
+- in-memory/reference broker;
+- Vault or cloud-secret-backed broker;
+- internal IAM/token-exchange broker;
+- remote/sidecar broker for stronger secret isolation.
+
+Those are examples, not approved package names. A public Broker contract should be extracted only after multiple real integrations prove the shared semantics.
+
+Avoid a universal API such as unrestricted `authorizedFetch(url)` unless the target/policy boundary is strong enough to prevent arbitrary credential forwarding. The safer product-facing abstraction is normally a service-specific typed client.
+
+## Service integrations are composable plugins
+
+Different ERP systems should not become branches inside one Broker.
+
+Conceptually:
+
+```text
+                   Authority Broker
+                         │
+          ┌──────────────┼──────────────┐
+          ▼              ▼              ▼
+      ERP-A plugin   ERP-B plugin    MCP plugin
+          │              │              │
+          ▼              ▼              ▼
+      ErpAClient      ErpBClient    McpTransport
+```
+
+An integration plugin may consume Tenant configuration plus Principal authority and provide a typed capability:
+
+```text
+ERP-A Integration
+  requires:
+    TenantErpAConfig
+    Principal authority/broker
+
+  provides:
+    ErpAClient
+```
+
+The Operation then consumes `ErpAClient`, not an ERP token.
+
+## Near-term execution: do not redesign M4 again
+
+The current M4 contract remains the implementation baseline:
+
+```text
+Product Ingress
+  -> RuntimeComposition
+  -> PrincipalCredentials
+  -> Operation
+```
+
+For M5, use the existing M4 primitives to ship a real DSH MCP Tools vertical slice first. Trusted integration code may consume `PrincipalCredentials` where required by the current DSH/MCP seam. If a small brokered helper naturally appears inside that implementation, keep it private until evidence justifies promotion.
+
+Do **not** block M5 on designing a universal Broker API.
+
+## Evidence path before a breaking abstraction
+
+The preferred sequence is:
+
+```text
+M4 current contract
+        ↓
+M5 real MCP Tools integration
+        ↓
+second real integration (for example ERP)
+        ↓
+compare repeated authority / refresh / injection / audit semantics
+        ↓
+extract the smallest proven Broker contract
+        ↓
+next prerelease may make a deliberate breaking change
+```
+
+At that point `PrincipalCredentials` may:
+
+1. remain as a low-level primitive used by Broker providers;
+2. become an internal/provider SPI rather than a recommended public application API; or
+3. disappear where a Broker talks directly to Vault/IAM.
+
+No choice is frozen today.
+
+## Security boundary
+
+A same-process Broker materially reduces normal-path secret exposure: Operations, tools, logs and application callbacks do not need to receive raw tokens. It does **not** make a hostile same-process plugin unable to inspect process memory or monkey-patch trusted code.
+
+Strong secret non-disclosure eventually requires a process/container/sidecar/remote authority boundary when the threat model demands it.
+
+## Decision rule
+
+When evaluating future capability/plugin designs, prefer these five rules:
+
+1. **Core owns identity/lifecycle, not vendor business.**
+2. **Secrets stay behind authority boundaries whenever practical.**
+3. **Operations consume typed abilities/clients, not raw credentials.**
+4. **Service-specific integrations are composable plugins, not Broker branches.**
+5. **Public abstractions and package boundaries are earned by real vertical slices; prerelease breaking changes are acceptable.**

--- a/docs/vision/authority-capabilities.zh-CN.md
+++ b/docs/vision/authority-capabilities.zh-CN.md
@@ -1,0 +1,148 @@
+[English](./authority-capabilities.md) | 简体中文
+
+# Vision —— Authority-Oriented Capabilities
+
+> Status：**非绑定的长期方向**。这不是当前 v0.3 API contract，不进入 release gate，也不能拿它作为提前创建 package / abstraction 的理由。
+
+## 为什么要记录这个方向
+
+M4 刻意引入了一个很小的 Principal-scoped `PrincipalCredentials` capability，用一个真实 product-facing capability 验证 trusted ingress、Principal ownership、replacement、isolation 与 lifecycle。
+
+它在当前阶段是有用的，但 **raw credential 不是长期推荐的 Agent-facing abstraction**。
+
+长期方向是：
+
+```text
+Credential-as-Data
+        ↓ 由真实实现证据推动演进
+Capability-as-Authority
+```
+
+理想状态下，Operation 拿到的是 `ErpClient`、`McpTransport` 或其他 service-specific typed ability；credential 本身留在 authority boundary 后面。
+
+## 长期职责拆分
+
+```text
+dsh-multi-tenant Core
+  identity / lifecycle / composition / attestation
+                │
+                ▼
+Authority / Credential Broker plugin
+  policy / secret resolution / refresh / injection / audit
+                │
+                ▼
+Service Integration plugin
+  ERP-A / ERP-B / MCP / GitHub / internal API / ...
+                │
+                ▼
+Typed client / transport capability
+                │
+                ▼
+Operation
+  client.query(...) / transport.call(...)
+```
+
+真正需要长期保留的是原则，而不是某个接口名字：
+
+> **Core 管身份和生命周期；Broker 管授权与 secret；Integration 管厂商协议；Operation 消费 typed ability；Secret 在可行时留在 authority boundary 后面。**
+
+## Broker 不是 Core 里的新上帝对象
+
+未来 Broker 更适合作为可替换 plugin capability，而不是 Core 内部不断增长的 switch / branch。
+
+未来可能出现的实现包括：
+
+- in-memory / reference broker；
+- Vault / cloud secret-backed broker；
+- internal IAM / token-exchange broker；
+- 为更强 secret isolation 服务的 remote / sidecar broker。
+
+这些只是例子，不是已经批准的 package name。只有多个真实 integration 证明共享语义以后，才应该提炼正式 Broker contract。
+
+尤其不要轻易提供 unrestricted `authorizedFetch(url)` 这种万能入口；如果 target / policy 约束不够强，它很容易重新变成“帮调用方偷偷塞 Authorization header 的任意 HTTP 代理”。产品层通常应该拿 service-specific typed client。
+
+## 不同业务系统通过 Integration Plugin 组装
+
+不同 ERP 不应该变成一个 Broker 里的分支：
+
+```text
+                   Authority Broker
+                         │
+          ┌──────────────┼──────────────┐
+          ▼              ▼              ▼
+      ERP-A plugin   ERP-B plugin    MCP plugin
+          │              │              │
+          ▼              ▼              ▼
+      ErpAClient      ErpBClient    McpTransport
+```
+
+一个 integration plugin 可以消费 Tenant config + Principal authority，并提供 typed capability：
+
+```text
+ERP-A Integration
+  requires:
+    TenantErpAConfig
+    Principal authority/broker
+
+  provides:
+    ErpAClient
+```
+
+Operation 最终消费的是 `ErpAClient`，不是 ERP token。
+
+## 短期执行：不要再次推翻 M4
+
+当前 M4 contract 继续作为实现 baseline：
+
+```text
+Product Ingress
+  -> RuntimeComposition
+  -> PrincipalCredentials
+  -> Operation
+```
+
+M5 先使用现有 M4 primitive 跑通真正的 DSH MCP Tools vertical slice。当前 DSH / MCP seam 如果要求 trusted integration code 消费 `PrincipalCredentials`，可以这样做；如果实现过程中自然出现一个很小的 brokered helper，先保持 private，直到证据足以支撑公共 abstraction。
+
+**不要为了设计 universal Broker API 阻塞 M5。**
+
+## 做破坏性抽象以前需要的证据
+
+推荐顺序：
+
+```text
+M4 当前 contract
+        ↓
+M5 真实 MCP Tools integration
+        ↓
+第二个真实 integration（例如 ERP）
+        ↓
+比较重复出现的 authority / refresh / injection / audit 语义
+        ↓
+提炼最小、已经被证明的 Broker contract
+        ↓
+下一个 prerelease 可以做 deliberate breaking change
+```
+
+到那时 `PrincipalCredentials` 可能有三种命运：
+
+1. 继续作为 Broker provider 使用的 low-level primitive；
+2. 降级成 internal/provider SPI，不再推荐给 application code；
+3. 在 Broker 直接连接 Vault / IAM 的实现中消失。
+
+现在不冻结任何一种。
+
+## Security Boundary
+
+Same-process Broker 仍然有真实安全收益：正常应用路径下，Operation、Tool、日志和业务 callback 不再需要看到 raw token。但它不能阻止 hostile same-process plugin 读取 process memory 或 monkey-patch trusted code。
+
+如果 threat model 要求 Agent process 从物理上都不能拿到 secret，最终还需要 process / container / sidecar / remote authority boundary。
+
+## 长期判断规则
+
+未来评估 capability / plugin 设计时，优先使用五条规则：
+
+1. **Core owns identity/lifecycle, not vendor business.**
+2. **Secrets stay behind authority boundaries whenever practical.**
+3. **Operations consume typed abilities/clients, not raw credentials.**
+4. **Service-specific integrations are composable plugins, not Broker branches.**
+5. **Public abstraction / package boundary 由真实 vertical slice 挣出来；prerelease breaking change 可以接受。**

--- a/packages/multi-tenant/README.md
+++ b/packages/multi-tenant/README.md
@@ -55,6 +55,8 @@ const provider = definePrincipalCredentialsProvider({
 
 `principalCredentials` is a canonical `CapabilityToken<PrincipalCredentials, 'principal'>`. It is isolated by Principal lifecycle and can be replaced without changing Framework Core. `InMemoryPrincipalCredentials` is reference/test infrastructure, not a production secret store.
 
+`PrincipalCredentials` is intentionally a **low-level current primitive**, not a promise that raw tokens are the long-term recommended Agent-facing abstraction. The long-term direction is for service-specific Integration Plugins to provide typed clients/transports while authority/credential Broker plugins keep secrets behind a narrower boundary. That direction is non-binding today and must not block the current M5 MCP Tools vertical slice.
+
 ### 4. One-shot work
 
 ```ts
@@ -101,7 +103,9 @@ dsh-multi-tenant/testing
 
 ## Security boundary
 
-Cordis Context is trusted same-process isolation/composition, not a hostile-code sandbox. Strong filesystem/process/network/shell isolation belongs to container/Pod deployment architecture.
+Cordis Context is trusted same-process isolation/composition, not a hostile-code sandbox. A future same-process Broker can reduce normal-path secret exposure but cannot protect against malicious code sharing the process. Strong filesystem/process/network/shell/secret isolation belongs to container/Pod/sidecar/remote deployment architecture.
+
+Long-term authority-capability direction is documented in the repository at `docs/vision/authority-capabilities.md`; it is not part of the current npm API contract.
 
 ## Install
 

--- a/packages/multi-tenant/README.zh-CN.md
+++ b/packages/multi-tenant/README.zh-CN.md
@@ -55,6 +55,8 @@ const provider = definePrincipalCredentialsProvider({
 
 `principalCredentials` 是 canonical `CapabilityToken<PrincipalCredentials, 'principal'>`，随 Principal lifecycle 隔离，可以替换 provider 而不用改 Core。`InMemoryPrincipalCredentials` 只用于 reference / test，不是 production secret store。
 
+`PrincipalCredentials` 被明确定位成**当前阶段的 low-level primitive**，不是“长期推荐让 Agent 直接拿 raw token”的承诺。长期方向是让 service-specific Integration Plugin 提供 typed client / transport，并让 authority / credential Broker plugin 把 secret 留在更窄的边界后面。这个方向当前不冻结 API，也不能阻塞 M5 的真实 MCP Tools vertical slice。
+
 ### 4. One-shot Work
 
 ```ts
@@ -101,7 +103,9 @@ dsh-multi-tenant/testing
 
 ## Security Boundary
 
-Cordis Context 是 trusted same-process isolation / composition，不是 hostile-code sandbox。Filesystem / process / network / shell strong isolation 属于 container / Pod deployment architecture。
+Cordis Context 是 trusted same-process isolation / composition，不是 hostile-code sandbox。未来 same-process Broker 可以减少正常路径上的 secret 暴露，但不能防御共享进程的恶意代码。Filesystem / process / network / shell / secret strong isolation 属于 container / Pod / sidecar / remote deployment architecture。
+
+长期 authority-capability 方向记录在仓库 `docs/vision/authority-capabilities.zh-CN.md`，不属于当前 npm API contract。
 
 ## Install
 


### PR DESCRIPTION
## Intent

Quick documentation-only recovery PR.

PR #35 was merged into the M4 feature branch rather than `main`, so its useful documentation never became part of the mainline. This PR applies exactly that documentation tree on top of current `main` without changing Runtime behavior.

## What lands on main

- explicit separation of **Spec / Direction / Vision**;
- M5 as the only near-term execution focus;
- `PrincipalCredentials` positioned as the current low-level primitive, not the permanent Agent-facing API;
- non-binding `Credential-as-Data -> Capability-as-Authority` direction;
- future Broker and service-specific ERP/MCP integrations described as composable plugins that must be earned by real vertical slices;
- CONTRIBUTING rules preventing Vision from silently becoming public contract.

No package/runtime implementation changes are introduced.
