### PR TITLE
release: dsh-multi-tenant 0.4.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Publish alpha package
+name: Publish package
 
 run-name: Publish dsh-multi-tenant from main
 
@@ -65,8 +65,15 @@ jobs:
             exit 1
           fi
           RELEASE_VERSION=$(node -p "require('./packages/multi-tenant/package.json').version")
+          NPM_TAG=$(node -p "require('./packages/multi-tenant/package.json').publishConfig.tag")
           echo "RELEASE_VERSION=$RELEASE_VERSION" >> "$GITHUB_ENV"
-          echo "Publishing dsh-multi-tenant@$RELEASE_VERSION as npm alpha"
+          echo "NPM_TAG=$NPM_TAG" >> "$GITHUB_ENV"
+          echo "Publishing dsh-multi-tenant@$RELEASE_VERSION as npm $NPM_TAG"
+
+          if [ "$NPM_TAG" != "latest" ]; then
+            echo "Stable release workflow requires publishConfig.tag=latest; got $NPM_TAG" >&2
+            exit 1
+          fi
 
           node - <<'NODE'
           const { execFileSync } = require('node:child_process')
@@ -91,10 +98,10 @@ jobs:
       - name: Publish to npm via Trusted Publishing
         if: steps.registry.outputs.publish_needed == 'true'
         working-directory: packages/multi-tenant
-        run: npm publish --access public --provenance --tag alpha
+        run: npm publish --access public --provenance --tag "$NPM_TAG"
 
-      - name: Verify registry artifact and alpha tag
-        run: node scripts/registry-smoke.mjs "$RELEASE_VERSION"
+      - name: Verify registry artifact and dist-tag
+        run: node scripts/registry-smoke.mjs "$RELEASE_VERSION" "$NPM_TAG"
 
       - name: Create matching Git tag and GitHub release
         env:

--- a/README.md
+++ b/README.md
@@ -2,18 +2,18 @@
 
 `dsh-multi-tenant` is a multi-tenant plugin for DeepSeek Harness. It turns an authenticated `(tenantId, principalId)` into an owned Agent resource without exposing or accepting the underlying DSH session identity.
 
-Current line: **`dsh-multi-tenant@0.4.0-alpha.3`**, pinned to DSH **`0.1.2-rc.1`** at commit **`a66e4702047846cdaa10c66c9d3df3951f5ea70d`**. Its matching source tag is **`v0.4.0-alpha.3`**.
+Current release: **`dsh-multi-tenant@0.4.0`**, pinned to DSH **`0.1.2-rc.1`** at commit **`a66e4702047846cdaa10c66c9d3df3951f5ea70d`**. Its matching source tag is **`v0.4.0`**.
 
-Alpha.3 is an integration release for DSH hosts, not a stable compatibility promise. It is ready for product wiring and feedback when the host already owns authentication and accepts the documented single-active-process and logical-isolation boundaries. npm distribution uses the `alpha` dist-tag and does not move `latest`; npm publication and a GitHub prerelease remain explicit distribution operations separate from the source tag.
+`0.4.0` is the first non-prerelease distribution of the clean multi-tenant plugin API and is published on npm's `latest` dist-tag. It is the reviewed, supported entry point for the documented `0.4` surface, not a `1.0`-level promise that the project will never evolve. Incompatible changes must be explicitly versioned and documented. DSH `0.1.2-rc.1` is still an upstream release candidate and remains an exact peer; a later DSH RC or stable build requires an explicit compatibility release rather than entering silently.
 
 The plugin owns Principal-scoped Agent authorization, a durable SQLite Agent directory, capability leases, and DSH Agent/MCP lifecycle. The host still owns authentication, secret storage, and any strong process/container isolation.
 
-Alpha.3 keeps the two operational contracts completed in alpha.2 on top of the clean `0.4` architecture:
+The stable release carries forward the two operational contracts completed during the alpha line on top of the clean `0.4` architecture:
 
 - abandoned SQLite `provisioning` records deterministically become terminal `failed` before the service is exposed;
 - MCP, Secret, runtime-partition, and DSH setup providers receive cooperative lifecycle cancellation and are validated before use.
 
-The DSH alpha.5-to-RC.1 upstream delta contains release metadata only: no Agent, Session, persistence, MCP, or Tools source changed. Alpha.3 nevertheless advances every direct DSH peer/development dependency and the source-identity gate to the exact RC.1 release, then reruns the full native lifecycle and packed-consumer evidence.
+The DSH alpha.5-to-RC.1 upstream delta contains release metadata only: no Agent, Session, persistence, MCP, or Tools source changed. `0.4.0` nevertheless fixes every direct DSH peer/development dependency and the source-identity gate to the exact RC.1 release, then reruns the full native lifecycle and packed-consumer evidence.
 
 It deliberately does not become a public authentication gateway, distributed ownership system, sandbox, or process supervisor. Those responsibilities stay with the host or with explicitly implemented provider protocols.
 
@@ -33,4 +33,4 @@ authenticated request
 
 The default shared runtime provides logical isolation, not a hostile-code security boundary. Stock DSH `/api` remains private/administrative and is not a public multi-tenant ingress.
 
-Alpha.2 passes a service lifecycle `AbortSignal` through MCP, Secret, runtime-partition, and DSH setup, completing [#50](https://github.com/GuoMonth/dsh-multi-tenant/issues/50). Shutdown remains cooperative: host code that ignores abort or never settles can still delay completion, and the plugin adds no forced termination or default timeout.
+The lifecycle contract passes a service `AbortSignal` through MCP, Secret, runtime-partition, and DSH setup, as completed in [#50](https://github.com/GuoMonth/dsh-multi-tenant/issues/50). Shutdown remains cooperative: host code that ignores abort or never settles can still delay completion, and the plugin adds no forced termination or default timeout.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -2,18 +2,18 @@
 
 `dsh-multi-tenant` 是 DeepSeek Harness 的多租户插件。它把宿主认证得到的 `(tenantId, principalId)` 转换为有明确所有者的 Agent 资源，不接受也不暴露底层 DSH session identity。
 
-当前版本：**`dsh-multi-tenant@0.4.0-alpha.3`**，精确固定 DSH **`0.1.2-rc.1`** 和 commit **`a66e4702047846cdaa10c66c9d3df3951f5ea70d`**。对应的源码 tag 是 **`v0.4.0-alpha.3`**。
+当前正式版：**`dsh-multi-tenant@0.4.0`**，精确固定 DSH **`0.1.2-rc.1`** 和 commit **`a66e4702047846cdaa10c66c9d3df3951f5ea70d`**。对应的源码 tag 是 **`v0.4.0`**。
 
-Alpha.3 是供 DSH 宿主集成和反馈使用的预发布版本，不承诺稳定兼容。适合已经由宿主负责认证，并接受文档所述 single-active-process 与逻辑隔离边界的产品接入。npm 分发只使用 `alpha` dist-tag，不移动 `latest`；npm 发布和 GitHub prerelease 是独立于源码 tag 的显式分发操作。
+`0.4.0` 是全新多租户插件 API 首个不带 prerelease 标识的正式分发版本，通过 npm `latest` dist-tag 发布。它是当前已审查、受支持的 `0.4` 公共入口，不等于 `1.0` 级别的永久兼容承诺；不兼容变更必须通过新版本和文档显式说明。DSH `0.1.2-rc.1` 本身仍是上游 RC，并作为 exact peer 固定；后续 DSH RC 或 stable 不会静默进入依赖图，必须通过新的兼容版本显式升级。
 
 插件负责 Principal-scoped Agent 授权、持久 SQLite Agent Directory、能力租约，以及 DSH Agent/MCP 生命周期。宿主仍负责认证、Secret 存储，以及需要时的进程/容器级强隔离。
 
-Alpha.3 保留 alpha.2 在全新 `0.4` 架构上补齐的两个运行契约：
+正式版保留 alpha 阶段在全新 `0.4` 架构上补齐的两个运行契约：
 
 - 遗留的 SQLite `provisioning` 记录会在 service 对外可用前确定性地进入终态 `failed`；
 - MCP、Secret、runtime-partition 和 DSH setup provider 会收到合作式生命周期取消信号，返回结果在使用前经过校验。
 
-DSH alpha.5 到 RC.1 的上游差异只有 release metadata，没有修改 Agent、Session、persistence、MCP 或 Tools 源码。Alpha.3 仍会把全部直接 DSH peer/dev dependency 和源码身份门禁精确推进到 RC.1，并重新执行完整原生生命周期与打包消费者证据。
+DSH alpha.5 到 RC.1 的上游差异只有 release metadata，没有修改 Agent、Session、persistence、MCP 或 Tools 源码。`0.4.0` 仍把全部直接 DSH peer/dev dependency 和源码身份门禁精确固定到 RC.1，并重新执行完整原生生命周期与打包消费者证据。
 
 它不会扩张成公网认证入口、分布式所有权系统、sandbox 或进程管理器。这些职责继续由宿主承担，或通过明确的 provider 协议实现。
 
@@ -33,4 +33,4 @@ DSH alpha.5 到 RC.1 的上游差异只有 release metadata，没有修改 Agent
 
 默认 shared runtime 只提供逻辑隔离，不是 hostile-code 安全边界。Stock DSH `/api` 保持私有/管理用途，不是公网多租户入口。
 
-Alpha.2 会把 service lifecycle `AbortSignal` 传入 MCP、Secret、runtime-partition 和 DSH setup，完成 [#50](https://github.com/GuoMonth/dsh-multi-tenant/issues/50)。Shutdown 仍是 cooperative 的：忽略 abort 或永不结束的宿主代码仍可能延迟完成，插件不会增加强制终止或默认 timeout。
+生命周期契约会把 service `AbortSignal` 传入 MCP、Secret、runtime-partition 和 DSH setup，该能力已在 [#50](https://github.com/GuoMonth/dsh-multi-tenant/issues/50) 完成。Shutdown 仍是 cooperative 的：忽略 abort 或永不结束的宿主代码仍可能延迟完成，插件不会增加强制终止或默认 timeout。

--- a/docs/reference/compatibility.md
+++ b/docs/reference/compatibility.md
@@ -1,16 +1,16 @@
 # Compatibility
 
-`dsh-multi-tenant@0.4.0-alpha.3` targets Node `^22.19.0 || >=24.0.0` and exactly DSH `0.1.2-rc.1` (release source commit `a66e4702047846cdaa10c66c9d3df3951f5ea70d`). Its DSH peer and development dependencies are exact, not ranges.
+`dsh-multi-tenant@0.4.0` targets Node `^22.19.0 || >=24.0.0` and exactly DSH `0.1.2-rc.1` (release source commit `a66e4702047846cdaa10c66c9d3df3951f5ea70d`). Its DSH peer and development dependencies are exact, not ranges.
 
-Alpha.3 is an integration prerelease with matching source tag `v0.4.0-alpha.3`, distributed on npm only through the `alpha` dist-tag. It does not claim API stability and must not replace the npm `latest` channel.
+`0.4.0` is the first non-prerelease distribution of this plugin's clean public surface, with matching source tag `v0.4.0` and npm `latest` dist-tag. It is not a `1.0`-level indefinite compatibility promise; incompatible changes must be explicitly versioned and documented. DSH `0.1.2-rc.1` is still an upstream release candidate: the plugin release does not relabel DSH or imply compatibility with later DSH prereleases. Exact DSH upgrades are reviewed and released explicitly.
 
-The exact [alpha.5-to-RC.1 upstream comparison](https://github.com/deepseek-ai/deepseek-harness/compare/dsh-v0.1.2-alpha.5...dsh-v0.1.2-rc.1) contains two release commits and only package-version metadata changes. Agent registry/loop, core Session, persistence, Session projection, MCP client, Tools, and API/Web source are unchanged. Even so, alpha.3 advances every direct DSH peer/development dependency and the source-identity gate together; RC.1 is its only supported DSH baseline.
+The exact [alpha.5-to-RC.1 upstream comparison](https://github.com/deepseek-ai/deepseek-harness/compare/dsh-v0.1.2-alpha.5...dsh-v0.1.2-rc.1) contains two release commits and only package-version metadata changes. Agent registry/loop, core Session, persistence, Session projection, MCP client, Tools, and API/Web source are unchanged. Even so, `0.4.0` advances every direct DSH peer/development dependency and the source-identity gate together; RC.1 is its only supported DSH baseline.
 
 The earlier alpha.4-to-alpha.5 review found functional changes in storage-domain compatibility, JSON storage, and persisted session-projection cache handling. Those changes remain part of RC.1 and continue to be exercised by restart and real lifecycle tests.
 
 `0.4` is a clean product line. It has no source, data, or API compatibility promise with `0.3`: Session claims, credentials, Operations, RuntimeComposition, compatibility facades, and the old SQLite ownership table are not read or migrated.
 
-Alpha.2 makes the lifecycle `AbortSignal` arguments on MCP, Secret, runtime-partition, and DSH driver contracts required. This is an intentional prerelease source break: host providers must accept the signal and cooperate with shutdown where possible.
+The lifecycle `AbortSignal` arguments on MCP, Secret, runtime-partition, and DSH driver contracts are required. Host providers must accept the signal and cooperate with shutdown where possible.
 
 Supported public code/API subpaths are the package root, `/mcp`, `/sqlite`, `/web`, `/testing`, and `/starter`. `./cordis.patch.yml` is additionally exported for the DSH loader; it is configuration data rather than a JavaScript API. Anything else is private.
 

--- a/docs/reference/compatibility.zh-CN.md
+++ b/docs/reference/compatibility.zh-CN.md
@@ -1,16 +1,16 @@
 # 兼容性
 
-`dsh-multi-tenant@0.4.0-alpha.3` 支持 Node `^22.19.0 || >=24.0.0`，并精确固定 DSH `0.1.2-rc.1`（release source commit `a66e4702047846cdaa10c66c9d3df3951f5ea70d`）。DSH peer/dev dependency 都是 exact version，不使用范围。
+`dsh-multi-tenant@0.4.0` 支持 Node `^22.19.0 || >=24.0.0`，并精确固定 DSH `0.1.2-rc.1`（release source commit `a66e4702047846cdaa10c66c9d3df3951f5ea70d`）。DSH peer/dev dependency 都是 exact version，不使用范围。
 
-Alpha.3 是用于集成的预发布版本，对应源码 tag 为 `v0.4.0-alpha.3`，npm 只通过 `alpha` dist-tag 分发。它不承诺 API 稳定，也不得替换 npm `latest` channel。
+`0.4.0` 是本插件全新公共面首个不带 prerelease 标识的正式分发版本，对应源码 tag 为 `v0.4.0`，通过 npm `latest` dist-tag 发布。它不代表 `1.0` 级别的永久兼容承诺；不兼容变更必须通过新版本和文档显式说明。DSH `0.1.2-rc.1` 本身仍是上游 RC：插件正式版不会改变 DSH 的版本性质，也不意味着兼容后续 DSH prerelease。每次 DSH 精确升级都必须单独审查和发布。
 
-精确的 [alpha.5 到 RC.1 上游比较](https://github.com/deepseek-ai/deepseek-harness/compare/dsh-v0.1.2-alpha.5...dsh-v0.1.2-rc.1) 只有两个 release commit，变更全部是 package version metadata。Agent registry/loop、核心 Session、persistence、Session projection、MCP client、Tools 和 API/Web 源码均未变化。即便如此，alpha.3 仍会同时推进全部直接 DSH peer/dev dependency 和源码身份门禁；RC.1 是它唯一支持的 DSH 基线。
+精确的 [alpha.5 到 RC.1 上游比较](https://github.com/deepseek-ai/deepseek-harness/compare/dsh-v0.1.2-alpha.5...dsh-v0.1.2-rc.1) 只有两个 release commit，变更全部是 package version metadata。Agent registry/loop、核心 Session、persistence、Session projection、MCP client、Tools 和 API/Web 源码均未变化。即便如此，`0.4.0` 仍同时推进全部直接 DSH peer/dev dependency 和源码身份门禁；RC.1 是它唯一支持的 DSH 基线。
 
 此前 alpha.4 到 alpha.5 的源码审查确认了 storage-domain 兼容、JSON storage 和持久化 session-projection cache 的有效变化。这些变化已经进入 RC.1，并继续由 restart 和真实生命周期测试覆盖。
 
 `0.4` 是全新产品线，不承诺与 `0.3` 保持源码、数据或 API 兼容。Session claim、credential、Operation、RuntimeComposition、兼容 facade 和旧 SQLite ownership table 都不会被读取或迁移。
 
-Alpha.2 将 MCP、Secret、runtime-partition 和 DSH driver 契约中的 lifecycle `AbortSignal` 参数改为必填。这是有意的 prerelease 源码破坏：宿主 provider 必须接收 signal，并在可行时合作式响应 shutdown。
+MCP、Secret、runtime-partition 和 DSH driver 契约中的 lifecycle `AbortSignal` 参数是必填项；宿主 provider 必须接收 signal，并在可行时合作式响应 shutdown。
 
 支持的公共代码/API 子路径只有 package root、`/mcp`、`/sqlite`、`/web`、`/testing`、`/starter`。此外还为 DSH loader 公开 `./cordis.patch.yml`；它是配置数据，不是 JavaScript API。其余内容都是 private。
 

--- a/docs/reference/release.md
+++ b/docs/reference/release.md
@@ -1,6 +1,6 @@
 # Release checks
 
-The current release identity is `dsh-multi-tenant@0.4.0-alpha.3` with matching Git tag `v0.4.0-alpha.3`. npm distribution uses the `alpha` dist-tag; it must not update `latest`.
+The current release identity is `dsh-multi-tenant@0.4.0` with matching Git tag `v0.4.0`. npm distribution uses the `latest` dist-tag. Its only supported Harness baseline is DSH `0.1.2-rc.1` at commit `a66e4702047846cdaa10c66c9d3df3951f5ea70d`.
 
 ```bash
 pnpm install --frozen-lockfile
@@ -13,6 +13,6 @@ CI repeats the checks on Node 22.19 and Node 24 and separately checks out DSH co
 
 Project workflows reject mutable third-party `uses:` references during preflight and pin reviewed actions to full commit SHAs. pnpm enforces a 1,440-minute release-age delay; only exact packages from the reviewed DSH RC.1 source are excluded. The official JSONL test backend is dev-only, and its `koffi` install is the only allowed native dependency build besides the explicitly denied redundant `esbuild` postinstall.
 
-These commands do not publish npm, create a Git tag, or create a GitHub Release. The source tag, npm artifact, and GitHub prerelease are independently verifiable release artifacts.
+These commands do not publish npm, create a Git tag, or create a GitHub Release. The source tag, npm artifact, and GitHub Release are independently verifiable release artifacts.
 
-Distribution remains an explicit manual workflow action and requires a successful CI run for the exact `main` commit being released. The workflow publishes with npm Trusted Publishing and provenance, verifies the registry artifact and `alpha` dist-tag, reuses a matching source tag or creates it when absent, and creates a matching GitHub prerelease. It fails if an existing tag identifies a different commit.
+Distribution remains an explicit manual workflow action and requires a successful CI run for the exact `main` commit being released. The workflow publishes with npm Trusted Publishing and provenance, verifies the registry artifact and `latest` dist-tag, reuses a matching source tag or creates it when absent, and creates a matching GitHub Release. It fails if an existing tag identifies a different commit.

--- a/docs/reference/release.zh-CN.md
+++ b/docs/reference/release.zh-CN.md
@@ -1,6 +1,6 @@
 # 发布检查
 
-当前 release identity 是 `dsh-multi-tenant@0.4.0-alpha.3`，对应 Git tag 为 `v0.4.0-alpha.3`。npm 分发使用 `alpha` dist-tag，不得更新 `latest`。
+当前 release identity 是 `dsh-multi-tenant@0.4.0`，对应 Git tag 为 `v0.4.0`。npm 分发使用 `latest` dist-tag。唯一支持的 Harness 基线是 DSH `0.1.2-rc.1`，对应 commit `a66e4702047846cdaa10c66c9d3df3951f5ea70d`。
 
 ```bash
 pnpm install --frozen-lockfile
@@ -13,6 +13,6 @@ CI 在 Node 22.19 和 Node 24 上重复执行，并单独 checkout DSH commit `a
 
 Preflight 会拒绝项目 workflow 中任何可变的第三方 `uses:`，已审核 Action 全部固定到完整 commit SHA。pnpm 明确执行 1,440 分钟 release-age 延迟，只有已审核 DSH RC.1 源码对应的 exact package 可以例外。官方 JSONL 测试 backend 仅是 dev dependency；其 `koffi` install 是唯一允许的 native dependency build，冗余的 `esbuild` postinstall 仍被明确拒绝。
 
-这些命令不会发布 npm、创建 Git tag 或创建 GitHub Release。源码 tag、npm artifact 和 GitHub prerelease 是可以分别核验的 release 产物。
+这些命令不会发布 npm、创建 Git tag 或创建 GitHub Release。源码 tag、npm artifact 和 GitHub Release 是可以分别核验的 release 产物。
 
-分发必须显式手动触发 workflow，并要求待发布的精确 `main` commit 已有成功的 CI 结果。该 workflow 通过 npm Trusted Publishing 和 provenance 发布，验证 registry artifact 与 `alpha` dist-tag，复用指向同一提交的源码 tag（不存在时才创建），最后创建对应 GitHub prerelease；如果已有 tag 指向其他提交则直接失败。
+分发必须显式手动触发 workflow，并要求待发布的精确 `main` commit 已有成功的 CI 结果。该 workflow 通过 npm Trusted Publishing 和 provenance 发布，验证 registry artifact 与 `latest` dist-tag，复用指向同一提交的源码 tag（不存在时才创建），最后创建对应 GitHub Release；如果已有 tag 指向其他提交则直接失败。

--- a/docs/releases/v0.4.0.md
+++ b/docs/releases/v0.4.0.md
@@ -1,0 +1,44 @@
+# dsh-multi-tenant 0.4.0
+
+Release posture: **first non-prerelease release of the clean DSH multi-tenant plugin line**. The matching source tag is `v0.4.0`, and npm distribution uses the `latest` dist-tag.
+
+## DSH compatibility baseline
+
+`dsh-multi-tenant@0.4.0` supports exactly DSH `0.1.2-rc.1` at release commit `a66e4702047846cdaa10c66c9d3df3951f5ea70d`. Every direct DSH peer and development dependency is exact, and the lockfile gate rejects any different resolved DSH version.
+
+DSH `0.1.2-rc.1` is an upstream release candidate, not a stable DSH release. This plugin release does not relabel it or claim forward compatibility with later RC or stable builds. A DSH baseline change requires a new plugin compatibility release and the same source-identity and lifecycle evidence.
+
+The official [DSH alpha.5-to-RC.1 comparison](https://github.com/deepseek-ai/deepseek-harness/compare/dsh-v0.1.2-alpha.5...dsh-v0.1.2-rc.1) contains only release metadata changes. Agent registry/loop, Session, persistence, Session projection, MCP client, Tools, Cordis integration, and API/Web source are unchanged across that delta.
+
+## Stable release decision
+
+The documented `0.4` plugin API, provider contracts, SQLite Agent Directory schema, Web input surface, and lifecycle semantics are the reviewed public contract for this release. `0.4.0` is not a `1.0`-level promise against future evolution; incompatible changes must be explicitly versioned and documented instead of entering an existing artifact silently.
+
+The project remains specifically a DSH multi-tenant plugin. It owns the path from a server-minted Principal to a Principal-scoped Agent resource and controlled DSH Agent/MCP execution. It does not grow into an authentication gateway, distributed ownership coordinator, sandbox, or process supervisor.
+
+`0.4` is intentionally incompatible with `0.3`. Session claims, credentials, Operations, RuntimeComposition, compatibility facades, and the old ownership table were removed and are not migrated. Users of the `0.4.0-alpha.*` line can adopt `0.4.0` without a public API or SQLite schema change.
+
+## Evidence
+
+The release contract verifies frozen installation, exact DSH peers and source identity, Node 22.19 and Node 24, type declarations, all unit/contract/Web tests, native DSH AgentLoop + JSONL + official MCP create/restart/resume/delete, SQLite restart/CAS/default permissions and abandoned-provisioning recovery, lifecycle cancellation, secret-leak probes, and a clean installed-tarball consumer.
+
+The release workflow requires successful CI for the exact `main` commit, publishes through npm Trusted Publishing with provenance, verifies `dsh-multi-tenant@0.4.0` and the `latest` dist-tag, and creates the matching non-prerelease Git tag and GitHub Release.
+
+## Explicit limits
+
+- The built-in SQLite directory is local, single-node, and requires the host to guarantee a single active process.
+- The bundled shared runtime provides logical isolation, not a hostile-code boundary.
+- Authentication, secret storage, configured-path ACLs, and the truth of a strong-isolation provider remain host responsibilities.
+- Stock DSH `/api` remains private/administrative; no public Typert ingress is provided.
+- Delete does not physically erase DSH logs, and cooperative shutdown cannot force unresponsive host code to stop.
+- `0.3` data and prior unpublished candidate schemas are not migrated.
+
+## 中文复盘
+
+`dsh-multi-tenant@0.4.0` 是全新 DSH 多租户插件产品线首个不带 prerelease 标识的正式分发版本，对应源码 tag `v0.4.0`，通过 npm `latest` dist-tag 发布。它是当前已审查、受支持的公共入口，不等于 `1.0` 级别的永久兼容承诺；不兼容变更必须通过新版本和文档显式说明。
+
+本版本唯一支持的 Harness 基线是 DSH `0.1.2-rc.1`，对应 release commit `a66e4702047846cdaa10c66c9d3df3951f5ea70d`。所有直接 DSH peer/dev dependency 与 lockfile resolution 都使用精确版本。DSH RC.1 本身仍是上游预发布版本；插件正式版不会把它描述成 DSH 稳定版，也不承诺兼容后续 RC 或 stable。升级 DSH 必须通过新的插件兼容版本、源码身份核验和真实生命周期门禁。
+
+“正式版”承诺的是插件已经公开的 `0.4` API、provider 契约、SQLite Agent Directory schema、Web 输入和生命周期语义。项目定位不变：只负责从服务端 Principal 到 Principal-scoped Agent 资源及受控 DSH Agent/MCP 执行，不扩张成认证网关、分布式协调器、sandbox 或进程管理器。
+
+`0.4` 不兼容 `0.3`，也不迁移旧数据；但从 `0.4.0-alpha.*` 升级到 `0.4.0` 不修改公共 API 或 SQLite schema。默认边界继续保持：本地 single-node/single-active-process SQLite、进程内逻辑隔离、宿主负责认证与强隔离、公网不得使用 stock DSH `/api`、删除不物理擦除 DSH 日志、合作式取消不能强制终止不响应的宿主代码。

--- a/packages/multi-tenant/README.md
+++ b/packages/multi-tenant/README.md
@@ -2,23 +2,23 @@
 
 # dsh-multi-tenant
 
-`dsh-multi-tenant@0.4.0-alpha.3` is a DSH multi-tenant plugin for Node 22.19+ and Node 24. It is pinned to `@deepseek-ai/*@0.1.2-rc.1` at upstream commit `a66e4702047846cdaa10c66c9d3df3951f5ea70d`.
+`dsh-multi-tenant@0.4.0` is a DSH multi-tenant plugin for Node 22.19+ and Node 24. It is pinned to `@deepseek-ai/*@0.1.2-rc.1` at upstream commit `a66e4702047846cdaa10c66c9d3df3951f5ea70d`.
 
-This alpha is for host integration and contract feedback. It provides a compact authority path from a server-minted Principal to an owned DSH Agent, durable local directory, and Agent-scoped MCP lifecycle. It assumes the host already provides trustworthy authentication and owns any isolation stronger than the bundled logical boundary.
+This is the first non-prerelease distribution of the clean `0.4` plugin surface. It provides a compact authority path from a server-minted Principal to an owned DSH Agent, durable local directory, and Agent-scoped MCP lifecycle. It assumes the host already provides trustworthy authentication and owns any isolation stronger than the bundled logical boundary.
 
 ## Install
 
-When the npm distribution is available, use the alpha channel or pin the reviewed build exactly:
+Install the stable channel, or pin this reviewed build exactly:
 
 ```bash
-pnpm add dsh-multi-tenant@alpha
-# or pin the reviewed prerelease exactly
-pnpm add dsh-multi-tenant@0.4.0-alpha.3
+pnpm add dsh-multi-tenant
+# or pin the reviewed release exactly
+pnpm add dsh-multi-tenant@0.4.0
 ```
 
-The `alpha` channel may introduce source-breaking provider contract changes before `0.4.0`. Use the exact version when reproducible deployments matter. The matching source tag is `v0.4.0-alpha.3`; publishing the npm artifact and GitHub prerelease are separate explicit release operations.
+The matching source tag is `v0.4.0`, and npm publishes it on the `latest` dist-tag. This is the reviewed, supported entry point for the documented `0.4` API and lifecycle contract, not a `1.0`-level promise against future evolution. Incompatible changes must be explicitly versioned and documented. DSH `0.1.2-rc.1` remains an upstream release candidate and an exact peer dependency; later DSH builds require an explicit plugin compatibility release.
 
-DSH RC.1 changes only release metadata relative to alpha.5, but alpha.3 intentionally supports RC.1 alone. All direct DSH peers and development dependencies are exact so an unreviewed Harness build cannot silently enter the runtime graph.
+DSH RC.1 changes only release metadata relative to alpha.5, but `0.4.0` intentionally supports RC.1 alone. All direct DSH peers and development dependencies are exact so an unreviewed Harness build cannot silently enter the runtime graph.
 
 Load the plugin after the DSH `agents` and `tools` services. With no host replacements it uses `.dsh-multi-tenant/agents.sqlite`, an empty MCP declaration, and DSH's shared in-process runtime:
 
@@ -134,7 +134,7 @@ Routes are `POST/GET /_dsh-multi-tenant/agents` and `GET/DELETE /_dsh-multi-tena
 - SQLite records use CAS revisions and Principal-scoped SQL. An authorized delete immediately invalidates active callback views and reserves a serialized barrier; later `withAgent()` calls cannot overtake it and see only not-found after the scrubbed tombstone is committed.
 - Provisioning is unpublished until DSH setup and the database ready transition both succeed.
 - Per-Agent create/resume/refresh/delete is serialized; concurrent opens single-flight; plugin shutdown cancels and drains every owned handle.
-- The alpha.2 lifecycle contract, retained in alpha.3, propagates abort through MCP, Secret, RuntimePartition, and DSH setup and validates provider results before use. Drain remains cooperative: code that ignores abort or never settles can delay delete or shutdown indefinitely; forced interruption and arbitrary default timeouts are out of scope.
+- The lifecycle contract propagates abort through MCP, Secret, RuntimePartition, and DSH setup and validates provider results before use. Drain remains cooperative: code that ignores abort or never settles can delay delete or shutdown indefinitely; forced interruption and arbitrary default timeouts are out of scope.
 - A configured `strong` minimum fails closed before DSH Agent creation when the provider offers only `logical` isolation.
 - `TenantAgentRepository`, `TenantMcpProvider`, `SecretProvider`, `RuntimePartitionProvider`, and `DshRuntimeDriver` are the host replacement protocols. They compose through Cordis services; there is no second DI system.
 - The bundled shared provider is process-local logical separation. It does not isolate hostile plugins, tools, filesystem access, subprocesses, memory, or network traffic.

--- a/packages/multi-tenant/README.zh-CN.md
+++ b/packages/multi-tenant/README.zh-CN.md
@@ -2,23 +2,23 @@
 
 # dsh-multi-tenant
 
-`dsh-multi-tenant@0.4.0-alpha.3` 是面向 Node 22.19+ / Node 24 的 DSH 多租户插件，精确固定 `@deepseek-ai/*@0.1.2-rc.1` 和上游 commit `a66e4702047846cdaa10c66c9d3df3951f5ea70d`。
+`dsh-multi-tenant@0.4.0` 是面向 Node 22.19+ / Node 24 的 DSH 多租户插件，精确固定 `@deepseek-ai/*@0.1.2-rc.1` 和上游 commit `a66e4702047846cdaa10c66c9d3df3951f5ea70d`。
 
-这个 alpha 用于宿主集成和契约反馈。它提供一条精简的 authority path：从服务端创建的 Principal，到有明确所有者的 DSH Agent、持久本地 Directory 和 Agent-scoped MCP 生命周期。它假定宿主已经提供可信认证，并负责强于默认逻辑边界的隔离。
+这是全新 `0.4` 插件公共面的首个不带 prerelease 标识的正式分发版本。它提供一条精简的 authority path：从服务端创建的 Principal，到有明确所有者的 DSH Agent、持久本地 Directory 和 Agent-scoped MCP 生命周期。它假定宿主已经提供可信认证，并负责强于默认逻辑边界的隔离。
 
 ## 安装
 
-npm 分发产物可用后，可以使用 alpha channel，或精确固定本次已审查的构建：
+npm 可以直接安装稳定通道，也可以精确固定本次已审查的版本：
 
 ```bash
-pnpm add dsh-multi-tenant@alpha
-# 或精确固定本次已审查的预发布版本
-pnpm add dsh-multi-tenant@0.4.0-alpha.3
+pnpm add dsh-multi-tenant
+# 或精确固定本次已审查的正式版本
+pnpm add dsh-multi-tenant@0.4.0
 ```
 
-在 `0.4.0` 稳定版之前，`alpha` channel 仍可能引入 provider 契约的源码破坏；需要可复现部署时应固定精确版本。对应的源码 tag 是 `v0.4.0-alpha.3`；npm artifact 和 GitHub prerelease 的发布仍是独立的显式 release 操作。
+对应源码 tag 是 `v0.4.0`，npm 使用 `latest` dist-tag。它是当前已审查、受支持的 `0.4` API 与生命周期契约入口，不等于 `1.0` 级别的永久兼容承诺；不兼容变更必须通过新版本和文档显式说明。DSH `0.1.2-rc.1` 本身仍是上游 RC，并保持 exact peer。升级到后续 DSH 版本需要新的插件兼容版本，不会静默发生。
 
-DSH RC.1 相对 alpha.5 只修改了 release metadata，但 alpha.3 有意只支持 RC.1。全部直接 DSH peer/dev dependency 都使用精确版本，未经审查的 Harness 构建不会静默进入 runtime graph。
+DSH RC.1 相对 alpha.5 只修改了 release metadata，但 `0.4.0` 有意只支持 RC.1。全部直接 DSH peer/dev dependency 都使用精确版本，未经审查的 Harness 构建不会静默进入 runtime graph。
 
 在 DSH 的 `agents` 和 `tools` service 之后加载。宿主没有提供替代实现时，插件使用 `.dsh-multi-tenant/agents.sqlite`、空 MCP 声明和 DSH 进程内 shared runtime：
 
@@ -126,7 +126,7 @@ mountMultiTenantWeb(ctx, ctx.multiTenant, {
 - SQLite 使用 CAS revision 和 Principal-scoped SQL；已授权删除会立即使 active callback view 失效并预留串行屏障，后发 `withAgent()` 不能越过删除，只会在已清理的 tombstone 提交后得到 not-found。
 - DSH setup 和数据库 ready transition 都成功后，Agent 才会公开。
 - 每个 Agent 的 create/resume/refresh/delete 串行；并发打开 single-flight；插件关闭会 cancel 并 drain 全部 handle。
-- Alpha.3 保留 alpha.2 的生命周期契约：把 abort 传入 MCP、Secret、RuntimePartition 和 DSH setup，并在使用前校验 provider 结果。Drain 仍是 cooperative 的：忽略 abort 或永不结束的代码可能无限延迟 delete/shutdown；强制中断和任意默认 timeout 不在范围内。
+- 生命周期契约会把 abort 传入 MCP、Secret、RuntimePartition 和 DSH setup，并在使用前校验 provider 结果。Drain 仍是 cooperative 的：忽略 abort 或永不结束的代码可能无限延迟 delete/shutdown；强制中断和任意默认 timeout 不在范围内。
 - 最低隔离配置为 `strong` 时，共享逻辑 provider 会在创建 DSH Agent 前 fail closed。
 - `TenantAgentRepository`、`TenantMcpProvider`、`SecretProvider`、`RuntimePartitionProvider`、`DshRuntimeDriver` 是宿主替换协议，统一通过 Cordis service 组合。
 - 默认 shared provider 只是进程内逻辑隔离，不能隔离 hostile plugin/tool、filesystem、subprocess、内存或网络。

--- a/packages/multi-tenant/package.json
+++ b/packages/multi-tenant/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-multi-tenant",
-  "version": "0.4.0-alpha.3",
+  "version": "0.4.0",
   "description": "A DSH-native multi-tenant plugin with trusted Principal contexts, Principal-scoped Agent resources, durable local ownership, and Agent-scoped MCP capabilities.",
   "author": "DeepSeek Harness community contributors",
   "license": "MIT",
@@ -14,7 +14,7 @@
   },
   "publishConfig": {
     "access": "public",
-    "tag": "alpha",
+    "tag": "latest",
     "provenance": true
   },
   "sideEffects": false,

--- a/scripts/registry-smoke.mjs
+++ b/scripts/registry-smoke.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-/** Post-publication verification for the exact alpha artifact. */
+/** Post-publication verification for the exact artifact and npm dist-tag. */
 import { execFileSync } from 'node:child_process'
 import { fileURLToPath } from 'node:url'
 
@@ -7,9 +7,10 @@ const PACKAGE_NAME = 'dsh-multi-tenant'
 const EXPECTED_REPOSITORY = 'https://github.com/guomonth/dsh-multi-tenant'
 const root = fileURLToPath(new URL('..', import.meta.url))
 const version = process.argv[2]
+const distTag = process.argv[3]
 
-if (!version) {
-  console.error('usage: node scripts/registry-smoke.mjs <version>')
+if (!version || !distTag) {
+  console.error('usage: node scripts/registry-smoke.mjs <version> <dist-tag>')
   process.exit(2)
 }
 
@@ -42,9 +43,9 @@ for (let attempt = 1; attempt <= 10; attempt++) {
 }
 if (registryVersion !== version) throw new Error(`registry did not resolve ${PACKAGE_NAME}@${version}`)
 
-const alphaVersion = npmJson(['view', `${PACKAGE_NAME}@alpha`, 'version'])
-if (alphaVersion !== version) {
-  throw new Error(`npm alpha dist-tag resolves to ${String(alphaVersion)}, expected ${version}`)
+const taggedVersion = npmJson(['view', `${PACKAGE_NAME}@${distTag}`, 'version'])
+if (taggedVersion !== version) {
+  throw new Error(`npm ${distTag} dist-tag resolves to ${String(taggedVersion)}, expected ${version}`)
 }
 
 const repository = npmJson(['view', `${PACKAGE_NAME}@${version}`, 'repository.url'])
@@ -65,4 +66,4 @@ execFileSync('node', [
   stdio: ['ignore', 'inherit', 'inherit'],
 })
 
-console.log(`registry smoke passed: ${PACKAGE_NAME}@${version}; alpha=${version}; integrity=${integrity.slice(0, 20)}…`)
+console.log(`registry smoke passed: ${PACKAGE_NAME}@${version}; ${distTag}=${version}; integrity=${integrity.slice(0, 20)}…`)

--- a/scripts/release-preflight.mjs
+++ b/scripts/release-preflight.mjs
@@ -7,7 +7,7 @@ const root = fileURLToPath(new URL('..', import.meta.url))
 const pkg = JSON.parse(readFileSync(join(root, 'packages/multi-tenant/package.json'), 'utf8'))
 const rootPkg = JSON.parse(readFileSync(join(root, 'package.json'), 'utf8'))
 const errors = []
-const version = '0.4.0-alpha.3'
+const version = '0.4.0'
 const releaseTag = `v${version}`
 const requiredExports = ['.', './mcp', './sqlite', './web', './testing', './starter', './cordis.patch.yml']
 
@@ -19,8 +19,8 @@ function filesBelow(directory) {
 }
 
 if (pkg.name !== 'dsh-multi-tenant' || pkg.version !== version) errors.push('release identity mismatch')
-if (pkg.publishConfig?.access !== 'public' || pkg.publishConfig?.tag !== 'alpha' || pkg.publishConfig?.provenance !== true) {
-  errors.push('publishConfig must be public alpha with provenance')
+if (pkg.publishConfig?.access !== 'public' || pkg.publishConfig?.tag !== 'latest' || pkg.publishConfig?.provenance !== true) {
+  errors.push('publishConfig must be public latest with provenance')
 }
 if (pkg.license !== 'MIT') errors.push('license must be MIT')
 if (pkg.dsh?.bundle?.patch !== './cordis.patch.yml') errors.push('DSH bundle patch missing')
@@ -30,8 +30,8 @@ for (const file of ['dist', 'README.md', 'README.zh-CN.md', 'LICENSE', 'cordis.p
 }
 
 for (const [path, markers] of Object.entries({
-  'README.md': [version, releaseTag, 'alpha` dist-tag', 'logical isolation', 'DSH `/api`', 'issues/50'],
-  'README.zh-CN.md': [version, releaseTag, 'alpha` dist-tag', '逻辑隔离', 'Stock DSH `/api`', 'issues/50'],
+  'README.md': [version, releaseTag, '`latest` dist-tag', 'DSH `0.1.2-rc.1`', 'logical isolation', 'DSH `/api`', 'issues/50'],
+  'README.zh-CN.md': [version, releaseTag, '`latest` dist-tag', 'DSH `0.1.2-rc.1`', '逻辑隔离', 'Stock DSH `/api`', 'issues/50'],
   'packages/multi-tenant/README.md': [version, releaseTag, '## Minimal API', '## Real MCP configuration', '## Guarantees and boundaries', 'single-active-process', 'issues/49', 'issues/50', './cordis.patch.yml'],
   'packages/multi-tenant/README.zh-CN.md': [version, releaseTag, '## 最小 API', '## 真实 MCP', '## 保证与边界', 'single-active-process', 'issues/49', 'issues/50', './cordis.patch.yml'],
   'docs/reference/compatibility.md': [version, releaseTag, '0.1.2-rc.1', './cordis.patch.yml'],
@@ -41,8 +41,8 @@ for (const [path, markers] of Object.entries({
   [`docs/releases/v${version}.md`]: [
     version,
     releaseTag,
-    '## DSH RC baseline',
-    '## Compatibility decision',
+    '## DSH compatibility baseline',
+    '## Stable release decision',
     '## Evidence',
     '## Explicit limits',
     '## 中文复盘',
@@ -85,7 +85,7 @@ for (const marker of ["'22.19.0'", "'24'", 'pnpm install --frozen-lockfile', 'pn
   if (!ci.includes(marker)) errors.push(`CI missing ${marker}`)
 }
 const release = readFileSync(join(root, '.github/workflows/release.yml'), 'utf8')
-for (const marker of ['workflow_dispatch:', 'environment: npm-release', 'actions: read', 'id-token: write', 'Require successful CI for release commit', 'pnpm release:check', 'npm publish --access public --provenance --tag alpha']) {
+for (const marker of ['workflow_dispatch:', 'environment: npm-release', 'actions: read', 'id-token: write', 'Require successful CI for release commit', 'pnpm release:check', 'npm publish --access public --provenance --tag "$NPM_TAG"']) {
   if (!release.includes(marker)) errors.push(`manual release workflow missing ${marker}`)
 }
 
@@ -126,4 +126,4 @@ if (errors.length > 0) {
   console.error(`release preflight failed:\n- ${errors.join('\n- ')}`)
   process.exit(1)
 }
-console.log(`release preflight passed: dsh-multi-tenant@${version} on alpha`)
+console.log(`release preflight passed: dsh-multi-tenant@${version} on latest`)

--- a/scripts/verify-v04.mjs
+++ b/scripts/verify-v04.mjs
@@ -7,7 +7,7 @@ import { DSH_TARGET } from './dsh-target.mjs'
 const root = fileURLToPath(new URL('..', import.meta.url))
 const pkg = JSON.parse(readFileSync(join(root, 'packages/multi-tenant/package.json'), 'utf8'))
 const errors = []
-const expectedVersion = '0.4.0-alpha.3'
+const expectedVersion = '0.4.0'
 const expectedDsh = '0.1.2-rc.1'
 const expectedCommit = 'a66e4702047846cdaa10c66c9d3df3951f5ea70d'
 const expectedExports = ['.', './mcp', './sqlite', './web', './testing', './starter', './cordis.patch.yml']
@@ -19,7 +19,7 @@ const dshPackages = [
 ]
 
 if (pkg.version !== expectedVersion) errors.push(`package version must be ${expectedVersion}`)
-if (pkg.publishConfig?.tag !== 'alpha') errors.push('publishConfig.tag must be alpha')
+if (pkg.publishConfig?.tag !== 'latest') errors.push('publishConfig.tag must be latest')
 if (DSH_TARGET.version !== expectedDsh || DSH_TARGET.commit !== expectedCommit) {
   errors.push('DSH target identity drifted from 0.1.2-rc.1')
 }


### PR DESCRIPTION
## Summary

- promote the reviewed 0.4 line to the first non-prerelease package release
- document the exact DSH 0.1.2-rc.1 / a66e4702047846cdaa10c66c9d3df3951f5ea70d compatibility baseline in English and Chinese
- switch npm distribution and registry verification from alpha to latest
- add the v0.4.0 release note and normal GitHub Release path

No runtime API, lifecycle behavior, Web contract, or SQLite schema changes are included.

## Compatibility boundary

DSH 0.1.2-rc.1 remains an upstream release candidate. dsh-multi-tenant 0.4.0 supports that exact DSH version only; later DSH RC or stable builds require an explicit compatibility release. This non-prerelease package does not claim 1.0-level indefinite compatibility.

## Evidence

- pnpm install --frozen-lockfile
- pnpm release:check (58 tests, native DSH AgentLoop/JSONL/MCP lifecycle, SQLite probes, packed consumer)
- pnpm audit --prod
- registry smoke script exercised against the existing alpha.2 artifact
- npm 0.4.0, v0.4.0 tag, and GitHub Release confirmed absent before publication