### PR TITLE
docs: freeze v0.3.0-rc.2 First Product Experience scope

### DIFF
--- a/DIRECTION.md
+++ b/DIRECTION.md
@@ -2,11 +2,11 @@
 
 # Direction
 
-`0.3` is the current product baseline. We do not maintain a long milestone roadmap or preserve prerelease archaeology in the live tree just because it once existed.
+`0.3` is the current product baseline. The project does not maintain a long milestone roadmap or preserve prerelease archaeology in the live tree merely because it once existed.
 
 ## Current baseline
 
-The project now ships one product story:
+`0.3.0-rc.1` is released and proves the Core product story:
 
 ```text
 trusted product subject
@@ -18,25 +18,52 @@ trusted product subject
   -> native MCP Tools
 ```
 
-The immediate goal is not another milestone. It is to release `0.3.0-rc.1`, use it in real products, and keep the tree small enough to evolve quickly from actual friction.
+The Runtime correctness problem is no longer the highest-priority gap. The next bottleneck is **Time to First Value**: can a product developer with an existing Web identity experience the multi-tenant DSH value quickly, without first becoming a framework expert?
 
-## Next evidence, not next milestone
+## Next release: 0.3.0-rc.2 — First Product Experience
 
-The next architectural decision should come from a second real integration (for example ERP), not from another speculative roadmap.
+The next release is intentionally product-focused rather than architecture-focused.
 
-The question worth answering is whether authority / refresh / injection / audit behavior repeats across integrations strongly enough to justify a reusable Broker / authority plugin contract.
+Its P0 outcome is:
 
 ```text
-real MCP integration        ✅
+existing JWT / Cookie / req.user
         ↓
-second real integration
+TrustedSubject
         ↓
-compare repeated semantics
+Tenant / Principal
         ↓
-extract only proven abstractions
+DSH Web + Principal-bound Agent
         ↓
-make prerelease breaking changes when justified
+real MCP Tool
+        ↓
+visible identity / Session isolation
 ```
+
+The release scope is deliberately narrow:
+
+1. a runnable DSH Web SaaS starter using real DSH + real MCP;
+2. thin JWT and Cookie/session identity bridge examples;
+3. a shorter opinionated product-facing happy path over the existing Core;
+4. actionable first-use diagnostics without leaking secrets.
+
+Success means a first-time developer can reach a real MCP Tool call in 30 minutes or less from the README/starter path, and can visibly observe allowed owner behavior plus denied cross-Principal Session access.
+
+See [`docs/scopes/v0.3.0-rc.2.md`](./docs/scopes/v0.3.0-rc.2.md) for the frozen P0 scope and explicit non-goals.
+
+## Not blocking rc.2
+
+Important follow-ups remain, but they do not block First Product Experience:
+
+- production Redis/SQL Session Store;
+- universal Broker / `Capability-as-Authority` contract;
+- generic OAuth/OIDC/token refresh framework;
+- Permission/Policy plugin;
+- full Audit/OTel product;
+- second ERP/direct-business-API integration;
+- hostile-code strong isolation.
+
+These should be pulled forward only when real product usage proves they are required for the P0 experience.
 
 ## Live tree policy
 
@@ -44,9 +71,12 @@ make prerelease breaking changes when justified
 - Delete superseded milestone names, old release notes and one-shot probes/workflows.
 - Let Git history and tags preserve archaeology instead of charging the active tree for it.
 - Add packages/abstractions only after real vertical slices prove independent value.
+- Current release scope documents are temporary live artifacts; once shipped, history moves back to Git.
 
 ## Long-term principle
 
 > **Core owns identity/lifecycle; Broker owns authority/secrets; Integration owns vendor protocol; Operation consumes typed abilities; secrets stay behind the authority boundary whenever practical.**
+
+That long-term direction remains valid, but `0.3.0-rc.2` does not block on extracting the Broker abstraction.
 
 See [`docs/vision/authority-capabilities.md`](./docs/vision/authority-capabilities.md).

--- a/DIRECTION.zh-CN.md
+++ b/DIRECTION.zh-CN.md
@@ -6,7 +6,7 @@
 
 ## 当前基线
 
-现在项目只讲一条产品故事：
+`0.3.0-rc.1` 已经发布，并且证明了当前 Core 产品链路：
 
 ```text
 trusted product subject
@@ -18,35 +18,65 @@ trusted product subject
   -> native MCP Tools
 ```
 
-短期目标不是继续补 milestone，而是把 `0.3.0-rc.1` 真正发出去、在真实项目里用起来，然后根据实际摩擦继续快速演进。
+Runtime correctness 已经不再是当前最高优先级 Gap。下一个真正的瓶颈是 **Time to First Value**：一个本来就有 Web 登录身份的产品开发者，能不能不先成为框架专家，就快速感受到 Multi-Tenant DSH 的价值？
 
-## 下一步看 Evidence，不看 Milestone 编号
+## 下个版本：0.3.0-rc.2 — First Product Experience
 
-下一个架构决策应该来自第二个真实 integration（例如 ERP），而不是来自下一张 speculative roadmap。
+下个版本明确以产品体验为中心，而不是继续推进架构 milestone。
 
-真正值得观察的问题是：authority / refresh / injection / audit 是否在多个 integration 里重复出现到足以提炼 Broker / authority plugin contract。
+P0 目标链路：
 
 ```text
-真实 MCP integration        ✅
+已有 JWT / Cookie / req.user
         ↓
-第二个真实 integration
+TrustedSubject
         ↓
-比较重复语义
+Tenant / Principal
         ↓
-只提炼被证明的 abstraction
+DSH Web + Principal-bound Agent
         ↓
-必要时直接做 prerelease breaking change
+真实 MCP Tool
+        ↓
+肉眼可见的 identity / Session 隔离
 ```
+
+范围故意收窄到四件事：
+
+1. 一个使用真实 DSH + 真实 MCP 的可运行 DSH Web SaaS Starter；
+2. 薄 JWT 与 Cookie/session identity bridge 示例；
+3. 在现有 Core 之上的更短 opinionated product-facing happy path；
+4. 不泄露 secret 的、可操作 first-use diagnostics。
+
+成功标准是：第一次接触项目的开发者只看 README / Starter，30 分钟以内完成真实 MCP Tool 调用，并且能够直接看到 owner 正常访问与 cross-Principal Session 被拒绝这两个结果。
+
+完整冻结范围与明确 Non-goals 见 [`docs/scopes/v0.3.0-rc.2.zh-CN.md`](./docs/scopes/v0.3.0-rc.2.zh-CN.md)。
+
+## 不阻塞 rc.2 的后续能力
+
+以下能力仍然重要，但不能阻塞 First Product Experience：
+
+- production Redis / SQL Session Store；
+- 通用 Broker / `Capability-as-Authority` contract；
+- generic OAuth / OIDC / token refresh framework；
+- Permission / Policy Plugin；
+- 完整 Audit / OTel 产品；
+- 第二个 ERP / direct-business-API integration；
+- hostile-code strong isolation。
+
+只有真实产品使用证明其中某项是 P0 闭环的必要条件时，才允许把它提前拉进来，而且只补最小 seam。
 
 ## Live Tree Policy
 
 - 当前代码、当前 contract、当前 evidence 留在主树；
 - 已经被替代的 milestone 名称、旧 release note、一次性 probe / workflow 删除；
 - 历史价值交给 Git history / tag，不让 archaeology 增加当前维护成本；
-- package / abstraction 只有在真实 vertical slice 证明独立价值后才新增。
+- package / abstraction 只有在真实 vertical slice 证明独立价值后才新增；
+- 当前 release scope 文档只是 live artifact，版本发布后历史重新交给 Git。
 
 ## 长期原则
 
 > **Core 管 identity / lifecycle；Broker 管 authority / secret；Integration 管 vendor protocol；Operation 消费 typed ability；Secret 在可行时留在 authority boundary 后面。**
+
+这个长期方向仍然有效，但 `0.3.0-rc.2` 不以抽取 Broker abstraction 为阻塞条件。
 
 详见 [`docs/vision/authority-capabilities.zh-CN.md`](./docs/vision/authority-capabilities.zh-CN.md)。

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 If you already like DeepSeek Harness but now need to put it behind a real SaaS product, this project handles the layer that usually becomes dangerous first: **which organization/user owns the request, which credentials and MCP config they may use, which Session they may resume, and which long-lived Agent lifecycle belongs to them.**
 
-> Release candidate: **`dsh-multi-tenant@0.3.0-rc.1`**
+> Current release: **`dsh-multi-tenant@0.3.0-rc.1`**
 >
 > Compatible DSH baseline: `0.1.1-rc.2` at `b150a551b8d465e31e418e1b2eaf5e79bbb7d28e`.
 
@@ -182,6 +182,25 @@ CI proves the real external assumptions, a real stdio MCP server, real `tools/li
 
 See [`docs/reference/compatibility.md`](./docs/reference/compatibility.md).
 
+## Next release focus
+
+`0.3.0-rc.2` is intentionally focused on **First Product Experience** rather than another Core milestone.
+
+The P0 goal is to make the real product path tangible:
+
+```text
+existing JWT / Cookie / req.user
+  -> Tenant / Principal
+  -> DSH Web
+  -> Principal-bound Agent
+  -> real MCP Tool
+  -> visible identity / Session isolation
+```
+
+The release is limited to a runnable DSH Web SaaS starter, thin JWT/Cookie identity bridges, a shorter product-facing happy path and actionable first-use diagnostics. Production persistence, universal Broker/Auth abstractions, Permission/Audit products and the second ERP integration are explicitly non-blocking follow-ups.
+
+See [`docs/scopes/v0.3.0-rc.2.md`](./docs/scopes/v0.3.0-rc.2.md).
+
 ## Where this is going
 
 The current `PrincipalCredentials` capability is deliberately low-level. The preferred long-term direction is **Capability-as-Authority**: Operations consume typed abilities such as an `ErpClient`/transport while secrets stay behind replaceable Broker/authority plugins whenever practical.
@@ -190,11 +209,11 @@ That is Vision, not a frozen `0.3` API. See [`docs/vision/authority-capabilities
 
 ## Release status
 
-`0.3.0-rc.1` is a prerelease and the project is intentionally moving fast. Breaking changes are acceptable when real integrations prove a better contract.
+`0.3.0-rc.1` is the currently published prerelease. The project is intentionally moving fast, and deliberate breaking changes remain acceptable when real integrations prove a better contract.
 
 The live repository keeps only current `0.3` release documentation and current release infrastructure; older prerelease archaeology stays in Git history/tags rather than the active tree.
 
-See [`docs/releases/v0.3.0-rc.1.md`](./docs/releases/v0.3.0-rc.1.md) and [`docs/reference/release.md`](./docs/reference/release.md).
+See [`docs/releases/v0.3.0-rc.1.md`](./docs/releases/v0.3.0-rc.1.md), [`docs/scopes/v0.3.0-rc.2.md`](./docs/scopes/v0.3.0-rc.2.md), and [`docs/reference/release.md`](./docs/reference/release.md).
 
 ## License
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -6,7 +6,7 @@
 
 如果你已经认可 DeepSeek Harness 的 Agent 执行模型，但准备把它放进一个真正的 SaaS 产品，那么最先变复杂的通常不是模型，而是这几件事：**这个请求属于谁、能拿哪份 credential、应该连接哪个 MCP、能不能恢复某个 Session，以及这个长生命周期 Agent 最终归谁管理。**
 
-> Release candidate：**`dsh-multi-tenant@0.3.0-rc.1`**
+> 当前已发布版本：**`dsh-multi-tenant@0.3.0-rc.1`**
 >
 > Compatible DSH baseline：`0.1.1-rc.2` / `b150a551b8d465e31e418e1b2eaf5e79bbb7d28e`。
 
@@ -183,6 +183,25 @@ CI 会证明真实外部 DSH / Cordis assumptions、真实 stdio MCP server、�
 
 详见 [`docs/reference/compatibility.zh-CN.md`](./docs/reference/compatibility.zh-CN.md)。
 
+## 下个版本聚焦
+
+`0.3.0-rc.2` 明确以 **First Product Experience** 为最高优先级，而不是继续做新的 Core milestone。
+
+P0 目标就是把真实产品链路做出明显体感：
+
+```text
+已有 JWT / Cookie / req.user
+  -> Tenant / Principal
+  -> DSH Web
+  -> Principal-bound Agent
+  -> 真实 MCP Tool
+  -> 肉眼可见的 identity / Session 隔离
+```
+
+这个版本只聚焦：可运行 DSH Web SaaS Starter、薄 JWT/Cookie Identity Bridge、更短 product-facing happy path、可操作 first-use diagnostics。Production persistence、通用 Broker/Auth abstraction、Permission/Audit 产品、第二个 ERP integration 都明确是 non-blocking follow-up。
+
+完整范围见 [`docs/scopes/v0.3.0-rc.2.zh-CN.md`](./docs/scopes/v0.3.0-rc.2.zh-CN.md)。
+
 ## 接下来往哪里走
 
 当前 `PrincipalCredentials` 仍然是 low-level primitive。长期更希望往 **Capability-as-Authority** 演进：Operation 消费 `ErpClient` / transport 这类 typed ability，secret 尽量留在可替换 Broker / authority plugin 后面。
@@ -191,11 +210,11 @@ CI 会证明真实外部 DSH / Cordis assumptions、真实 stdio MCP server、�
 
 ## Release 状态
 
-`0.3.0-rc.1` 仍然是 prerelease，而且项目会继续快速推进。真实 integration 如果证明当前 contract 不够好，后续允许 deliberate breaking change。
+`0.3.0-rc.1` 是当前已发布 prerelease。项目会继续快速推进，真实 integration 如果证明当前 contract 不够好，后续仍允许 deliberate breaking change。
 
 当前 live tree 只保留 `0.3` 仍有用的 release 文档和发布基建；旧 v0.1 / v0.2 的 prerelease archaeology 留在 Git history / tag 里，不继续污染主分支。
 
-详见 [`docs/releases/v0.3.0-rc.1.md`](./docs/releases/v0.3.0-rc.1.md) 与 [`docs/reference/release.zh-CN.md`](./docs/reference/release.zh-CN.md)。
+详见 [`docs/releases/v0.3.0-rc.1.md`](./docs/releases/v0.3.0-rc.1.md)、[`docs/scopes/v0.3.0-rc.2.zh-CN.md`](./docs/scopes/v0.3.0-rc.2.zh-CN.md) 与 [`docs/reference/release.zh-CN.md`](./docs/reference/release.zh-CN.md)。
 
 ## License
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,7 +9,8 @@ Old prerelease notes, milestone names, superseded investigation documents and on
 ## Start here
 
 - [Project README](../README.md) — what problem the project solves, installation and the first product flow
-- [Direction](../DIRECTION.md) — current direction without a milestone roadmap
+- [Direction](../DIRECTION.md) — current product direction
+- [v0.3.0-rc.2 scope](./scopes/v0.3.0-rc.2.md) — frozen next-release goal: First Product Experience
 - [CONTRIBUTING](../CONTRIBUTING.md) — engineering, evidence and live-tree policy
 
 ## Current product/runtime contracts
@@ -22,12 +23,20 @@ Old prerelease notes, milestone names, superseded investigation documents and on
 - [SaaS boundaries](./specs/saas-boundaries.md) — Product Ingress, Runtime capability and Agent Integration planes
 - [SaaS composition](./specs/saas-composition.md) — compiler, scope-local identity and provider materialization
 
+## Current release scope
+
+`0.3.0-rc.2` is deliberately product-first. Its P0 scope is limited to a runnable DSH Web SaaS starter, thin JWT/Cookie identity bridges, a shorter product-facing happy path and actionable first-use diagnostics.
+
+Production persistence, universal Broker/Auth abstractions, Permission/Audit products and the second ERP integration are explicitly non-blocking follow-ups.
+
+See [the scope document](./scopes/v0.3.0-rc.2.md) for acceptance criteria and non-goals.
+
 ## Evidence and release
 
 - [`v0.3-assumptions.json`](./specs/v0.3-assumptions.json) — machine-readable external assumptions and proofs
 - [Compatibility](./reference/compatibility.md) — pinned DSH/Cordis baseline and current CI evidence
 - [Release contract](./reference/release.md) — npm/OIDC publication and registry verification
-- [0.3.0-rc.1 release note](./releases/v0.3.0-rc.1.md) — current release candidate
+- [0.3.0-rc.1 release note](./releases/v0.3.0-rc.1.md) — currently published release
 
 ## Long-term vision
 

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -9,8 +9,9 @@
 ## 从这里开始
 
 - [项目 README](../README.zh-CN.md) — 先看它解决什么问题、怎么安装、怎么跑第一条产品链路
-- [Direction](../DIRECTION.zh-CN.md) — 当前方向，不维护长篇 milestone roadmap
-- [CONTRIBUTING](../CONTRIBUTING.zh-CN.md) — engineering / evidence policy
+- [Direction](../DIRECTION.zh-CN.md) — 当前产品方向
+- [v0.3.0-rc.2 Scope](./scopes/v0.3.0-rc.2.zh-CN.md) — 已冻结的下个版本目标：First Product Experience
+- [CONTRIBUTING](../CONTRIBUTING.zh-CN.md) — engineering / evidence / live-tree policy
 
 ## 当前产品 / Runtime Contract
 
@@ -22,12 +23,20 @@
 - [SaaS boundaries](./specs/saas-boundaries.zh-CN.md) — Product Ingress、Runtime capability、Agent Integration planes
 - [SaaS composition](./specs/saas-composition.zh-CN.md) — compiler、scope-local identity、provider materialization
 
+## 当前 Release Scope
+
+`0.3.0-rc.2` 明确 product-first。P0 只包含：可运行的 DSH Web SaaS Starter、薄 JWT/Cookie Identity Bridge、更短的 product-facing happy path，以及可操作 first-use diagnostics。
+
+Production persistence、通用 Broker/Auth abstraction、Permission/Audit 产品、第二个 ERP integration 都明确属于 non-blocking follow-up。
+
+完整验收标准与 Non-goals 见 [Scope 文档](./scopes/v0.3.0-rc.2.zh-CN.md)。
+
 ## Evidence 与 Release
 
 - [`v0.3-assumptions.json`](./specs/v0.3-assumptions.json) — machine-readable external assumptions / proofs
 - [Compatibility](./reference/compatibility.zh-CN.md) — pinned DSH / Cordis baseline 与当前 CI evidence
 - [Release contract](./reference/release.zh-CN.md) — npm / OIDC publication 与 registry verification
-- [0.3.0-rc.1 release note](./releases/v0.3.0-rc.1.md) — 当前 release candidate
+- [0.3.0-rc.1 release note](./releases/v0.3.0-rc.1.md) — 当前已发布版本
 
 ## 长期 Vision
 

--- a/docs/scopes/v0.3.0-rc.2.md
+++ b/docs/scopes/v0.3.0-rc.2.md
@@ -1,0 +1,173 @@
+[简体中文](./v0.3.0-rc.2.zh-CN.md) | English
+
+# v0.3.0-rc.2 Scope — First Product Experience
+
+`0.3.0-rc.2` is the first release whose highest priority is **user-perceived product value**, not another Core architecture milestone.
+
+`0.3.0-rc.1` established the multi-tenant Runtime contract and proved the DSH-native MCP path. The next release must prove that a product developer who already has a Web identity can experience that value quickly, without first learning the internal composition model.
+
+## Release outcome
+
+A first-time developer should be able to follow one product-facing path:
+
+```text
+existing Web identity (JWT / Cookie / req.user)
+        ↓
+trusted Tenant / Principal
+        ↓
+principal-bound DSH Agent
+        ↓
+real MCP connection
+        ↓
+native MCP Tool call
+        ↓
+visible tenant / user / Session isolation
+```
+
+The release is successful when this flow feels like a product integration rather than a framework assembly exercise.
+
+## P0 scope
+
+### 1. Runnable DSH Web SaaS starter
+
+Ship one real, copyable starter/reference product that uses the existing DSH Web experience instead of inventing a second chat UI.
+
+It must demonstrate at least:
+
+- a real DSH Web launch path;
+- two Tenants and at least two Principals;
+- a browser-visible login/switch-user flow suitable for demonstration;
+- a real MCP server and real MCP Tool discovery/execution;
+- Tenant-specific MCP configuration;
+- Principal-specific credential/identity propagation;
+- successful create/resume for the owner;
+- denied cross-Principal Session resume;
+- no raw credential/token exposure to the model or UI.
+
+The preferred first-run experience is one command or one short documented sequence. Docker Compose is allowed when it materially reduces setup friction, but is not a release goal by itself.
+
+### 2. Thin Web identity bridge
+
+Prove the two identity paths most product developers already have:
+
+```text
+Bearer JWT
+  -> existing verification
+  -> TrustedSubject
+
+HttpOnly Cookie / existing server session / req.user
+  -> existing authentication middleware
+  -> TrustedSubject
+```
+
+The framework must continue to start **after authentication**. This release must not become a JWT/OIDC/authentication framework.
+
+The bridge should reduce integration to a small product-owned mapping from an already trusted request/user object into `tenantId` + `principalId` (and optional product metadata).
+
+### 3. Opinionated product-facing entry path
+
+Keep the current Core contracts intact, but provide a significantly shorter happy path for product developers.
+
+The common starter path should not require first-time users to understand or manually assemble all of these before first success:
+
+- `CapabilityToken`;
+- provider dependency graphs;
+- scope fingerprints;
+- Cordis Fiber semantics;
+- `CompositionPlan` internals.
+
+Implementation may introduce a thin product facade/profile that compiles into the existing Core. The exact public symbol name is not frozen by this scope document; the acceptance criterion is reduced glue and reduced conceptual load, not a speculative API name.
+
+### 4. First-use diagnostics
+
+A failed first integration must be actionable without reading source code.
+
+At minimum, the product path must distinguish failures such as:
+
+- identity resolution failed;
+- Tenant MCP configuration missing/invalid;
+- Principal credential unavailable;
+- Session ownership conflict;
+- MCP connection/setup failed;
+- MCP tool discovery failed.
+
+Diagnostics must identify the failing layer while never printing raw secrets.
+
+A dedicated `doctor` command is optional for this release; actionable structured errors and starter-visible diagnostics are mandatory.
+
+## Product acceptance criteria
+
+### Time to First Value
+
+A developer on the supported Node/DSH baseline, starting from the project README/starter instructions, should be able to reach the first successful real MCP Tool call in **30 minutes or less** without reading internal architecture specs.
+
+### First-success concepts
+
+Before first success, the user should mainly need to understand:
+
+1. Tenant;
+2. Principal;
+3. MCP configuration;
+4. credential/identity mapping.
+
+Internal composition concepts remain available for framework authors but should not be prerequisites for the starter path.
+
+### Isolation demo
+
+The reference flow must visibly prove at least one positive and one negative multi-tenant behavior:
+
+```text
+Acme / Alice -> own Agent + own MCP identity -> allowed
+Acme / Bob   -> Alice Session               -> denied
+```
+
+A second Tenant should also be present so the demo covers both sibling Principal and cross-Tenant separation.
+
+### Copyability
+
+The starter must make it obvious which small pieces a product developer replaces with their own system:
+
+- trusted subject resolver;
+- Tenant MCP endpoint/config loader;
+- Principal credential/authority loader.
+
+The rest of the lifecycle and ownership behavior should remain reusable.
+
+## Explicitly out of scope for rc.2
+
+These are valuable, but they must not block the First Product Experience release:
+
+- Redis/Postgres/MySQL production `TenantSessionStore` implementations;
+- a universal Credential Broker / `Capability-as-Authority` public contract;
+- generic token refresh / OAuth / OIDC / SAML framework support;
+- fine-grained Permission/Policy plugin;
+- full Audit/OTel product;
+- second ERP/direct-business-API vertical slice;
+- hostile-code strong isolation (process/Pod project remains the boundary for that problem);
+- MCP Resources / Prompts support beyond what the pinned Harness can consume;
+- replacing DSH Web with a custom frontend;
+- broad CLI/desktop packaging work unrelated to the first SaaS Web experience.
+
+If any of these are required to make the P0 flow actually work, add only the smallest local seam needed and do not promote it into a general abstraction without evidence.
+
+## Non-goals
+
+`0.3.0-rc.2` is **not** intended to:
+
+- redesign the Runtime ownership model;
+- introduce a second DI/lifecycle substrate beside Cordis;
+- freeze a universal auth or Broker API;
+- maximize feature count;
+- claim production readiness for persistence/strong isolation not yet implemented.
+
+## Engineering rule for this release
+
+When product experience and internal elegance compete, prefer the smallest implementation that delivers a real end-to-end user win **without weakening current isolation/lifecycle guarantees**.
+
+Do not hide real gaps with mocks. The reference success path must use the same installed package, DSH Agent lifecycle and official MCP client that a real product would use.
+
+## Versioning note
+
+This scope PR does not bump the package version. The package remains `0.3.0-rc.1` until implementation is ready for the normal release-convergence step that cuts `0.3.0-rc.2`.
+
+After `0.3.0-rc.2` ships, this scope document should either be removed from the live tree or rewritten around the next current product target; Git history preserves the completed scope.

--- a/docs/scopes/v0.3.0-rc.2.zh-CN.md
+++ b/docs/scopes/v0.3.0-rc.2.zh-CN.md
@@ -1,0 +1,173 @@
+[English](./v0.3.0-rc.2.md) | 简体中文
+
+# v0.3.0-rc.2 Scope — First Product Experience
+
+`0.3.0-rc.2` 的最高优先级明确改成 **用户能直接感受到的产品价值**，而不是继续做新的 Core 架构 milestone。
+
+`0.3.0-rc.1` 已经建立了 Multi-Tenant Runtime Contract，也证明了 DSH-native MCP 路径。下一个版本必须证明：一个本来就有 Web 登录身份的产品开发者，不需要先学习内部 Composition 模型，也能快速得到真实体验。
+
+## 这个版本最终要让用户得到什么
+
+第一次接触项目的开发者应该能沿着一条产品链路跑通：
+
+```text
+已有 Web 身份（JWT / Cookie / req.user）
+        ↓
+trusted Tenant / Principal
+        ↓
+Principal-bound DSH Agent
+        ↓
+真实 MCP 连接
+        ↓
+native MCP Tool 调用
+        ↓
+肉眼可见的 Tenant / User / Session 隔离
+```
+
+成功标准不是“Framework API 又多了一层”，而是这条链路让用户感觉自己在做产品集成，而不是拼装底层框架。
+
+## P0 范围
+
+### 1. 可真正运行的 DSH Web SaaS Starter
+
+交付一个真实、可复制的 Starter / Reference Product，优先复用 DSH 现有 Web 体验，不另造第二套聊天前端。
+
+至少必须证明：
+
+- 真实 DSH Web 启动路径；
+- 两个 Tenant，且至少两个 Principal；
+- 浏览器里能看见、适合演示的登录 / 切换用户流程；
+- 真实 MCP Server + 真实 Tool discovery / execution；
+- Tenant-specific MCP config；
+- Principal-specific credential / identity propagation；
+- Owner 正常 create/resume；
+- Cross-Principal Session resume 被拒绝；
+- raw credential / token 不进入模型上下文，也不展示在 UI。
+
+第一次运行最好是一条命令或非常短的步骤。Docker Compose 如果能明显降低门槛可以使用，但它本身不是 release goal。
+
+### 2. 薄 Web Identity Bridge
+
+优先证明绝大多数产品已经存在的两条身份路径：
+
+```text
+Bearer JWT
+  -> 现有验证逻辑
+  -> TrustedSubject
+
+HttpOnly Cookie / 现有 server session / req.user
+  -> 现有 authentication middleware
+  -> TrustedSubject
+```
+
+Framework 仍然必须从 **authentication 已完成之后** 开始。这个版本不能变成 JWT / OIDC / Authentication Framework。
+
+集成层应该让产品只写一个很薄的 mapping：把已经可信的 request/user 对象映射到 `tenantId` + `principalId`（以及可选产品 metadata）。
+
+### 3. Opinionated Product-facing Entry Path
+
+当前 Core Contract 保持不变，但普通产品开发者的 happy path 必须明显缩短。
+
+第一次成功之前，用户不应该被迫先理解或手工拼装：
+
+- `CapabilityToken`；
+- provider dependency graph；
+- scope fingerprint；
+- Cordis Fiber semantics；
+- `CompositionPlan` internals。
+
+实现上可以增加一层非常薄的 product facade / profile，再编译到现有 Core。这个 scope 文档不提前冻结具体 public symbol 名；验收标准是减少 glue code 和概念负担，而不是为了 scope 先发明 API 名字。
+
+### 4. First-use Diagnostics
+
+第一次集成失败时，用户必须能直接知道坏在哪一层，而不是读源码或猜 stack trace。
+
+至少要区分：
+
+- identity resolution failed；
+- Tenant MCP config missing / invalid；
+- Principal credential unavailable；
+- Session ownership conflict；
+- MCP connection / setup failed；
+- MCP tool discovery failed。
+
+Diagnostics 要指出失败层，但绝不能打印 raw secret。
+
+独立的 `doctor` CLI 在这个版本里可以不做；但结构化、可操作的错误和 Starter 里能看到的诊断信息是必须项。
+
+## 产品验收标准
+
+### Time to First Value
+
+在支持的 Node / DSH baseline 上，一个开发者只看项目 README / Starter 文档，**30 分钟以内**应该能完成第一次真实 MCP Tool 调用，而且不需要先读内部 Architecture Specs。
+
+### 第一次成功前需要理解的概念
+
+尽量压缩到四个：
+
+1. Tenant；
+2. Principal；
+3. MCP config；
+4. credential / identity mapping。
+
+`CompositionPlan`、Fiber、fingerprint 等保留给需要深入框架的开发者，不作为第一次成功前置知识。
+
+### 隔离效果必须肉眼可见
+
+Reference Flow 至少证明一个正例和一个反例：
+
+```text
+Acme / Alice -> 自己的 Agent + 自己的 MCP identity -> allowed
+Acme / Bob   -> Alice Session                         -> denied
+```
+
+同时还要有第二个 Tenant，覆盖 sibling Principal 与 cross-Tenant 两种隔离。
+
+### 可复制性
+
+Starter 必须让产品开发者一眼看出，真正接自己系统时只需要替换哪些小块：
+
+- trusted subject resolver；
+- Tenant MCP endpoint / config loader；
+- Principal credential / authority loader。
+
+其余生命周期、ownership、Session safety 应该直接复用。
+
+## rc.2 明确不做什么
+
+以下能力很重要，但不能阻塞 First Product Experience：
+
+- Redis / Postgres / MySQL production `TenantSessionStore`；
+- 通用 Credential Broker / `Capability-as-Authority` public contract；
+- generic token refresh / OAuth / OIDC / SAML framework；
+- fine-grained Permission / Policy Plugin；
+- 完整 Audit / OpenTelemetry 产品；
+- 第二个 ERP / direct-business-API vertical slice；
+- hostile-code strong isolation（继续由 process / Pod 项目承担）；
+- pinned Harness 尚无稳定 consumer seam 的 MCP Resources / Prompts；
+- 自研一套新的 Web UI 去替换 DSH Web；
+- 与第一次 SaaS Web 体验无关的大范围 CLI / Desktop packaging。
+
+如果 P0 闭环确实需要其中某个能力，只补足最小本地 seam，不因为“以后可能有用”就提前抽成通用 abstraction。
+
+## Non-goals
+
+`0.3.0-rc.2` 不负责：
+
+- 重做 Runtime ownership model；
+- 在 Cordis 之外再引入一套 DI / lifecycle substrate；
+- 冻结一个 universal auth / Broker API；
+- 追求功能数量；
+- 对尚未实现的 persistence / strong isolation 宣称 production readiness。
+
+## 这个版本的工程判断规则
+
+当“内部架构更漂亮”和“用户第一次体验更直接”发生冲突时，在**不削弱现有 isolation / lifecycle guarantee** 的前提下，优先选择最小但真实可用的产品实现。
+
+不能用 mock 掩盖真实 Gap。Reference success path 必须使用和真实产品一样的 installed package、DSH Agent lifecycle、官方 MCP client。
+
+## Versioning Note
+
+这个 scope PR 不修改 package version。实现完成、进入正常 release convergence 时，再把 package 从 `0.3.0-rc.1` 切到 `0.3.0-rc.2`。
+
+`0.3.0-rc.2` 发布以后，这份 scope 文档应该从 live tree 删除，或者直接改写成下一个当前产品目标；已经完成的 scope 交给 Git history 保存。


### PR DESCRIPTION
## Why this PR exists

`0.3.0-rc.1` proved the Core multi-tenant Runtime and the real DSH-native MCP path. The next bottleneck is no longer another architecture milestone; it is **Time to First Value for a product developer**.

This PR freezes the next-release scope before implementation starts.

**Target version:** `0.3.0-rc.2`

**Release theme:** **First Product Experience**

This is a scope-only PR. It does **not** bump the package version and does **not** implement the features yet.

## P0 product outcome

A first-time developer who already has a Web identity should be able to experience this path without first learning the framework internals:

```text
existing JWT / Cookie / req.user
        ↓
TrustedSubject
        ↓
Tenant / Principal
        ↓
DSH Web + Principal-bound Agent
        ↓
real MCP Tool
        ↓
visible identity / Session isolation
```

## Frozen P0 scope

### 1. Runnable DSH Web SaaS starter

Use the existing DSH Web experience rather than inventing another chat frontend.

The starter must demonstrate:

- real DSH Web launch;
- two Tenants and multiple Principals;
- browser-visible login/switch-user flow;
- real MCP server + real Tool discovery/execution;
- Tenant-specific MCP config;
- Principal-specific credential/identity propagation;
- owner create/resume success;
- denied cross-Principal Session resume;
- no raw token/credential exposure to model/UI.

### 2. Thin Web identity bridge

Prove two common existing product paths:

```text
Bearer JWT -> existing verification -> TrustedSubject
Cookie/server session/req.user -> existing middleware -> TrustedSubject
```

Authentication remains product-owned. rc.2 must not become a JWT/OIDC authentication framework.

### 3. Opinionated product-facing happy path

Keep the Core contract intact, but reduce the amount of glue and the number of concepts required before first success.

A first-time product developer should not need to understand `CapabilityToken`, provider graphs, fingerprints, Cordis Fiber semantics or `CompositionPlan` internals just to run the starter.

The scope deliberately does not freeze a speculative public API name; implementation must earn the smallest product facade/profile over the existing Core.

### 4. First-use diagnostics

Failures must identify the broken layer without leaking secrets, including at least:

- identity resolution;
- Tenant MCP config;
- Principal credential;
- Session ownership;
- MCP setup/connect;
- MCP tool discovery.

A dedicated `doctor` CLI is optional; actionable structured errors are mandatory.

## Acceptance criteria

### Time to First Value

A developer following README/starter instructions on the supported baseline should reach the **first real MCP Tool call within 30 minutes**, without reading internal architecture specs.

### First-success concepts

Before first success, the main concepts should be limited to:

1. Tenant
2. Principal
3. MCP config
4. credential/identity mapping

### Isolation must be visible

At minimum:

```text
Acme / Alice -> own Agent + own MCP identity -> allowed
Acme / Bob   -> Alice Session               -> denied
```

A second Tenant must also be present so both sibling-Principal and cross-Tenant separation are visible.

### Copyability

The starter must make it obvious that a real product replaces only small product-owned seams:

- trusted subject resolver;
- Tenant MCP config loader;
- Principal credential/authority loader.

## Explicitly NOT blocking rc.2

These are valuable follow-ups, but they are deliberately excluded from the release gate:

- Redis/Postgres/MySQL production Session Store;
- universal Credential Broker / `Capability-as-Authority` contract;
- generic OAuth/OIDC/token refresh framework;
- Permission/Policy plugin;
- full Audit/OTel product;
- second ERP/direct-business-API integration;
- hostile-code strong isolation;
- MCP Resources/Prompts beyond the pinned Harness consumer seams;
- replacing DSH Web with a custom frontend;
- broad CLI/Desktop packaging unrelated to first SaaS Web success.

If a P0 path genuinely needs one of these, add only the smallest local seam needed; do not turn it into a general abstraction without evidence.

## Documentation changes

- add EN/ZH `docs/scopes/v0.3.0-rc.2*` as the current scope contract;
- update EN/ZH `DIRECTION*` from “next architecture evidence” to “First Product Experience”;
- update EN/ZH docs index;
- correct root README status from “release candidate” to the actually published `0.3.0-rc.1`;
- surface the rc.2 product focus from the project homepage.

## Verification

Scope head: `2f0b514c6fe82a6841d0e329ccce02a855ba3863`

CI run **#284 / `32805619079` — success**:

- ✅ Pinned DSH source identity
- ✅ Package contract — Node 22.19.0
- ✅ Package contract — Node 24
- ✅ Real DSH integration — Node 22.19.0
- ✅ Real DSH integration — Node 24

This confirms the scope/documentation changes do not weaken the current `0.3.0-rc.1` package, installed-artifact or real DSH/MCP contracts.

## Versioning / live-tree rule

The package remains `0.3.0-rc.1` in this PR. The version bump belongs to the later implementation/release-convergence PR.

After rc.2 ships, this scope document should be removed or rewritten around the next current target. Git history preserves the completed scope.